### PR TITLE
Fix attachment management for all supported types

### DIFF
--- a/automation/service/service.go
+++ b/automation/service/service.go
@@ -113,6 +113,7 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, ws websock
 		&expr.KVV{},
 		&expr.Reader{},
 		&expr.Vars{},
+		&expr.Bytes{},
 
 		&automation.EmailMessage{},
 	)

--- a/tests/workflows/attachment_management_types_test.go
+++ b/tests/workflows/attachment_management_types_test.go
@@ -1,0 +1,68 @@
+package workflows
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cortezaproject/corteza-server/automation/types"
+	cmpTypes "github.com/cortezaproject/corteza-server/compose/types"
+	"github.com/cortezaproject/corteza-server/pkg/expr"
+	"github.com/stretchr/testify/require"
+)
+
+type (
+	auxReader struct {
+		read bool
+	}
+)
+
+func Test_attachment_management_types(t *testing.T) {
+	var (
+		ctx = bypassRBAC(context.Background())
+		req = require.New(t)
+	)
+
+	req.NoError(defStore.TruncateAttachments(ctx))
+
+	loadNewScenario(ctx, t)
+
+	var (
+		aux = struct {
+			AttachedString     *cmpTypes.Attachment
+			AttachedReader     *cmpTypes.Attachment
+			AttachedReadSeeker *cmpTypes.Attachment
+			AttachedBytes      *cmpTypes.Attachment
+		}{}
+	)
+
+	v := &expr.Vars{}
+	v.AssignFieldValue("sourceString", expr.Must(expr.NewString("hello")))
+	v.AssignFieldValue("sourceReader", expr.Must(expr.NewReader(&auxReader{})))
+	v.AssignFieldValue("sourceReadSeeker", expr.Must(expr.NewReader(strings.NewReader("hello"))))
+	v.AssignFieldValue("sourceBytes", expr.Must(expr.NewBytes([]byte{'h', 'e', 'l', 'l', 'o'})))
+
+	vars, _ := mustExecWorkflow(ctx, t, "attachments", types.WorkflowExecParams{
+		Input: v,
+	})
+	req.NoError(vars.Decode(&aux))
+
+	req.NotNil(aux.AttachedString)
+	req.NotNil(aux.AttachedReader)
+	req.NotNil(aux.AttachedReadSeeker)
+	req.NotNil(aux.AttachedBytes)
+}
+
+func (ar *auxReader) Read(dst []byte) (int, error) {
+	if ar.read {
+		return 0, io.EOF
+	}
+
+	for i := range dst {
+		dst[i] = byte('a')
+	}
+
+	ar.read = true
+	return len(dst), nil
+}

--- a/tests/workflows/testdata/attachment_management_types/data_model.yaml
+++ b/tests/workflows/testdata/attachment_management_types/data_model.yaml
@@ -1,0 +1,9 @@
+namespaces:
+  ns1:
+    name: Namespace#1
+
+modules:
+  mod1:
+    name: Module#1
+    fields:
+      f1: { label: 'Field1', kind: 'File' }

--- a/tests/workflows/testdata/attachment_management_types/workflow.yaml
+++ b/tests/workflows/testdata/attachment_management_types/workflow.yaml
@@ -1,0 +1,96 @@
+workflows:
+  attachments:
+    enabled: true
+    trace: true
+    triggers:
+      - enabled: true
+        stepID: 11
+
+    steps:
+      - stepID: 11
+        kind: function
+        ref: composeRecordsNew
+        arguments:
+          - { target: module,    type: Handle, value: "mod1" }
+          - { target: namespace, type: Handle, value: "ns1" }
+        results:
+          - { target: attachableString, expr: "record"  }
+      - stepID: 12
+        kind: function
+        ref: composeRecordsNew
+        arguments:
+          - { target: module,    type: Handle, value: "mod1" }
+          - { target: namespace, type: Handle, value: "ns1" }
+        results:
+          - { target: attachableReader, expr: "record"  }
+      - stepID: 13
+        kind: function
+        ref: composeRecordsNew
+        arguments:
+          - { target: module,    type: Handle, value: "mod1" }
+          - { target: namespace, type: Handle, value: "ns1" }
+        results:
+          - { target: attachableReadSeeker, expr: "record"  }
+      - stepID: 14
+        kind: function
+        ref: composeRecordsNew
+        arguments:
+          - { target: module,    type: Handle, value: "mod1" }
+          - { target: namespace, type: Handle, value: "ns1" }
+        results:
+          - { target: attachableBytes, expr: "record"  }
+
+
+
+
+      # Store attachment from given string
+      - stepID: 20
+        kind: function
+        ref: attachmentCreate
+        arguments:
+          - { target: content,   type: String,        expr:  "sourceString" }
+          - { target: name,      type: String,        value: "att.txt" }
+          - { target: resource,  type: ComposeRecord, expr:  "attachableString" }
+          - { target: fieldName, type: String,        value: "f1" }
+        results:
+          - { target: attachedString, expr: "attachment"  }
+      - stepID: 21
+        kind: function
+        ref: attachmentCreate
+        arguments:
+          - { target: content,   type: Reader,        expr:  "sourceReader" }
+          - { target: name,      type: String,        value: "att.txt" }
+          - { target: resource,  type: ComposeRecord, expr:  "attachableReader" }
+          - { target: fieldName, type: String,        value: "f1" }
+        results:
+          - { target: attachedReader, expr: "attachment"  }
+      - stepID: 22
+        kind: function
+        ref: attachmentCreate
+        arguments:
+          - { target: content,   type: Reader,        expr:  "sourceReadSeeker" }
+          - { target: name,      type: String,        value: "att.txt" }
+          - { target: resource,  type: ComposeRecord, expr:  "attachableReadSeeker" }
+          - { target: fieldName, type: String,        value: "f1" }
+        results:
+          - { target: attachedReadSeeker, expr: "attachment"  }
+      - stepID: 23
+        kind: function
+        ref: attachmentCreate
+        arguments:
+          - { target: content,   type: Bytes,        expr:  "sourceBytes" }
+          - { target: name,      type: String,        value: "att.txt" }
+          - { target: resource,  type: ComposeRecord, expr:  "attachableBytes" }
+          - { target: fieldName, type: String,        value: "f1" }
+        results:
+          - { target: attachedBytes, expr: "attachment"  }
+
+    paths:
+      - { parentID: 11, childID: 12 }
+      - { parentID: 12, childID: 13 }
+      - { parentID: 13, childID: 14 }
+
+      - { parentID: 14, childID: 20 }
+      - { parentID: 20, childID: 21 }
+      - { parentID: 21, childID: 22 }
+      - { parentID: 22, childID: 23 }


### PR DESCRIPTION
* Add missing expr.Bytes expr. type
* Fix attachment upload when []bytes used (missing type, improper
  size calculation)
* Fix attachment upload when ReadSeeker used (missing size calculation)
* Fix attachment upload when Reader used (missing logic, missing size
  calculation)
