### PR TITLE
Prevent duplicate workflow prompts from sending

### DIFF
--- a/pkg/wfexec/prompt.go
+++ b/pkg/wfexec/prompt.go
@@ -1,8 +1,9 @@
 package wfexec
 
 import (
-	"github.com/cortezaproject/corteza-server/pkg/expr"
 	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/expr"
 )
 
 type (
@@ -16,6 +17,8 @@ type (
 		// state to be resumed
 		state *State
 
+		sent bool
+
 		// prompt reference; something client can use
 		// for orientation, what kind of prompt is expected
 		ref string
@@ -28,6 +31,8 @@ type (
 		StateID   uint64     `json:"stateID,string"`
 		Payload   *expr.Vars `json:"payload"`
 		OwnerId   uint64     `json:"-"`
+
+		Original *prompted `json:"-"`
 	}
 
 	ResumedPrompt struct {
@@ -47,6 +52,7 @@ func (p *prompted) toPending() *PendingPrompt {
 		StateID:   p.state.stateId,
 		Payload:   p.payload,
 		OwnerId:   p.ownerId,
+		Original:  p,
 	}
 }
 
@@ -55,4 +61,8 @@ func (p *prompted) toResumed() *ResumedPrompt {
 		StateID: p.state.stateId,
 		OwnerId: p.ownerId,
 	}
+}
+
+func (p *prompted) MarkSent() {
+	p.sent = true
 }

--- a/pkg/wfexec/session.go
+++ b/pkg/wfexec/session.go
@@ -293,9 +293,30 @@ func (s *Session) AllPendingPrompts() (out []*PendingPrompt) {
 	defer s.mux.RUnlock()
 	s.mux.RLock()
 
-	out = make([]*PendingPrompt, 0, len(s.prompted))
+	return s.pendingPrompts(s.prompted)
+}
 
-	for _, p := range s.prompted {
+// UnsentPendingPrompts returns unsent pending prompts for all user
+func (s *Session) UnsentPendingPrompts() (out []*PendingPrompt) {
+	defer s.mux.RUnlock()
+	s.mux.RLock()
+
+	aux := s.pendingPrompts(s.prompted)
+	for _, p := range aux {
+		if p.Original.sent {
+			continue
+		}
+
+		out = append(out, p)
+	}
+
+	return
+}
+
+func (s *Session) pendingPrompts(prompted map[uint64]*prompted) (out []*PendingPrompt) {
+	out = make([]*PendingPrompt, 0, len(prompted))
+
+	for _, p := range prompted {
 		pending := p.toPending()
 		pending.SessionID = s.id
 		out = append(out, pending)


### PR DESCRIPTION
Decided on doing the filtering on the back-end -- just so we send over less data, that's it