### PR TITLE
2022.9.x feature privacy console

### DIFF
--- a/automation/rest/eventTypes.gen.go
+++ b/automation/rest/eventTypes.gen.go
@@ -1980,6 +1980,181 @@ func getEventTypeDefinitions() []eventTypeDef {
 		},
 
 		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "onManual",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "beforeCreate",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "beforeUpdate",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "beforeDelete",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "afterCreate",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "afterUpdate",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
+			ResourceType: "system:data-privacy-request",
+			EventType:    "afterDelete",
+			Properties: []eventTypePropertyDef{
+
+				{
+					Name:      "dataPrivacyRequest",
+					Type:      "",
+					Immutable: false,
+				},
+
+				{
+					Name:      "oldDataPrivacyRequest",
+					Type:      "",
+					Immutable: true,
+				},
+			},
+			Constraints: []eventTypeConstraintDef{
+
+				{
+					Name: "role.name",
+				},
+			},
+		},
+
+		{
 			ResourceType: "system:mail",
 			EventType:    "onManual",
 			Properties: []eventTypePropertyDef{

--- a/codegen/assets/templates/gocode/locale/$component_types.go.tpl
+++ b/codegen/assets/templates/gocode/locale/$component_types.go.tpl
@@ -73,7 +73,16 @@ func {{ .expIdent }}ResourceTranslationTpl() string {
 }
 
 func (r *{{ .expIdent }}) DecodeTranslations(tt locale.ResourceTranslationIndex) {
-	var aux *locale.ResourceTranslation
+    {{- $decodeFuncExist := false }}
+    {{- range .keys }}
+        {{- if not .decodeFunc }}
+            {{- $decodeFuncExist = true }}
+        {{- end }}
+    {{- end}}
+
+    {{- if $decodeFuncExist }}
+        var aux *locale.ResourceTranslation
+    {{- end }}
 
 	{{- range .keys }}
 		{{ if .decodeFunc }}

--- a/codegen/assets/templates/gocode/store/rdbms/rdbms.go.tpl
+++ b/codegen/assets/templates/gocode/store/rdbms/rdbms.go.tpl
@@ -342,11 +342,15 @@ func (s *Store) Query{{ .expIdentPlural }}(
 	{{ if .features.paging }}
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
-			return
-		} else {
-			expr = append(expr, tExpr...)
-		}
+        {{- if .features.sorting }}
+        if tExpr, err = cursorWithSorting(f.PageCursor, s.{{ .api.sortableFields.fnIdent }}()); err != nil {
+        {{- else }}
+        if tExpr, err = cursor(f.PageCursor); err != nil {
+        {{- end }}
+            return
+        } else {
+            expr = append(expr, tExpr...)
+        }
 	}
 	{{ end }}
 

--- a/compose/chart.cue
+++ b/compose/chart.cue
@@ -43,6 +43,21 @@ chart: schema.#Resource & {
 		}
 	}
 
+	locale: {
+		extended: true
+
+		keys: {
+			reportsYaxisLabel: {
+				path: ["yAxis", "label"]
+				customHandler: true
+			}
+			reportsMetricLabel: {
+				path: ["metrics", {part: "metricID", var: true}, "label"]
+				customHandler: true
+			}
+		}
+	}
+
 	store: {
 		ident: "composeChart"
 

--- a/compose/module-field.cue
+++ b/compose/module-field.cue
@@ -34,11 +34,12 @@ moduleField: schema.#Resource & {
 
 	filter: {
 		struct: {
-			module_id: { goType: "[]uint64" }
+			module_id: { goType: "[]uint64", ident: "moduleID", storeIdent: "rel_module" }
 			deleted: { goType: "filter.State", storeIdent: "deleted_at" }
 		}
 
 		byNilState: ["deleted"]
+		byValue: ["module_id"]
 	}
 
 	features: {

--- a/compose/rest.yaml
+++ b/compose/rest.yaml
@@ -1089,6 +1089,32 @@ endpoints:
         name: chartID
         required: true
         title: Chart ID
+  - name: listTranslations
+    method: GET
+    title: List chart translation
+    path: "/{chartID}/translation"
+    parameters:
+      path:
+        - type: uint64
+          name: chartID
+          required: true
+          title: ID
+  - name: updateTranslations
+    method: PATCH
+    title: Update chart translation
+    path: "/{chartID}/translation"
+    parameters:
+      path:
+        - type: uint64
+          name: chartID
+          required: true
+          title: ID
+      post:
+        - name: translations
+          type: locale.ResourceTranslationSet
+          title: Resource translation to upsert
+          required: true
+
 - title: Notifications
   description: Compose Notifications
   entrypoint: notification

--- a/compose/rest.yaml
+++ b/compose/rest.yaml
@@ -980,6 +980,7 @@ endpoints:
   imports:
     - sqlxTypes github.com/jmoiron/sqlx/types
     - github.com/cortezaproject/corteza-server/pkg/label
+    - github.com/cortezaproject/corteza-server/pkg/locale
     - time
   parameters:
     path:

--- a/compose/rest/chart.go
+++ b/compose/rest/chart.go
@@ -37,7 +37,8 @@ type (
 			Update(ctx context.Context, chart *types.Chart) (*types.Chart, error)
 			DeleteByID(ctx context.Context, namespaceID, chartID uint64) error
 		}
-		ac chartAccessController
+		locale service.ResourceTranslationsManagerService
+		ac     chartAccessController
 	}
 
 	chartAccessController interface {
@@ -50,8 +51,9 @@ type (
 
 func (Chart) New() *Chart {
 	return &Chart{
-		chart: service.DefaultChart,
-		ac:    service.DefaultAccessControl,
+		chart:  service.DefaultChart,
+		locale: service.DefaultResourceTranslation,
+		ac:     service.DefaultAccessControl,
 	}
 }
 
@@ -132,6 +134,14 @@ func (ctrl Chart) Delete(ctx context.Context, r *request.ChartDelete) (interface
 	}
 
 	return api.OK(), ctrl.chart.DeleteByID(ctx, r.NamespaceID, r.ChartID)
+}
+
+func (ctrl Chart) ListTranslations(ctx context.Context, r *request.ChartListTranslations) (interface{}, error) {
+	return ctrl.locale.Chart(ctx, r.NamespaceID, r.ChartID)
+}
+
+func (ctrl Chart) UpdateTranslations(ctx context.Context, r *request.ChartUpdateTranslations) (interface{}, error) {
+	return api.OK(), ctrl.locale.Upsert(ctx, r.Translations)
 }
 
 func (ctrl Chart) makePayload(ctx context.Context, c *types.Chart, err error) (*chartPayload, error) {

--- a/compose/rest/handlers/chart.go
+++ b/compose/rest/handlers/chart.go
@@ -24,15 +24,19 @@ type (
 		Read(context.Context, *request.ChartRead) (interface{}, error)
 		Update(context.Context, *request.ChartUpdate) (interface{}, error)
 		Delete(context.Context, *request.ChartDelete) (interface{}, error)
+		ListTranslations(context.Context, *request.ChartListTranslations) (interface{}, error)
+		UpdateTranslations(context.Context, *request.ChartUpdateTranslations) (interface{}, error)
 	}
 
 	// HTTP API interface
 	Chart struct {
-		List   func(http.ResponseWriter, *http.Request)
-		Create func(http.ResponseWriter, *http.Request)
-		Read   func(http.ResponseWriter, *http.Request)
-		Update func(http.ResponseWriter, *http.Request)
-		Delete func(http.ResponseWriter, *http.Request)
+		List               func(http.ResponseWriter, *http.Request)
+		Create             func(http.ResponseWriter, *http.Request)
+		Read               func(http.ResponseWriter, *http.Request)
+		Update             func(http.ResponseWriter, *http.Request)
+		Delete             func(http.ResponseWriter, *http.Request)
+		ListTranslations   func(http.ResponseWriter, *http.Request)
+		UpdateTranslations func(http.ResponseWriter, *http.Request)
 	}
 )
 
@@ -118,6 +122,38 @@ func NewChart(h ChartAPI) *Chart {
 
 			api.Send(w, r, value)
 		},
+		ListTranslations: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewChartListTranslations()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.ListTranslations(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+		UpdateTranslations: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewChartUpdateTranslations()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.UpdateTranslations(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
 	}
 }
 
@@ -129,5 +165,7 @@ func (h Chart) MountRoutes(r chi.Router, middlewares ...func(http.Handler) http.
 		r.Get("/namespace/{namespaceID}/chart/{chartID}", h.Read)
 		r.Post("/namespace/{namespaceID}/chart/{chartID}", h.Update)
 		r.Delete("/namespace/{namespaceID}/chart/{chartID}", h.Delete)
+		r.Get("/namespace/{namespaceID}/chart/{chartID}/translation", h.ListTranslations)
+		r.Patch("/namespace/{namespaceID}/chart/{chartID}/translation", h.UpdateTranslations)
 	})
 }

--- a/compose/rest/request/chart.go
+++ b/compose/rest/request/chart.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/cortezaproject/corteza-server/pkg/label"
+	"github.com/cortezaproject/corteza-server/pkg/locale"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/go-chi/chi/v5"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
@@ -159,6 +160,35 @@ type (
 		//
 		// Chart ID
 		ChartID uint64 `json:",string"`
+	}
+
+	ChartListTranslations struct {
+		// NamespaceID PATH parameter
+		//
+		// Namespace ID
+		NamespaceID uint64 `json:",string"`
+
+		// ChartID PATH parameter
+		//
+		// ID
+		ChartID uint64 `json:",string"`
+	}
+
+	ChartUpdateTranslations struct {
+		// NamespaceID PATH parameter
+		//
+		// Namespace ID
+		NamespaceID uint64 `json:",string"`
+
+		// ChartID PATH parameter
+		//
+		// ID
+		ChartID uint64 `json:",string"`
+
+		// Translations POST parameter
+		//
+		// Resource translation to upsert
+		Translations locale.ResourceTranslationSet
 	}
 )
 
@@ -690,6 +720,142 @@ func (r ChartDelete) GetChartID() uint64 {
 
 // Fill processes request and fills internal variables
 func (r *ChartDelete) Fill(req *http.Request) (err error) {
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "namespaceID")
+		r.NamespaceID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+		val = chi.URLParam(req, "chartID")
+		r.ChartID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewChartListTranslations request
+func NewChartListTranslations() *ChartListTranslations {
+	return &ChartListTranslations{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartListTranslations) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"namespaceID": r.NamespaceID,
+		"chartID":     r.ChartID,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartListTranslations) GetNamespaceID() uint64 {
+	return r.NamespaceID
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartListTranslations) GetChartID() uint64 {
+	return r.ChartID
+}
+
+// Fill processes request and fills internal variables
+func (r *ChartListTranslations) Fill(req *http.Request) (err error) {
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "namespaceID")
+		r.NamespaceID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+		val = chi.URLParam(req, "chartID")
+		r.ChartID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewChartUpdateTranslations request
+func NewChartUpdateTranslations() *ChartUpdateTranslations {
+	return &ChartUpdateTranslations{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartUpdateTranslations) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"namespaceID":  r.NamespaceID,
+		"chartID":      r.ChartID,
+		"translations": r.Translations,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartUpdateTranslations) GetNamespaceID() uint64 {
+	return r.NamespaceID
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartUpdateTranslations) GetChartID() uint64 {
+	return r.ChartID
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ChartUpdateTranslations) GetTranslations() locale.ResourceTranslationSet {
+	return r.Translations
+}
+
+// Fill processes request and fills internal variables
+func (r *ChartUpdateTranslations) Fill(req *http.Request) (err error) {
+
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		err = json.NewDecoder(req.Body).Decode(r)
+
+		switch {
+		case err == io.EOF:
+			err = nil
+		case err != nil:
+			return fmt.Errorf("error parsing http request body: %w", err)
+		}
+	}
+
+	{
+		// Caching 32MB to memory, the rest to disk
+		if err = req.ParseMultipartForm(32 << 20); err != nil && err != http.ErrNotMultipart {
+			return err
+		} else if err == nil {
+			// Multipart params
+
+		}
+	}
+
+	{
+		if err = req.ParseForm(); err != nil {
+			return err
+		}
+
+		// POST params
+
+		//if val, ok := req.Form["translations[]"]; ok && len(val) > 0  {
+		//    r.Translations, err = locale.ResourceTranslationSet(val), nil
+		//    if err != nil {
+		//        return err
+		//    }
+		//}
+	}
 
 	{
 		var val string

--- a/compose/service/chart.go
+++ b/compose/service/chart.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"github.com/cortezaproject/corteza-server/pkg/locale"
 	"reflect"
+	"strconv"
 
 	"github.com/cortezaproject/corteza-server/compose/types"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
@@ -17,9 +19,11 @@ type (
 		actionlog actionlog.Recorder
 		ac        chartAccessController
 		store     store.Storer
+		locale    ResourceTranslationsManagerService
 	}
 
 	chartAccessController interface {
+		CanManageResourceTranslations(ctx context.Context) bool
 		CanSearchChartsOnNamespace(context.Context, *types.Namespace) bool
 		CanReadNamespace(context.Context, *types.Namespace) bool
 		CanCreateChartOnNamespace(context.Context, *types.Namespace) bool
@@ -44,12 +48,14 @@ func Chart() *chart {
 		ac:        DefaultAccessControl,
 		actionlog: DefaultActionlog,
 		store:     DefaultStore,
+		locale:    DefaultResourceTranslation,
 	}
 }
 
 func (svc chart) Find(ctx context.Context, filter types.ChartFilter) (set types.ChartSet, f types.ChartFilter, err error) {
 	var (
 		aProps = &chartActionProps{filter: &filter}
+		ns     *types.Namespace
 	)
 
 	// For each fetched item, store backend will check if it is valid or not
@@ -62,7 +68,7 @@ func (svc chart) Find(ctx context.Context, filter types.ChartFilter) (set types.
 	}
 
 	err = func() error {
-		ns, err := loadNamespace(ctx, svc.store, filter.NamespaceID)
+		ns, err = loadNamespace(ctx, svc.store, filter.NamespaceID)
 		if err != nil {
 			return err
 		}
@@ -98,6 +104,13 @@ func (svc chart) Find(ctx context.Context, filter types.ChartFilter) (set types.
 		if err = label.Load(ctx, svc.store, toLabeledCharts(set)...); err != nil {
 			return err
 		}
+
+		// i18n
+		tag := locale.GetAcceptLanguageFromContext(ctx)
+		set.Walk(func(p *types.Chart) error {
+			p.DecodeTranslations(svc.locale.Locale().ResourceTranslations(tag, p.ResourceTranslation()))
+			return nil
+		})
 
 		return nil
 	}()
@@ -158,8 +171,21 @@ func (svc chart) Create(ctx context.Context, new *types.Chart) (*types.Chart, er
 		new.UpdatedAt = nil
 		new.DeletedAt = nil
 
+		// Ensure chart report IDs
+		for i, report := range new.Config.Reports {
+			new.Config.Reports[i].ReportID = nextID()
+			// Ensure chart report metric IDs
+			for j := range report.Metrics {
+				new.Config.Reports[i].Metrics[j]["metricID"] = strconv.FormatUint(nextID(), 10)
+			}
+		}
+
 		if err = store.CreateComposeChart(ctx, s, new); err != nil {
 			return err
+		}
+
+		if err = updateTranslations(ctx, svc.ac, svc.locale, new.EncodeTranslations()...); err != nil {
+			return
 		}
 
 		if err = label.Create(ctx, s, new); err != nil {
@@ -249,6 +275,10 @@ func (svc chart) updater(ctx context.Context, namespaceID, chartID uint64, actio
 			}
 		}
 
+		if err = updateTranslations(ctx, svc.ac, svc.locale, c.EncodeTranslations()...); err != nil {
+			return
+		}
+
 		if changes&chartLabelsChanged > 0 {
 			if err = label.Update(ctx, s, c); err != nil {
 				return
@@ -304,6 +334,25 @@ func (svc chart) handleUpdate(ctx context.Context, upd *types.Chart) chartUpdate
 			res.Config = upd.Config
 		}
 
+		// Assure ReportIDs
+		for i, r := range res.Config.Reports {
+			if r.ReportID == 0 {
+				r.ReportID = nextID()
+				res.Config.Reports[i] = r
+
+				changes |= chartChanged
+			}
+
+			// Ensure chart report metric IDs
+			for j, m := range r.Metrics {
+				if val, ok := m["metricID"]; !ok || val == 0 {
+					m["metricID"] = strconv.FormatUint(nextID(), 10)
+					res.Config.Reports[i].Metrics[j] = m
+
+					changes |= chartChanged
+				}
+			}
+		}
 		if changes&chartChanged > 0 {
 			res.UpdatedAt = now()
 		}

--- a/compose/service/locale.gen.go
+++ b/compose/service/locale.gen.go
@@ -37,6 +37,7 @@ type (
 	}
 
 	ResourceTranslationsManagerService interface {
+		Chart(ctx context.Context, namespaceID uint64, id uint64) (locale.ResourceTranslationSet, error)
 		Module(ctx context.Context, namespaceID uint64, id uint64) (locale.ResourceTranslationSet, error)
 		Namespace(ctx context.Context, id uint64) (locale.ResourceTranslationSet, error)
 		Page(ctx context.Context, namespaceID uint64, id uint64) (locale.ResourceTranslationSet, error)
@@ -148,12 +149,27 @@ func (svc resourceTranslationsManager) Locale() locale.Resource {
 	return svc.locale
 }
 
+func (svc resourceTranslationsManager) Chart(ctx context.Context, namespaceID uint64, id uint64) (locale.ResourceTranslationSet, error) {
+	var (
+		err error
+		out locale.ResourceTranslationSet
+		res *types.Chart
+	)
+
+	res, err = svc.loadChart(ctx, svc.store, namespaceID, id)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := svc.chartExtended(ctx, res)
+	return append(out, tmp...), err
+}
+
 func (svc resourceTranslationsManager) Module(ctx context.Context, namespaceID uint64, id uint64) (locale.ResourceTranslationSet, error) {
 	var (
 		err error
 		out locale.ResourceTranslationSet
 		res *types.Module
-		k   types.LocaleKey
 	)
 
 	res, err = svc.loadModule(ctx, svc.store, namespaceID, id)
@@ -161,6 +177,7 @@ func (svc resourceTranslationsManager) Module(ctx context.Context, namespaceID u
 		return nil, err
 	}
 
+	var k types.LocaleKey
 	for _, tag := range svc.locale.Tags() {
 		k = types.LocaleKeyModuleName
 		out = append(out, &locale.ResourceTranslation{
@@ -181,7 +198,6 @@ func (svc resourceTranslationsManager) Namespace(ctx context.Context, id uint64)
 		err error
 		out locale.ResourceTranslationSet
 		res *types.Namespace
-		k   types.LocaleKey
 	)
 
 	res, err = svc.loadNamespace(ctx, svc.store, id)
@@ -189,6 +205,7 @@ func (svc resourceTranslationsManager) Namespace(ctx context.Context, id uint64)
 		return nil, err
 	}
 
+	var k types.LocaleKey
 	for _, tag := range svc.locale.Tags() {
 		k = types.LocaleKeyNamespaceName
 		out = append(out, &locale.ResourceTranslation{
@@ -224,7 +241,6 @@ func (svc resourceTranslationsManager) Page(ctx context.Context, namespaceID uin
 		err error
 		out locale.ResourceTranslationSet
 		res *types.Page
-		k   types.LocaleKey
 	)
 
 	res, err = svc.loadPage(ctx, svc.store, namespaceID, id)
@@ -232,6 +248,7 @@ func (svc resourceTranslationsManager) Page(ctx context.Context, namespaceID uin
 		return nil, err
 	}
 
+	var k types.LocaleKey
 	for _, tag := range svc.locale.Tags() {
 		k = types.LocaleKeyPageTitle
 		out = append(out, &locale.ResourceTranslation{

--- a/compose/service/locale.go
+++ b/compose/service/locale.go
@@ -272,6 +272,45 @@ func (svc resourceTranslationsManager) pageExtended(ctx context.Context, res *ty
 	return
 }
 
+func (svc resourceTranslationsManager) chartExtended(_ context.Context, res *types.Chart) (out locale.ResourceTranslationSet, err error) {
+	var (
+		yAxisLabelK  = types.LocaleKeyChartYAxisLabel
+		metricLabelK = types.LocaleKeyChartMetricsMetricIDLabel
+	)
+
+	for _, report := range res.Config.Reports {
+		for _, tag := range svc.locale.Tags() {
+			out = append(out, &locale.ResourceTranslation{
+				Resource: res.ResourceTranslation(),
+				Lang:     tag.String(),
+				Key:      yAxisLabelK.Path,
+				Msg:      svc.locale.TResourceFor(tag, res.ResourceTranslation(), yAxisLabelK.Path),
+			})
+		}
+
+		for _, metric := range report.Metrics {
+			if _, ok := metric["metricID"]; ok {
+				mID, is := metric["metricID"].(string)
+				if !is {
+					continue
+				}
+				mpl := strings.NewReplacer("{{metricID}}", mID)
+
+				for _, tag := range svc.locale.Tags() {
+					out = append(out, &locale.ResourceTranslation{
+						Resource: res.ResourceTranslation(),
+						Lang:     tag.String(),
+						Key:      mpl.Replace(metricLabelK.Path),
+						Msg:      svc.locale.TResourceFor(tag, res.ResourceTranslation(), mpl.Replace(metricLabelK.Path)),
+					})
+				}
+			}
+		}
+	}
+
+	return
+}
+
 func (svc resourceTranslationsManager) pageExtendedAutomationBlock(tag language.Tag, res *types.Page, block types.PageBlock, blockID uint64) (locale.ResourceTranslationSet, error) {
 	var (
 		k     = types.LocaleKeyPagePageBlockBlockIDButtonButtonIDLabel

--- a/compose/types/locale.gen.go
+++ b/compose/types/locale.gen.go
@@ -23,6 +23,7 @@ type (
 
 // Types and stuff
 const (
+	ChartResourceTranslationType       = "compose:chart"
 	ModuleResourceTranslationType      = "compose:module"
 	ModuleFieldResourceTranslationType = "compose:module-field"
 	NamespaceResourceTranslationType   = "compose:namespace"
@@ -31,6 +32,8 @@ const (
 
 var (
 	// @todo can we remove LocaleKey struct for string constant?
+	LocaleKeyChartYAxisLabel                                = LocaleKey{Path: "yAxis.label"}
+	LocaleKeyChartMetricsMetricIDLabel                      = LocaleKey{Path: "metrics.{{metricID}}.label"}
 	LocaleKeyModuleName                                     = LocaleKey{Path: "name"}
 	LocaleKeyModuleFieldLabel                               = LocaleKey{Path: "label"}
 	LocaleKeyModuleFieldMetaDescriptionView                 = LocaleKey{Path: "meta.description.view"}
@@ -56,6 +59,47 @@ var (
 	LocaleKeyPagePageBlockBlockIDButtonButtonIDLabel        = LocaleKey{Path: "pageBlock.{{blockID}}.button.{{buttonID}}.label"}
 	LocaleKeyPagePageBlockBlockIDContentBody                = LocaleKey{Path: "pageBlock.{{blockID}}.content.body"}
 )
+
+// ResourceTranslation returns string representation of Locale resource for Chart by calling ChartResourceTranslation fn
+//
+// Locale resource is in "compose:chart/..." format
+//
+// This function is auto-generated
+func (r Chart) ResourceTranslation() string {
+	return ChartResourceTranslation(r.NamespaceID, r.ID)
+}
+
+// ChartResourceTranslation returns string representation of Locale resource for Chart
+//
+// Locale resource is in the compose:chart/... format
+//
+// This function is auto-generated
+func ChartResourceTranslation(NamespaceID uint64, ID uint64) string {
+	cpts := []interface{}{
+		ChartResourceTranslationType,
+		strconv.FormatUint(NamespaceID, 10),
+		strconv.FormatUint(ID, 10),
+	}
+
+	return fmt.Sprintf(ChartResourceTranslationTpl(), cpts...)
+}
+
+func ChartResourceTranslationTpl() string {
+	return "%s/%s/%s"
+}
+
+func (r *Chart) DecodeTranslations(tt locale.ResourceTranslationIndex) {
+
+	r.decodeTranslations(tt)
+}
+
+func (r *Chart) EncodeTranslations() (out locale.ResourceTranslationSet) {
+	out = locale.ResourceTranslationSet{}
+
+	out = append(out, r.encodeTranslations()...)
+
+	return out
+}
 
 // ResourceTranslation returns string representation of Locale resource for Module by calling ModuleResourceTranslation fn
 //

--- a/pkg/envoy/resource/compose_chart.go
+++ b/pkg/envoy/resource/compose_chart.go
@@ -65,21 +65,25 @@ func (r *ComposeChart) SysID() uint64 {
 	return r.Res.ID
 }
 
-func (r *ComposeChart) RBACParts() (resource string, ref *Ref, path []*Ref) {
-	ref = r.Ref()
+func (r *ComposeChart) resourceParts(tpl string) (resource string, ref *Ref, path []*Ref) {
+	ref = r.Ref().Constraint(r.RefNs)
 	path = []*Ref{r.RefNs}
 	resource = fmt.Sprintf(types.ChartRbacResourceTpl(), types.ChartResourceType, r.RefNs.Identifiers.First(), firstOkString(strconv.FormatUint(r.Res.ID, 10), r.Res.Handle))
 
 	return
 }
 
-// func (r *ComposeChart) ResourceTranslationParts() (resource string, ref *Ref, path []*Ref) {
-// 	ref = r.Ref()
-// 	path = []*Ref{r.RefNs}
-// 	resource = fmt.Sprintf(types.ChartResourceTranslationTpl(), types.ChartResourceTranslationType, r.RefNs.Identifiers.First(), firstOkString(strconv.FormatUint(r.Res.ID, 10), r.Res.Handle))
+func (r *ComposeChart) RBACParts() (resource string, ref *Ref, path []*Ref) {
+	return r.resourceParts(types.ChartRbacResourceTpl())
+}
 
-// 	return
-// }
+func (r *ComposeChart) ResourceTranslationParts() (resource string, ref *Ref, path []*Ref) {
+	return r.resourceParts(types.ChartResourceTranslationTpl())
+}
+
+func (r *ComposeChart) encodeTranslations() ([]*ResourceTranslation, error) {
+	return nil, nil
+}
 
 // FindComposeChart looks for the chart in the resources
 func FindComposeChart(rr InterfaceSet, ii Identifiers) (ch *types.Chart) {

--- a/pkg/envoy/resource/rbac_references_system.gen.go
+++ b/pkg/envoy/resource/rbac_references_system.gen.go
@@ -49,6 +49,32 @@ func SystemAuthClientRbacReferences(authClient string) (res *Ref, pp []*Ref, err
 	return
 }
 
+// SystemDataPrivacyRequestRbacReferences generates RBAC references
+//
+// Resources with "envoy: false" are skipped
+//
+// This function is auto-generated
+func SystemDataPrivacyRequestRbacReferences(dataPrivacyRequest string) (res *Ref, pp []*Ref, err error) {
+	if dataPrivacyRequest != "*" {
+		res = &Ref{ResourceType: types.DataPrivacyRequestResourceType, Identifiers: MakeIdentifiers(dataPrivacyRequest)}
+	}
+
+	return
+}
+
+// SystemDataPrivacyRequestCommentRbacReferences generates RBAC references
+//
+// Resources with "envoy: false" are skipped
+//
+// This function is auto-generated
+func SystemDataPrivacyRequestCommentRbacReferences(dataPrivacyRequestComment string) (res *Ref, pp []*Ref, err error) {
+	if dataPrivacyRequestComment != "*" {
+		res = &Ref{ResourceType: types.DataPrivacyRequestCommentResourceType, Identifiers: MakeIdentifiers(dataPrivacyRequestComment)}
+	}
+
+	return
+}
+
 // SystemQueueRbacReferences generates RBAC references
 //
 // Resources with "envoy: false" are skipped

--- a/pkg/envoy/resource/rbac_rules_parse.gen.go
+++ b/pkg/envoy/resource/rbac_rules_parse.gen.go
@@ -74,6 +74,24 @@ func ParseRule(res string) (string, *Ref, []*Ref, error) {
 		)
 		return resourceType, ref, pp, err
 
+	case systemTypes.DataPrivacyRequestResourceType:
+		if len(path) != 1 {
+			return "", nil, nil, fmt.Errorf("expecting 1 reference components in path, got %d", len(path))
+		}
+		ref, pp, err := SystemDataPrivacyRequestRbacReferences(
+			path[0],
+		)
+		return resourceType, ref, pp, err
+
+	case systemTypes.DataPrivacyRequestCommentResourceType:
+		if len(path) != 1 {
+			return "", nil, nil, fmt.Errorf("expecting 1 reference components in path, got %d", len(path))
+		}
+		ref, pp, err := SystemDataPrivacyRequestCommentRbacReferences(
+			path[0],
+		)
+		return resourceType, ref, pp, err
+
 	case systemTypes.QueueResourceType:
 		if len(path) != 1 {
 			return "", nil, nil, fmt.Errorf("expecting 1 reference components in path, got %d", len(path))

--- a/pkg/envoy/resource/resource_translation.gen.go
+++ b/pkg/envoy/resource/resource_translation.gen.go
@@ -10,6 +10,18 @@ import (
 	systemTypes "github.com/cortezaproject/corteza-server/system/types"
 )
 
+func (r *ComposeChart) EncodeTranslations() ([]*ResourceTranslation, error) {
+	out := make([]*ResourceTranslation, 0, 10)
+
+	rr := r.Res.EncodeTranslations()
+	rr.SetLanguage(defaultLanguage)
+	res, ref, pp := r.ResourceTranslationParts()
+	out = append(out, NewResourceTranslation(systemTypes.FromLocale(rr), res, ref, pp...))
+
+	tmp, err := r.encodeTranslations()
+	return append(out, tmp...), err
+
+}
 func (r *ComposeModule) EncodeTranslations() ([]*ResourceTranslation, error) {
 	out := make([]*ResourceTranslation, 0, 10)
 

--- a/pkg/envoy/resource/resource_translation_parse.gen.go
+++ b/pkg/envoy/resource/resource_translation_parse.gen.go
@@ -47,6 +47,16 @@ func ParseResourceTranslation(res string) (string, *Ref, []*Ref, error) {
 
 	// make the resource provide the slice of parent resources we should nest under
 	switch resourceType {
+	case composeTypes.ChartResourceTranslationType:
+		if len(path) != 2 {
+			return "", nil, nil, fmt.Errorf("expecting 2 reference components in path, got %d", len(path))
+		}
+		ref, pp, err := ComposeChartResourceTranslationReferences(
+			path[0],
+			path[1],
+		)
+		return composeTypes.ChartResourceTranslationType, ref, pp, err
+
 	case composeTypes.ModuleResourceTranslationType:
 		if len(path) != 2 {
 			return "", nil, nil, fmt.Errorf("expecting 2 reference components in path, got %d", len(path))

--- a/pkg/envoy/resource/resource_translation_references_compose.gen.go
+++ b/pkg/envoy/resource/resource_translation_references_compose.gen.go
@@ -10,6 +10,16 @@ import (
 	"github.com/cortezaproject/corteza-server/compose/types"
 )
 
+// ComposeChartResourceTranslationReferences generates Locale references
+//
+// This function is auto-generated
+func ComposeChartResourceTranslationReferences(namespaceID string, self string) (res *Ref, pp []*Ref, err error) {
+	res = &Ref{ResourceType: types.ChartResourceType, Identifiers: MakeIdentifiers(self)}
+	pp = append(pp, &Ref{ResourceType: types.NamespaceResourceType, Identifiers: MakeIdentifiers(namespaceID)})
+
+	return
+}
+
 // ComposeModuleResourceTranslationReferences generates Locale references
 //
 // This function is auto-generated

--- a/pkg/envoy/store/rbac_rule_marshal.go
+++ b/pkg/envoy/store/rbac_rule_marshal.go
@@ -360,6 +360,9 @@ func (n *rbacRule) makeRBACResource(pl *payload) (string, error) {
 		// @todo add support for importing rbac rules for specific queue
 		return systemTypes.QueueRbacResource(p1ID), nil
 
+	case systemTypes.DataPrivacyRequestResourceType:
+		return systemTypes.DataPrivacyRequestRbacResource(p1ID), nil
+
 	case federationTypes.NodeResourceType:
 		return federationTypes.NodeRbacResource(p1ID), nil
 	case federationTypes.SharedModuleResourceType:

--- a/pkg/envoy/store/resource_translation_marshal.go
+++ b/pkg/envoy/store/resource_translation_marshal.go
@@ -172,20 +172,20 @@ func (n *resourceTranslation) makeResourceTranslation(pl *payload) (string, erro
 
 		return composeTypes.PageResourceTranslation(p0ID, p1ID), nil
 
-	// case composeTypes.ChartResourceType:
-	// 	p0 := resource.FindComposeNamespace(pl.state.ParentResources, n.refPathRes[0].Identifiers)
-	// 	if p0 == nil {
-	// 		return "", resource.ComposeNamespaceErrUnresolved(n.refPathRes[0].Identifiers)
-	// 	}
-	// 	p0ID = p0.ID
+	case composeTypes.ChartResourceType:
+		p0 := resource.FindComposeNamespace(pl.state.ParentResources, n.refPathRes[0].Identifiers)
+		if p0 == nil {
+			return "", resource.ComposeNamespaceErrUnresolved(n.refPathRes[0].Identifiers)
+		}
+		p0ID = p0.ID
 
-	// 	p1 := resource.FindComposeChart(pl.state.ParentResources, n.refLocaleRes.Identifiers)
-	// 	if p1 == nil {
-	// 		return "", resource.ComposeChartErrUnresolved(n.refLocaleRes.Identifiers)
-	// 	}
-	// 	p1ID = p1.ID
+		p1 := resource.FindComposeChart(pl.state.ParentResources, n.refLocaleRes.Identifiers)
+		if p1 == nil {
+			return "", resource.ComposeChartErrUnresolved(n.refLocaleRes.Identifiers)
+		}
+		p1ID = p1.ID
 
-	// 	return composeTypes.ChartResourceTranslation(p0ID, p1ID), nil
+		return composeTypes.ChartResourceTranslation(p0ID, p1ID), nil
 
 	case composeTypes.ModuleFieldResourceType:
 		p0 := resource.FindComposeNamespace(pl.state.ParentResources, n.refPathRes[0].Identifiers)

--- a/pkg/envoy/yaml/resource_translation_marshal.go
+++ b/pkg/envoy/yaml/resource_translation_marshal.go
@@ -162,24 +162,24 @@ func (r *resourceTranslation) makeResourceTranslationResource(state *envoy.Resou
 
 		return fmt.Sprintf(composeTypes.ModuleFieldResourceTranslationTpl(), composeTypes.ModuleFieldResourceTranslationType, p0ID, p1ID, p2ID), nil
 
-	// case composeTypes.ChartResourceType:
-	// 	if len(res.RefPath) > 0 {
-	// 		p0 := resource.FindComposeNamespace(state.ParentResources, res.RefPath[0].Identifiers)
-	// 		if p0 == nil {
-	// 			return "", resource.ComposeNamespaceErrUnresolved(res.RefPath[0].Identifiers)
-	// 		}
-	// 		p0ID = p0.Slug
-	// 	}
+	case composeTypes.ChartResourceType:
+		if len(res.RefPath) > 0 {
+			p0 := resource.FindComposeNamespace(state.ParentResources, res.RefPath[0].Identifiers)
+			if p0 == nil {
+				return "", resource.ComposeNamespaceErrUnresolved(res.RefPath[0].Identifiers)
+			}
+			p0ID = p0.Slug
+		}
 
-	// 	if res.RefRes != nil {
-	// 		p1 := resource.FindComposeChart(state.ParentResources, res.RefRes.Identifiers)
-	// 		if p1 == nil {
-	// 			return "", resource.ComposeChartErrUnresolved(res.RefRes.Identifiers)
-	// 		}
-	// 		p1ID = p1.Handle
-	// 	}
+		if res.RefRes != nil {
+			p1 := resource.FindComposeChart(state.ParentResources, res.RefRes.Identifiers)
+			if p1 == nil {
+				return "", resource.ComposeChartErrUnresolved(res.RefRes.Identifiers)
+			}
+			p1ID = p1.Handle
+		}
 
-	// 	return fmt.Sprintf(composeTypes.ChartResourceTranslationTpl(), composeTypes.ChartResourceTranslationType, p0ID, p1ID), nil
+		return fmt.Sprintf(composeTypes.ChartResourceTranslationTpl(), composeTypes.ChartResourceTranslationType, p0ID, p1ID), nil
 
 	// case automationTypes.WorkflowResourceType:
 	// 	if res.RefRes != nil {

--- a/pkg/provision/migrations_202203_resource_translations.go
+++ b/pkg/provision/migrations_202203_resource_translations.go
@@ -1,0 +1,116 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+	cmpTypes "github.com/cortezaproject/corteza-server/compose/types"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/store"
+	sysTypes "github.com/cortezaproject/corteza-server/system/types"
+	"go.uber.org/zap"
+	"strings"
+)
+
+// Migrates resource translations from the resource
+// struct to the dedicated store (table)
+//
+// While doing this, we also modify some resource substructure:
+//  - chart reports (assign report IDs)
+//
+// Note: we will migrate all translations to current default language
+// If you do not like that, shut down Corteza after migrations and fix this directly in the store
+func migratePost202203ResourceTranslations(ctx context.Context, log *zap.Logger, s store.Storer) (err error) {
+	log.Info("migrating post 202203 resource translations")
+
+	var (
+		migrated = make(map[string]bool)
+	)
+
+	set, _, err := store.SearchResourceTranslations(ctx, s, sysTypes.ResourceTranslationFilter{})
+	if err != nil {
+		return
+	}
+	err = set.Walk(func(r *sysTypes.ResourceTranslation) error {
+		var pos = strings.Index(r.Resource, "/")
+		if pos < 0 {
+			return nil
+		}
+
+		migrated[r.Resource[0:pos]] = true
+		return nil
+	})
+	if err != nil {
+		return
+	}
+
+	if !migrated[cmpTypes.ChartResourceTranslationType] {
+		if err = migrateComposeChartResourceTranslations(ctx, log, s); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// migrate resource translations for compose chart
+func migrateComposeChartResourceTranslations(ctx context.Context, log *zap.Logger, s store.Storer) error {
+	var (
+		tt sysTypes.ResourceTranslationSet
+	)
+	set, _, err := store.SearchComposeCharts(ctx, s, cmpTypes.ChartFilter{Deleted: filter.StateInclusive})
+	if err != nil {
+		return err
+	}
+
+	log.Info("migrating compose charts", zap.Int("count", len(set)))
+
+	return s.Tx(ctx, func(ctx context.Context, s store.Storer) error {
+		return set.Walk(func(res *cmpTypes.Chart) (err error) {
+			if tt, err = convertComposeChartReportsTranslations(res); err != nil {
+				return err
+			}
+
+			if err = store.CreateResourceTranslation(ctx, s, tt...); err != nil {
+				return
+			}
+
+			if err = store.UpdateComposeChart(ctx, s, res); err != nil {
+				return
+			}
+
+			return
+		})
+	})
+}
+
+// collects translations for compose chart blocks and alters them (adding block ID)
+func convertComposeChartReportsTranslations(res *cmpTypes.Chart) (sysTypes.ResourceTranslationSet, error) {
+	var tt sysTypes.ResourceTranslationSet
+
+	for i, r := range res.Config.Reports {
+		reportID := id.Next()
+		res.Config.Reports[i].ReportID = reportID
+
+		if _, ok := r.YAxis["label"]; ok {
+			tt = append(tt,
+				makeResourceTranslation(res, "yAxis.label", r.YAxis["label"].(string)),
+			)
+		}
+
+		// Ensure chart report metric IDs
+		for j, m := range r.Metrics {
+			metricID := id.Next()
+			res.Config.Reports[i].Metrics[j]["metricID"] = fmt.Sprintf("%d", metricID)
+			cmx := fmt.Sprintf("metrics.%d.", metricID)
+
+			if _, ok := m["label"]; ok {
+				tt = append(tt,
+					makeResourceTranslation(res, cmx+"label", m["label"].(string)),
+				)
+			}
+		}
+	}
+
+	return tt, nil
+}

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -41,6 +41,9 @@ func Run(ctx context.Context, log *zap.Logger, s store.Storer, provisionOpt opti
 		func() error { return cleanupPre202109Settings(ctx, log.Named("pre-202109-settings"), s) },
 		func() error { return migrateResourceTranslations(ctx, log.Named("resource-translations"), s) },
 		func() error { return migrateReportIdentifiers(ctx, log.Named("report-identifiers"), s) },
+		func() error {
+			return migratePost202203ResourceTranslations(ctx, log.Named("post-202203-resource-translations"), s)
+		},
 
 		// Config (full & partial)
 		func() error { return importConfig(ctx, log.Named("config"), s, provisionOpt.Path) },

--- a/provision/000_base/roles.yaml
+++ b/provision/000_base/roles.yaml
@@ -64,3 +64,9 @@ roles:
           - corteza::compose:record
           - corteza::system:authClient
           - corteza::automation:workflow
+
+  data-privacy-officer:
+    name: Data Privacy Officer
+    meta:
+      description: |-
+        Users that are allowed to view and manage privacy requests.

--- a/provision/000_base/system_access_control.yaml
+++ b/provision/000_base/system_access_control.yaml
@@ -162,3 +162,8 @@ allow:
       - update
       - delete
       - run
+
+  data-privacy-officer:
+    corteza::system:data-privacy-request/*:
+      - read
+      - approve

--- a/store/adapters/rdbms/aux_types.gen.go
+++ b/store/adapters/rdbms/aux_types.gen.go
@@ -380,6 +380,36 @@ type (
 		DeletedBy uint64                             `db:"deleted_by"`
 	}
 
+	// auxDataPrivacyRequest is an auxiliary structure used for transporting to/from RDBMS store
+	auxDataPrivacyRequest struct {
+		ID          uint64                   `db:"id"`
+		Kind        systemType.RequestKind   `db:"kind"`
+		Status      systemType.RequestStatus `db:"status"`
+		RequestedAt time.Time                `db:"requested_at"`
+		RequestedBy uint64                   `db:"requested_by"`
+		CompletedAt *time.Time               `db:"completed_at"`
+		CompletedBy uint64                   `db:"completed_by"`
+		CreatedAt   time.Time                `db:"created_at"`
+		UpdatedAt   *time.Time               `db:"updated_at"`
+		DeletedAt   *time.Time               `db:"deleted_at"`
+		CreatedBy   uint64                   `db:"created_by"`
+		UpdatedBy   uint64                   `db:"updated_by"`
+		DeletedBy   uint64                   `db:"deleted_by"`
+	}
+
+	// auxDataPrivacyRequestComment is an auxiliary structure used for transporting to/from RDBMS store
+	auxDataPrivacyRequestComment struct {
+		ID        uint64     `db:"id"`
+		RequestID uint64     `db:"request_id"`
+		Comment   string     `db:"comment"`
+		CreatedAt time.Time  `db:"created_at"`
+		UpdatedAt *time.Time `db:"updated_at"`
+		DeletedAt *time.Time `db:"deleted_at"`
+		CreatedBy uint64     `db:"created_by"`
+		UpdatedBy uint64     `db:"updated_by"`
+		DeletedBy uint64     `db:"deleted_by"`
+	}
+
 	// auxFederationExposedModule is an auxiliary structure used for transporting to/from RDBMS store
 	auxFederationExposedModule struct {
 		ID                 uint64                        `db:"id"`
@@ -1932,6 +1962,118 @@ func (aux *auxDalSensitivityLevel) scan(row scanner) error {
 		&aux.Handle,
 		&aux.Level,
 		&aux.Meta,
+		&aux.CreatedAt,
+		&aux.UpdatedAt,
+		&aux.DeletedAt,
+		&aux.CreatedBy,
+		&aux.UpdatedBy,
+		&aux.DeletedBy,
+	)
+}
+
+// encodes DataPrivacyRequest to auxDataPrivacyRequest
+//
+// This function is auto-generated
+func (aux *auxDataPrivacyRequest) encode(res *systemType.DataPrivacyRequest) (_ error) {
+	aux.ID = res.ID
+	aux.Kind = res.Kind
+	aux.Status = res.Status
+	aux.RequestedAt = res.RequestedAt
+	aux.RequestedBy = res.RequestedBy
+	aux.CompletedAt = res.CompletedAt
+	aux.CompletedBy = res.CompletedBy
+	aux.CreatedAt = res.CreatedAt
+	aux.UpdatedAt = res.UpdatedAt
+	aux.DeletedAt = res.DeletedAt
+	aux.CreatedBy = res.CreatedBy
+	aux.UpdatedBy = res.UpdatedBy
+	aux.DeletedBy = res.DeletedBy
+	return
+}
+
+// decodes DataPrivacyRequest from auxDataPrivacyRequest
+//
+// This function is auto-generated
+func (aux auxDataPrivacyRequest) decode() (res *systemType.DataPrivacyRequest, _ error) {
+	res = new(systemType.DataPrivacyRequest)
+	res.ID = aux.ID
+	res.Kind = aux.Kind
+	res.Status = aux.Status
+	res.RequestedAt = aux.RequestedAt
+	res.RequestedBy = aux.RequestedBy
+	res.CompletedAt = aux.CompletedAt
+	res.CompletedBy = aux.CompletedBy
+	res.CreatedAt = aux.CreatedAt
+	res.UpdatedAt = aux.UpdatedAt
+	res.DeletedAt = aux.DeletedAt
+	res.CreatedBy = aux.CreatedBy
+	res.UpdatedBy = aux.UpdatedBy
+	res.DeletedBy = aux.DeletedBy
+	return
+}
+
+// scans row and fills auxDataPrivacyRequest fields
+//
+// This function is auto-generated
+func (aux *auxDataPrivacyRequest) scan(row scanner) error {
+	return row.Scan(
+		&aux.ID,
+		&aux.Kind,
+		&aux.Status,
+		&aux.RequestedAt,
+		&aux.RequestedBy,
+		&aux.CompletedAt,
+		&aux.CompletedBy,
+		&aux.CreatedAt,
+		&aux.UpdatedAt,
+		&aux.DeletedAt,
+		&aux.CreatedBy,
+		&aux.UpdatedBy,
+		&aux.DeletedBy,
+	)
+}
+
+// encodes DataPrivacyRequestComment to auxDataPrivacyRequestComment
+//
+// This function is auto-generated
+func (aux *auxDataPrivacyRequestComment) encode(res *systemType.DataPrivacyRequestComment) (_ error) {
+	aux.ID = res.ID
+	aux.RequestID = res.RequestID
+	aux.Comment = res.Comment
+	aux.CreatedAt = res.CreatedAt
+	aux.UpdatedAt = res.UpdatedAt
+	aux.DeletedAt = res.DeletedAt
+	aux.CreatedBy = res.CreatedBy
+	aux.UpdatedBy = res.UpdatedBy
+	aux.DeletedBy = res.DeletedBy
+	return
+}
+
+// decodes DataPrivacyRequestComment from auxDataPrivacyRequestComment
+//
+// This function is auto-generated
+func (aux auxDataPrivacyRequestComment) decode() (res *systemType.DataPrivacyRequestComment, _ error) {
+	res = new(systemType.DataPrivacyRequestComment)
+	res.ID = aux.ID
+	res.RequestID = aux.RequestID
+	res.Comment = aux.Comment
+	res.CreatedAt = aux.CreatedAt
+	res.UpdatedAt = aux.UpdatedAt
+	res.DeletedAt = aux.DeletedAt
+	res.CreatedBy = aux.CreatedBy
+	res.UpdatedBy = aux.UpdatedBy
+	res.DeletedBy = aux.DeletedBy
+	return
+}
+
+// scans row and fills auxDataPrivacyRequestComment fields
+//
+// This function is auto-generated
+func (aux *auxDataPrivacyRequestComment) scan(row scanner) error {
+	return row.Scan(
+		&aux.ID,
+		&aux.RequestID,
+		&aux.Comment,
 		&aux.CreatedAt,
 		&aux.UpdatedAt,
 		&aux.DeletedAt,

--- a/store/adapters/rdbms/cursors_test.go
+++ b/store/adapters/rdbms/cursors_test.go
@@ -87,7 +87,7 @@ func Test_buildCursorCond(t *testing.T) {
 			var (
 				req = require.New(t)
 
-				sql, args, err = CursorCondition(tt.cursor, nil).ToSQL()
+				sql, args, err = CursorCondition(tt.cursor, nil, nil).ToSQL()
 			)
 
 			req.NoError(err)

--- a/store/adapters/rdbms/filter.go
+++ b/store/adapters/rdbms/filter.go
@@ -265,6 +265,26 @@ func DefaultFilters() (f *extendedFilters) {
 		return ee, f, err
 	}
 
+	f.DataPrivacyRequest = func(s *Store, f systemType.DataPrivacyRequestFilter) (ee []goqu.Expression, _ systemType.DataPrivacyRequestFilter, err error) {
+		if ee, f, err = DataPrivacyRequestFilter(f); err != nil {
+			return
+		}
+
+		if len(f.Kind) > 0 {
+			ee = append(ee, goqu.C("kind").In(f.Kind))
+		}
+
+		if len(f.Status) > 0 {
+			ee = append(ee, goqu.C("status").In(f.Status))
+		}
+
+		if f.Limit == 0 || f.Limit > MaxLimit {
+			f.Limit = MaxLimit
+		}
+
+		return ee, f, err
+	}
+
 	return
 }
 

--- a/store/adapters/rdbms/filters.gen.go
+++ b/store/adapters/rdbms/filters.gen.go
@@ -575,6 +575,10 @@ func ComposeModuleFieldFilter(f composeType.ModuleFieldFilter) (ee []goqu.Expres
 		ee = append(ee, expr)
 	}
 
+	if len(f.ModuleID) > 0 {
+		ee = append(ee, goqu.C("rel_module").In(f.ModuleID))
+	}
+
 	return ee, f, err
 }
 

--- a/store/adapters/rdbms/filters.gen.go
+++ b/store/adapters/rdbms/filters.gen.go
@@ -98,6 +98,12 @@ type (
 		// optional dalSensitivityLevel filter function called after the generated function
 		DalSensitivityLevel func(*Store, systemType.DalSensitivityLevelFilter) ([]goqu.Expression, systemType.DalSensitivityLevelFilter, error)
 
+		// optional dataPrivacyRequest filter function called after the generated function
+		DataPrivacyRequest func(*Store, systemType.DataPrivacyRequestFilter) ([]goqu.Expression, systemType.DataPrivacyRequestFilter, error)
+
+		// optional dataPrivacyRequestComment filter function called after the generated function
+		DataPrivacyRequestComment func(*Store, systemType.DataPrivacyRequestCommentFilter) ([]goqu.Expression, systemType.DataPrivacyRequestCommentFilter, error)
+
 		// optional federationExposedModule filter function called after the generated function
 		FederationExposedModule func(*Store, federationType.ExposedModuleFilter) ([]goqu.Expression, federationType.ExposedModuleFilter, error)
 
@@ -762,6 +768,47 @@ func DalSensitivityLevelFilter(f systemType.DalSensitivityLevelFilter) (ee []goq
 
 	if len(f.SensitivityLevelID) > 0 {
 		ee = append(ee, goqu.C("id").In(f.SensitivityLevelID))
+	}
+
+	return ee, f, err
+}
+
+// DataPrivacyRequestFilter returns logical expressions
+//
+// This function is called from Store.QueryDataPrivacyRequests() and can be extended
+// by setting Store.Filters.DataPrivacyRequest. Extension is called after all expressions
+// are generated and can choose to ignore or alter them.
+//
+// This function is auto-generated
+func DataPrivacyRequestFilter(f systemType.DataPrivacyRequestFilter) (ee []goqu.Expression, _ systemType.DataPrivacyRequestFilter, err error) {
+
+	// @todo codegen warning: filtering by Kind ([]types.RequestKind) not supported,
+	//       see rdbms.go.tpl and add an exception
+
+	// @todo codegen warning: filtering by Status ([]types.RequestStatus) not supported,
+	//       see rdbms.go.tpl and add an exception
+
+	if f.Query != "" {
+		ee = append(ee, goqu.Or(
+			goqu.C("kind").ILike("%"+f.Query+"%"),
+			goqu.C("status").ILike("%"+f.Query+"%"),
+		))
+	}
+
+	return ee, f, err
+}
+
+// DataPrivacyRequestCommentFilter returns logical expressions
+//
+// This function is called from Store.QueryDataPrivacyRequestComments() and can be extended
+// by setting Store.Filters.DataPrivacyRequestComment. Extension is called after all expressions
+// are generated and can choose to ignore or alter them.
+//
+// This function is auto-generated
+func DataPrivacyRequestCommentFilter(f systemType.DataPrivacyRequestCommentFilter) (ee []goqu.Expression, _ systemType.DataPrivacyRequestCommentFilter, err error) {
+
+	if len(f.RequestID) > 0 {
+		ee = append(ee, goqu.C("rel_request").In(f.RequestID))
 	}
 
 	return ee, f, err

--- a/store/adapters/rdbms/queries.gen.go
+++ b/store/adapters/rdbms/queries.gen.go
@@ -2641,6 +2641,230 @@ var (
 		}
 	}
 
+	// dataPrivacyRequestTable represents dataPrivacyRequests store table
+	//
+	// This value is auto-generated
+	dataPrivacyRequestTable = goqu.T("data_privacy_requests")
+
+	// dataPrivacyRequestSelectQuery assembles select query for fetching dataPrivacyRequests
+	//
+	// This function is auto-generated
+	dataPrivacyRequestSelectQuery = func(d goqu.DialectWrapper) *goqu.SelectDataset {
+		return d.Select(
+			"id",
+			"kind",
+			"status",
+			"requested_at",
+			"requested_by",
+			"completed_at",
+			"completed_by",
+			"created_at",
+			"updated_at",
+			"deleted_at",
+			"created_by",
+			"updated_by",
+			"deleted_by",
+		).From(dataPrivacyRequestTable)
+	}
+
+	// dataPrivacyRequestInsertQuery assembles query inserting dataPrivacyRequests
+	//
+	// This function is auto-generated
+	dataPrivacyRequestInsertQuery = func(d goqu.DialectWrapper, res *systemType.DataPrivacyRequest) *goqu.InsertDataset {
+		return d.Insert(dataPrivacyRequestTable).
+			Rows(goqu.Record{
+				"id":           res.ID,
+				"kind":         res.Kind,
+				"status":       res.Status,
+				"requested_at": res.RequestedAt,
+				"requested_by": res.RequestedBy,
+				"completed_at": res.CompletedAt,
+				"completed_by": res.CompletedBy,
+				"created_at":   res.CreatedAt,
+				"updated_at":   res.UpdatedAt,
+				"deleted_at":   res.DeletedAt,
+				"created_by":   res.CreatedBy,
+				"updated_by":   res.UpdatedBy,
+				"deleted_by":   res.DeletedBy,
+			})
+	}
+
+	// dataPrivacyRequestUpsertQuery assembles (insert+on-conflict) query for replacing dataPrivacyRequests
+	//
+	// This function is auto-generated
+	dataPrivacyRequestUpsertQuery = func(d goqu.DialectWrapper, res *systemType.DataPrivacyRequest) *goqu.InsertDataset {
+		var target = `,id`
+
+		return dataPrivacyRequestInsertQuery(d, res).
+			OnConflict(
+				goqu.DoUpdate(target[1:],
+					goqu.Record{
+						"kind":         res.Kind,
+						"status":       res.Status,
+						"requested_at": res.RequestedAt,
+						"requested_by": res.RequestedBy,
+						"completed_at": res.CompletedAt,
+						"completed_by": res.CompletedBy,
+						"created_at":   res.CreatedAt,
+						"updated_at":   res.UpdatedAt,
+						"deleted_at":   res.DeletedAt,
+						"created_by":   res.CreatedBy,
+						"updated_by":   res.UpdatedBy,
+						"deleted_by":   res.DeletedBy,
+					},
+				),
+			)
+	}
+
+	// dataPrivacyRequestUpdateQuery assembles query for updating dataPrivacyRequests
+	//
+	// This function is auto-generated
+	dataPrivacyRequestUpdateQuery = func(d goqu.DialectWrapper, res *systemType.DataPrivacyRequest) *goqu.UpdateDataset {
+		return d.Update(dataPrivacyRequestTable).
+			Set(goqu.Record{
+				"kind":         res.Kind,
+				"status":       res.Status,
+				"requested_at": res.RequestedAt,
+				"requested_by": res.RequestedBy,
+				"completed_at": res.CompletedAt,
+				"completed_by": res.CompletedBy,
+				"created_at":   res.CreatedAt,
+				"updated_at":   res.UpdatedAt,
+				"deleted_at":   res.DeletedAt,
+				"created_by":   res.CreatedBy,
+				"updated_by":   res.UpdatedBy,
+				"deleted_by":   res.DeletedBy,
+			}).
+			Where(dataPrivacyRequestPrimaryKeys(res))
+	}
+
+	// dataPrivacyRequestDeleteQuery assembles delete query for removing dataPrivacyRequests
+	//
+	// This function is auto-generated
+	dataPrivacyRequestDeleteQuery = func(d goqu.DialectWrapper, ee ...goqu.Expression) *goqu.DeleteDataset {
+		return d.Delete(dataPrivacyRequestTable).Where(ee...)
+	}
+
+	// dataPrivacyRequestDeleteQuery assembles delete query for removing dataPrivacyRequests
+	//
+	// This function is auto-generated
+	dataPrivacyRequestTruncateQuery = func(d goqu.DialectWrapper) *goqu.TruncateDataset {
+		return d.Truncate(dataPrivacyRequestTable)
+	}
+
+	// dataPrivacyRequestPrimaryKeys assembles set of conditions for all primary keys
+	//
+	// This function is auto-generated
+	dataPrivacyRequestPrimaryKeys = func(res *systemType.DataPrivacyRequest) goqu.Ex {
+		return goqu.Ex{
+			"id": res.ID,
+		}
+	}
+
+	// dataPrivacyRequestCommentTable represents dataPrivacyRequestComments store table
+	//
+	// This value is auto-generated
+	dataPrivacyRequestCommentTable = goqu.T("data_privacy_request_comments")
+
+	// dataPrivacyRequestCommentSelectQuery assembles select query for fetching dataPrivacyRequestComments
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentSelectQuery = func(d goqu.DialectWrapper) *goqu.SelectDataset {
+		return d.Select(
+			"id",
+			"rel_request",
+			"comment",
+			"created_at",
+			"updated_at",
+			"deleted_at",
+			"created_by",
+			"updated_by",
+			"deleted_by",
+		).From(dataPrivacyRequestCommentTable)
+	}
+
+	// dataPrivacyRequestCommentInsertQuery assembles query inserting dataPrivacyRequestComments
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentInsertQuery = func(d goqu.DialectWrapper, res *systemType.DataPrivacyRequestComment) *goqu.InsertDataset {
+		return d.Insert(dataPrivacyRequestCommentTable).
+			Rows(goqu.Record{
+				"id":          res.ID,
+				"rel_request": res.RequestID,
+				"comment":     res.Comment,
+				"created_at":  res.CreatedAt,
+				"updated_at":  res.UpdatedAt,
+				"deleted_at":  res.DeletedAt,
+				"created_by":  res.CreatedBy,
+				"updated_by":  res.UpdatedBy,
+				"deleted_by":  res.DeletedBy,
+			})
+	}
+
+	// dataPrivacyRequestCommentUpsertQuery assembles (insert+on-conflict) query for replacing dataPrivacyRequestComments
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentUpsertQuery = func(d goqu.DialectWrapper, res *systemType.DataPrivacyRequestComment) *goqu.InsertDataset {
+		var target = `,id`
+
+		return dataPrivacyRequestCommentInsertQuery(d, res).
+			OnConflict(
+				goqu.DoUpdate(target[1:],
+					goqu.Record{
+						"rel_request": res.RequestID,
+						"comment":     res.Comment,
+						"created_at":  res.CreatedAt,
+						"updated_at":  res.UpdatedAt,
+						"deleted_at":  res.DeletedAt,
+						"created_by":  res.CreatedBy,
+						"updated_by":  res.UpdatedBy,
+						"deleted_by":  res.DeletedBy,
+					},
+				),
+			)
+	}
+
+	// dataPrivacyRequestCommentUpdateQuery assembles query for updating dataPrivacyRequestComments
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentUpdateQuery = func(d goqu.DialectWrapper, res *systemType.DataPrivacyRequestComment) *goqu.UpdateDataset {
+		return d.Update(dataPrivacyRequestCommentTable).
+			Set(goqu.Record{
+				"rel_request": res.RequestID,
+				"comment":     res.Comment,
+				"created_at":  res.CreatedAt,
+				"updated_at":  res.UpdatedAt,
+				"deleted_at":  res.DeletedAt,
+				"created_by":  res.CreatedBy,
+				"updated_by":  res.UpdatedBy,
+				"deleted_by":  res.DeletedBy,
+			}).
+			Where(dataPrivacyRequestCommentPrimaryKeys(res))
+	}
+
+	// dataPrivacyRequestCommentDeleteQuery assembles delete query for removing dataPrivacyRequestComments
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentDeleteQuery = func(d goqu.DialectWrapper, ee ...goqu.Expression) *goqu.DeleteDataset {
+		return d.Delete(dataPrivacyRequestCommentTable).Where(ee...)
+	}
+
+	// dataPrivacyRequestCommentDeleteQuery assembles delete query for removing dataPrivacyRequestComments
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentTruncateQuery = func(d goqu.DialectWrapper) *goqu.TruncateDataset {
+		return d.Truncate(dataPrivacyRequestCommentTable)
+	}
+
+	// dataPrivacyRequestCommentPrimaryKeys assembles set of conditions for all primary keys
+	//
+	// This function is auto-generated
+	dataPrivacyRequestCommentPrimaryKeys = func(res *systemType.DataPrivacyRequestComment) goqu.Ex {
+		return goqu.Ex{
+			"id": res.ID,
+		}
+	}
+
 	// federationExposedModuleTable represents federationExposedModules store table
 	//
 	// This value is auto-generated

--- a/store/adapters/rdbms/rdbms.gen.go
+++ b/store/adapters/rdbms/rdbms.gen.go
@@ -29,48 +29,50 @@ import (
 )
 
 var (
-	_ store.Actionlogs               = &Store{}
-	_ store.ApigwFilters             = &Store{}
-	_ store.ApigwRoutes              = &Store{}
-	_ store.Applications             = &Store{}
-	_ store.Attachments              = &Store{}
-	_ store.AuthClients              = &Store{}
-	_ store.AuthConfirmedClients     = &Store{}
-	_ store.AuthOa2tokens            = &Store{}
-	_ store.AuthSessions             = &Store{}
-	_ store.AutomationSessions       = &Store{}
-	_ store.AutomationTriggers       = &Store{}
-	_ store.AutomationWorkflows      = &Store{}
-	_ store.ComposeAttachments       = &Store{}
-	_ store.ComposeCharts            = &Store{}
-	_ store.ComposeModules           = &Store{}
-	_ store.ComposeModuleFields      = &Store{}
-	_ store.ComposeNamespaces        = &Store{}
-	_ store.ComposePages             = &Store{}
-	_ store.ComposeRecords           = &Store{}
-	_ store.ComposeRecordValues      = &Store{}
-	_ store.Credentials              = &Store{}
-	_ store.DalConnections           = &Store{}
-	_ store.DalSensitivityLevels     = &Store{}
-	_ store.FederationExposedModules = &Store{}
-	_ store.FederationModuleMappings = &Store{}
-	_ store.FederationNodes          = &Store{}
-	_ store.FederationNodeSyncs      = &Store{}
-	_ store.FederationSharedModules  = &Store{}
-	_ store.Flags                    = &Store{}
-	_ store.Labels                   = &Store{}
-	_ store.Queues                   = &Store{}
-	_ store.QueueMessages            = &Store{}
-	_ store.RbacRules                = &Store{}
-	_ store.Reminders                = &Store{}
-	_ store.Reports                  = &Store{}
-	_ store.ResourceActivitys        = &Store{}
-	_ store.ResourceTranslations     = &Store{}
-	_ store.Roles                    = &Store{}
-	_ store.RoleMembers              = &Store{}
-	_ store.SettingValues            = &Store{}
-	_ store.Templates                = &Store{}
-	_ store.Users                    = &Store{}
+	_ store.Actionlogs                 = &Store{}
+	_ store.ApigwFilters               = &Store{}
+	_ store.ApigwRoutes                = &Store{}
+	_ store.Applications               = &Store{}
+	_ store.Attachments                = &Store{}
+	_ store.AuthClients                = &Store{}
+	_ store.AuthConfirmedClients       = &Store{}
+	_ store.AuthOa2tokens              = &Store{}
+	_ store.AuthSessions               = &Store{}
+	_ store.AutomationSessions         = &Store{}
+	_ store.AutomationTriggers         = &Store{}
+	_ store.AutomationWorkflows        = &Store{}
+	_ store.ComposeAttachments         = &Store{}
+	_ store.ComposeCharts              = &Store{}
+	_ store.ComposeModules             = &Store{}
+	_ store.ComposeModuleFields        = &Store{}
+	_ store.ComposeNamespaces          = &Store{}
+	_ store.ComposePages               = &Store{}
+	_ store.ComposeRecords             = &Store{}
+	_ store.ComposeRecordValues        = &Store{}
+	_ store.Credentials                = &Store{}
+	_ store.DalConnections             = &Store{}
+	_ store.DalSensitivityLevels       = &Store{}
+	_ store.DataPrivacyRequests        = &Store{}
+	_ store.DataPrivacyRequestComments = &Store{}
+	_ store.FederationExposedModules   = &Store{}
+	_ store.FederationModuleMappings   = &Store{}
+	_ store.FederationNodes            = &Store{}
+	_ store.FederationNodeSyncs        = &Store{}
+	_ store.FederationSharedModules    = &Store{}
+	_ store.Flags                      = &Store{}
+	_ store.Labels                     = &Store{}
+	_ store.Queues                     = &Store{}
+	_ store.QueueMessages              = &Store{}
+	_ store.RbacRules                  = &Store{}
+	_ store.Reminders                  = &Store{}
+	_ store.Reports                    = &Store{}
+	_ store.ResourceActivitys          = &Store{}
+	_ store.ResourceTranslations       = &Store{}
+	_ store.Roles                      = &Store{}
+	_ store.RoleMembers                = &Store{}
+	_ store.SettingValues              = &Store{}
+	_ store.Templates                  = &Store{}
+	_ store.Users                      = &Store{}
 )
 
 // CreateActionlog creates one or more rows in actionlog collection
@@ -656,7 +658,7 @@ func (s *Store) QueryApigwFilters(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableApigwFilterFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -1178,7 +1180,7 @@ func (s *Store) QueryApigwRoutes(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableApigwRouteFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -1704,7 +1706,7 @@ func (s *Store) QueryApplications(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableApplicationFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -2188,7 +2190,7 @@ func (s *Store) QueryAttachments(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableAttachmentFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -2670,7 +2672,7 @@ func (s *Store) QueryAuthClients(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableAuthClientFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -4212,7 +4214,7 @@ func (s *Store) QueryAutomationSessions(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableAutomationSessionFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -4700,7 +4702,7 @@ func (s *Store) QueryAutomationTriggers(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableAutomationTriggerFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -5184,7 +5186,7 @@ func (s *Store) QueryAutomationWorkflows(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableAutomationWorkflowFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -5742,7 +5744,7 @@ func (s *Store) QueryComposeAttachments(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableComposeAttachmentFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -6224,7 +6226,7 @@ func (s *Store) QueryComposeCharts(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableComposeChartFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -6757,7 +6759,7 @@ func (s *Store) QueryComposeModules(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableComposeModuleFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -7680,7 +7682,7 @@ func (s *Store) QueryComposeNamespaces(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableComposeNamespaceFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -8232,7 +8234,7 @@ func (s *Store) QueryComposePages(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableComposePageFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -8810,7 +8812,7 @@ func (s *Store) QueryComposeRecords(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableComposeRecordFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -10241,6 +10243,946 @@ func (s *Store) checkDalSensitivityLevelConstraints(ctx context.Context, res *sy
 	return nil
 }
 
+// CreateDataPrivacyRequest creates one or more rows in dataPrivacyRequest collection
+//
+// This function is auto-generated
+func (s *Store) CreateDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) (err error) {
+	for i := range rr {
+		if err = s.checkDataPrivacyRequestConstraints(ctx, rr[i]); err != nil {
+			return
+		}
+
+		if err = s.Exec(ctx, dataPrivacyRequestInsertQuery(s.Dialect, rr[i])); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// UpdateDataPrivacyRequest updates one or more existing entries in dataPrivacyRequest collection
+//
+// This function is auto-generated
+func (s *Store) UpdateDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) (err error) {
+	for i := range rr {
+		if err = s.checkDataPrivacyRequestConstraints(ctx, rr[i]); err != nil {
+			return
+		}
+
+		if err = s.Exec(ctx, dataPrivacyRequestUpdateQuery(s.Dialect, rr[i])); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// UpsertDataPrivacyRequest updates one or more existing entries in dataPrivacyRequest collection
+//
+// This function is auto-generated
+func (s *Store) UpsertDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) (err error) {
+	for i := range rr {
+		if err = s.checkDataPrivacyRequestConstraints(ctx, rr[i]); err != nil {
+			return
+		}
+
+		if err = s.Exec(ctx, dataPrivacyRequestUpsertQuery(s.Dialect, rr[i])); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// DeleteDataPrivacyRequest Deletes one or more entries from dataPrivacyRequest collection
+//
+// This function is auto-generated
+func (s *Store) DeleteDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) (err error) {
+	for i := range rr {
+		if err = s.Exec(ctx, dataPrivacyRequestDeleteQuery(s.Dialect, dataPrivacyRequestPrimaryKeys(rr[i]))); err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+// DeleteDataPrivacyRequestByID deletes single entry from dataPrivacyRequest collection
+//
+// This function is auto-generated
+func (s *Store) DeleteDataPrivacyRequestByID(ctx context.Context, id uint64) error {
+	return s.Exec(ctx, dataPrivacyRequestDeleteQuery(s.Dialect, goqu.Ex{
+		"id": id,
+	}))
+}
+
+// TruncateDataPrivacyRequests Deletes all rows from the dataPrivacyRequest collection
+func (s Store) TruncateDataPrivacyRequests(ctx context.Context) error {
+	return s.Exec(ctx, dataPrivacyRequestTruncateQuery(s.Dialect))
+}
+
+// SearchDataPrivacyRequests returns (filtered) set of DataPrivacyRequests
+//
+// This function is auto-generated
+func (s *Store) SearchDataPrivacyRequests(ctx context.Context, f systemType.DataPrivacyRequestFilter) (set systemType.DataPrivacyRequestSet, _ systemType.DataPrivacyRequestFilter, err error) {
+
+	// Cleanup unwanted cursor values (only relevant is f.PageCursor, next&prev are reset and returned)
+	f.PrevPage, f.NextPage = nil, nil
+
+	if f.PageCursor != nil {
+		// Page cursor exists; we need to validate it against used sort
+		// To cover the case when paging cursor is set but sorting is empty, we collect the sorting instructions
+		// from the cursor.
+		// This (extracted sorting info) is then returned as part of response
+		if f.Sort, err = f.PageCursor.Sort(f.Sort); err != nil {
+			return
+		}
+	}
+
+	// Make sure results are always sorted at least by primary keys
+	if f.Sort.Get("id") == nil {
+		f.Sort = append(f.Sort, &filter.SortExpr{
+			Column:     "id",
+			Descending: f.Sort.LastDescending(),
+		})
+	}
+
+	// Cloned sorting instructions for the actual sorting
+	// Original are passed to the etchFullPageOfDataPrivacyRequests fn used for cursor creation;
+	// direction information it MUST keep the initial
+	sort := f.Sort.Clone()
+
+	// When cursor for a previous page is used it's marked as reversed
+	// This tells us to flip the descending flag on all used sort keys
+	if f.PageCursor != nil && f.PageCursor.ROrder {
+		sort.Reverse()
+	}
+
+	set, f.PrevPage, f.NextPage, err = s.fetchFullPageOfDataPrivacyRequests(ctx, f, sort)
+
+	f.PageCursor = nil
+	if err != nil {
+		return nil, f, err
+	}
+
+	return set, f, nil
+}
+
+// fetchFullPageOfDataPrivacyRequests collects all requested results.
+//
+// Function applies:
+//  - cursor conditions (where ...)
+//  - limit
+//
+// Main responsibility of this function is to perform additional sequential queries in case when not enough results
+// are collected due to failed check on a specific row (by check fn).
+//
+// Function then moves cursor to the last item fetched
+//
+// This function is auto-generated
+func (s *Store) fetchFullPageOfDataPrivacyRequests(
+	ctx context.Context,
+	filter systemType.DataPrivacyRequestFilter,
+	sort filter.SortExprSet,
+) (set []*systemType.DataPrivacyRequest, prev, next *filter.PagingCursor, err error) {
+	var (
+		aux []*systemType.DataPrivacyRequest
+
+		// When cursor for a previous page is used it's marked as reversed
+		// This tells us to flip the descending flag on all used sort keys
+		reversedOrder = filter.PageCursor != nil && filter.PageCursor.ROrder
+
+		// Copy no. of required items to limit
+		// Limit will change when doing subsequent queries to fill
+		// the set with all required items
+		limit = filter.Limit
+
+		reqItems = filter.Limit
+
+		// cursor to prev. page is only calculated when cursor is used
+		hasPrev = filter.PageCursor != nil
+
+		// next cursor is calculated when there are more pages to come
+		hasNext bool
+
+		tryFilter systemType.DataPrivacyRequestFilter
+	)
+
+	set = make([]*systemType.DataPrivacyRequest, 0, DefaultSliceCapacity)
+
+	for try := 0; try < MaxRefetches; try++ {
+		// Copy filter & apply custom sorting that might be affected by cursor
+		tryFilter = filter
+		tryFilter.Sort = sort
+
+		if limit > 0 {
+			// fetching + 1 to peak ahead if there are more items
+			// we can fetch (next-page cursor)
+			tryFilter.Limit = limit + 1
+		}
+
+		if aux, hasNext, err = s.QueryDataPrivacyRequests(ctx, tryFilter); err != nil {
+			return nil, nil, nil, err
+		}
+
+		if len(aux) == 0 {
+			// nothing fetched
+			break
+		}
+
+		// append fetched items
+		set = append(set, aux...)
+
+		if reqItems == 0 || !hasNext {
+			// no max requested items specified, break out
+			break
+		}
+
+		collected := uint(len(set))
+
+		if reqItems > collected {
+			// not enough items fetched, try again with adjusted limit
+			limit = reqItems - collected
+
+			if limit < MinEnsureFetchLimit {
+				// In case limit is set very low and we've missed records in the first fetch,
+				// make sure next fetch limit is a bit higher
+				limit = MinEnsureFetchLimit
+			}
+
+			// Update cursor so that it points to the last item fetched
+			tryFilter.PageCursor = s.collectDataPrivacyRequestCursorValues(set[collected-1], filter.Sort...)
+
+			// Copy reverse flag from sorting
+			tryFilter.PageCursor.LThen = filter.Sort.Reversed()
+			continue
+		}
+
+		if reqItems < collected {
+			set = set[:reqItems]
+		}
+
+		break
+	}
+
+	collected := len(set)
+
+	if collected == 0 {
+		return nil, nil, nil, nil
+	}
+
+	if reversedOrder {
+		// Fetched set needs to be reversed because we've forced a descending order to get the previous page
+		for i, j := 0, collected-1; i < j; i, j = i+1, j-1 {
+			set[i], set[j] = set[j], set[i]
+		}
+
+		// when in reverse-order rules on what cursor to return change
+		hasPrev, hasNext = hasNext, hasPrev
+	}
+
+	if hasPrev {
+		prev = s.collectDataPrivacyRequestCursorValues(set[0], filter.Sort...)
+		prev.ROrder = true
+		prev.LThen = !filter.Sort.Reversed()
+	}
+
+	if hasNext {
+		next = s.collectDataPrivacyRequestCursorValues(set[collected-1], filter.Sort...)
+		next.LThen = filter.Sort.Reversed()
+	}
+
+	return set, prev, next, nil
+}
+
+// QueryDataPrivacyRequests queries the database, converts and checks each row and returns collected set
+//
+// With generics, we can remove this per-resource-generated function
+// and replace it with a single utility fetcher
+//
+// This function is auto-generated
+func (s *Store) QueryDataPrivacyRequests(
+	ctx context.Context,
+	f systemType.DataPrivacyRequestFilter,
+) (_ []*systemType.DataPrivacyRequest, more bool, err error) {
+	var (
+		ok bool
+
+		set         = make([]*systemType.DataPrivacyRequest, 0, DefaultSliceCapacity)
+		res         *systemType.DataPrivacyRequest
+		aux         *auxDataPrivacyRequest
+		rows        *sql.Rows
+		count       uint
+		expr, tExpr []goqu.Expression
+
+		sortExpr []exp.OrderedExpression
+	)
+
+	if s.Filters.DataPrivacyRequest != nil {
+		// extended filter set
+		tExpr, f, err = s.Filters.DataPrivacyRequest(s, f)
+	} else {
+		// using generated filter
+		tExpr, f, err = DataPrivacyRequestFilter(f)
+	}
+
+	if err != nil {
+		err = fmt.Errorf("could generate filter expression for DataPrivacyRequest: %w", err)
+		return
+	}
+
+	expr = append(expr, tExpr...)
+
+	// paging feature is enabled
+	if f.PageCursor != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableDataPrivacyRequestFields()); err != nil {
+			return
+		} else {
+			expr = append(expr, tExpr...)
+		}
+	}
+
+	query := dataPrivacyRequestSelectQuery(s.Dialect).Where(expr...)
+
+	// sorting feature is enabled
+	if sortExpr, err = order(f.Sort, s.sortableDataPrivacyRequestFields()); err != nil {
+		err = fmt.Errorf("could generate order expression for DataPrivacyRequest: %w", err)
+		return
+	}
+
+	if len(sortExpr) > 0 {
+		query = query.Order(sortExpr...)
+	}
+
+	if f.Limit > 0 {
+		query = query.Limit(f.Limit)
+	}
+
+	rows, err = s.Query(ctx, query)
+	if err != nil {
+		err = fmt.Errorf("could not query DataPrivacyRequest: %w", err)
+		return
+	}
+
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("could not query DataPrivacyRequest: %w", err)
+		return
+	}
+
+	defer func() {
+		closeError := rows.Close()
+		if err == nil {
+			// return error from close
+			err = closeError
+		}
+	}()
+
+	for rows.Next() {
+		if err = rows.Err(); err != nil {
+			err = fmt.Errorf("could not query DataPrivacyRequest: %w", err)
+			return
+		}
+
+		aux = new(auxDataPrivacyRequest)
+		if err = aux.scan(rows); err != nil {
+			err = fmt.Errorf("could not scan rows for DataPrivacyRequest: %w", err)
+			return
+		}
+
+		count++
+		if res, err = aux.decode(); err != nil {
+			err = fmt.Errorf("could not decode DataPrivacyRequest: %w", err)
+			return
+		}
+
+		// check fn set, call it and see if it passed the test
+		// if not, skip the item
+		if f.Check != nil {
+			if ok, err = f.Check(res); err != nil {
+				return
+			} else if !ok {
+				continue
+			}
+		}
+
+		set = append(set, res)
+	}
+
+	return set, f.Limit > 0 && count >= f.Limit, err
+
+}
+
+// LookupDataPrivacyRequestByID searches for data privacy request by ID
+//
+// It returns data privacy request even if deleted
+//
+// This function is auto-generated
+func (s *Store) LookupDataPrivacyRequestByID(ctx context.Context, id uint64) (_ *systemType.DataPrivacyRequest, err error) {
+	var (
+		rows   *sql.Rows
+		aux    = new(auxDataPrivacyRequest)
+		lookup = dataPrivacyRequestSelectQuery(s.Dialect).Where(
+			goqu.I("id").Eq(id),
+		).Limit(1)
+	)
+
+	rows, err = s.Query(ctx, lookup)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		closeError := rows.Close()
+		if err == nil {
+			// return error from close
+			err = closeError
+		}
+	}()
+
+	if err = rows.Err(); err != nil {
+		return
+	}
+
+	if !rows.Next() {
+		return nil, store.ErrNotFound.Stack(1)
+	}
+
+	if err = aux.scan(rows); err != nil {
+		return
+	}
+
+	return aux.decode()
+}
+
+// sortableDataPrivacyRequestFields returns all <no value> columns flagged as sortable
+//
+// With optional string arg, all columns are returned aliased
+//
+// This function is auto-generated
+func (Store) sortableDataPrivacyRequestFields() map[string]string {
+	return map[string]string{
+		"completed_at": "completed_at",
+		"completedat":  "completed_at",
+		"created_at":   "created_at",
+		"createdat":    "created_at",
+		"deleted_at":   "deleted_at",
+		"deletedat":    "deleted_at",
+		"id":           "id",
+		"kind":         "kind",
+		"requested_at": "requested_at",
+		"requestedat":  "requested_at",
+		"status":       "status",
+		"updated_at":   "updated_at",
+		"updatedat":    "updated_at",
+	}
+}
+
+// collectDataPrivacyRequestCursorValues collects values from the given resource that and sets them to the cursor
+// to be used for pagination
+//
+// Values that are collected must come from sortable, unique or primary columns/fields
+// At least one of the collected columns must be flagged as unique, otherwise fn appends primary keys at the end
+//
+// Known issue:
+//   when collecting cursor values for query that sorts by unique column with partial index (ie: unique handle on
+//   undeleted items)
+//
+// This function is auto-generated
+func (s *Store) collectDataPrivacyRequestCursorValues(res *systemType.DataPrivacyRequest, cc ...*filter.SortExpr) *filter.PagingCursor {
+	var (
+		cur = &filter.PagingCursor{LThen: filter.SortExprSet(cc).Reversed()}
+
+		hasUnique bool
+
+		pkID bool
+
+		collect = func(cc ...*filter.SortExpr) {
+			for _, c := range cc {
+				switch c.Column {
+				case "id":
+					cur.Set(c.Column, res.ID, c.Descending)
+					pkID = true
+				case "kind":
+					cur.Set(c.Column, res.Kind, c.Descending)
+				case "status":
+					cur.Set(c.Column, res.Status, c.Descending)
+				case "requestedAt":
+					cur.Set(c.Column, res.RequestedAt, c.Descending)
+				case "completedAt":
+					cur.Set(c.Column, res.CompletedAt, c.Descending)
+				case "createdAt":
+					cur.Set(c.Column, res.CreatedAt, c.Descending)
+				case "updatedAt":
+					cur.Set(c.Column, res.UpdatedAt, c.Descending)
+				case "deletedAt":
+					cur.Set(c.Column, res.DeletedAt, c.Descending)
+				}
+			}
+		}
+	)
+
+	collect(cc...)
+	if !hasUnique || !pkID {
+		collect(&filter.SortExpr{Column: "id", Descending: false})
+	}
+
+	return cur
+
+}
+
+// checkDataPrivacyRequestConstraints performs lookups (on valid) resource to check if any of the values on unique fields
+// already exists in the store
+//
+// Using built-in constraint checking would be more performant, but unfortunately we cannot rely
+// on the full support (MySQL does not support conditional indexes)
+//
+// This function is auto-generated
+func (s *Store) checkDataPrivacyRequestConstraints(ctx context.Context, res *systemType.DataPrivacyRequest) (err error) {
+	return nil
+}
+
+// CreateDataPrivacyRequestComment creates one or more rows in dataPrivacyRequestComment collection
+//
+// This function is auto-generated
+func (s *Store) CreateDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) (err error) {
+	for i := range rr {
+		if err = s.checkDataPrivacyRequestCommentConstraints(ctx, rr[i]); err != nil {
+			return
+		}
+
+		if err = s.Exec(ctx, dataPrivacyRequestCommentInsertQuery(s.Dialect, rr[i])); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// UpdateDataPrivacyRequestComment updates one or more existing entries in dataPrivacyRequestComment collection
+//
+// This function is auto-generated
+func (s *Store) UpdateDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) (err error) {
+	for i := range rr {
+		if err = s.checkDataPrivacyRequestCommentConstraints(ctx, rr[i]); err != nil {
+			return
+		}
+
+		if err = s.Exec(ctx, dataPrivacyRequestCommentUpdateQuery(s.Dialect, rr[i])); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// UpsertDataPrivacyRequestComment updates one or more existing entries in dataPrivacyRequestComment collection
+//
+// This function is auto-generated
+func (s *Store) UpsertDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) (err error) {
+	for i := range rr {
+		if err = s.checkDataPrivacyRequestCommentConstraints(ctx, rr[i]); err != nil {
+			return
+		}
+
+		if err = s.Exec(ctx, dataPrivacyRequestCommentUpsertQuery(s.Dialect, rr[i])); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// DeleteDataPrivacyRequestComment Deletes one or more entries from dataPrivacyRequestComment collection
+//
+// This function is auto-generated
+func (s *Store) DeleteDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) (err error) {
+	for i := range rr {
+		if err = s.Exec(ctx, dataPrivacyRequestCommentDeleteQuery(s.Dialect, dataPrivacyRequestCommentPrimaryKeys(rr[i]))); err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+// DeleteDataPrivacyRequestCommentByID deletes single entry from dataPrivacyRequestComment collection
+//
+// This function is auto-generated
+func (s *Store) DeleteDataPrivacyRequestCommentByID(ctx context.Context, id uint64) error {
+	return s.Exec(ctx, dataPrivacyRequestCommentDeleteQuery(s.Dialect, goqu.Ex{
+		"id": id,
+	}))
+}
+
+// TruncateDataPrivacyRequestComments Deletes all rows from the dataPrivacyRequestComment collection
+func (s Store) TruncateDataPrivacyRequestComments(ctx context.Context) error {
+	return s.Exec(ctx, dataPrivacyRequestCommentTruncateQuery(s.Dialect))
+}
+
+// SearchDataPrivacyRequestComments returns (filtered) set of DataPrivacyRequestComments
+//
+// This function is auto-generated
+func (s *Store) SearchDataPrivacyRequestComments(ctx context.Context, f systemType.DataPrivacyRequestCommentFilter) (set systemType.DataPrivacyRequestCommentSet, _ systemType.DataPrivacyRequestCommentFilter, err error) {
+
+	// Cleanup unwanted cursor values (only relevant is f.PageCursor, next&prev are reset and returned)
+	f.PrevPage, f.NextPage = nil, nil
+
+	if f.PageCursor != nil {
+		// Page cursor exists; we need to validate it against used sort
+		// To cover the case when paging cursor is set but sorting is empty, we collect the sorting instructions
+		// from the cursor.
+		// This (extracted sorting info) is then returned as part of response
+		if f.Sort, err = f.PageCursor.Sort(f.Sort); err != nil {
+			return
+		}
+	}
+
+	// Make sure results are always sorted at least by primary keys
+	if f.Sort.Get("id") == nil {
+		f.Sort = append(f.Sort, &filter.SortExpr{
+			Column:     "id",
+			Descending: f.Sort.LastDescending(),
+		})
+	}
+
+	// Cloned sorting instructions for the actual sorting
+	// Original are passed to the etchFullPageOfDataPrivacyRequestComments fn used for cursor creation;
+	// direction information it MUST keep the initial
+	sort := f.Sort.Clone()
+
+	// When cursor for a previous page is used it's marked as reversed
+	// This tells us to flip the descending flag on all used sort keys
+	if f.PageCursor != nil && f.PageCursor.ROrder {
+		sort.Reverse()
+	}
+
+	set, f.PrevPage, f.NextPage, err = s.fetchFullPageOfDataPrivacyRequestComments(ctx, f, sort)
+
+	f.PageCursor = nil
+	if err != nil {
+		return nil, f, err
+	}
+
+	return set, f, nil
+}
+
+// fetchFullPageOfDataPrivacyRequestComments collects all requested results.
+//
+// Function applies:
+//  - cursor conditions (where ...)
+//  - limit
+//
+// Main responsibility of this function is to perform additional sequential queries in case when not enough results
+// are collected due to failed check on a specific row (by check fn).
+//
+// Function then moves cursor to the last item fetched
+//
+// This function is auto-generated
+func (s *Store) fetchFullPageOfDataPrivacyRequestComments(
+	ctx context.Context,
+	filter systemType.DataPrivacyRequestCommentFilter,
+	sort filter.SortExprSet,
+) (set []*systemType.DataPrivacyRequestComment, prev, next *filter.PagingCursor, err error) {
+	var (
+		aux []*systemType.DataPrivacyRequestComment
+
+		// When cursor for a previous page is used it's marked as reversed
+		// This tells us to flip the descending flag on all used sort keys
+		reversedOrder = filter.PageCursor != nil && filter.PageCursor.ROrder
+
+		// Copy no. of required items to limit
+		// Limit will change when doing subsequent queries to fill
+		// the set with all required items
+		limit = filter.Limit
+
+		reqItems = filter.Limit
+
+		// cursor to prev. page is only calculated when cursor is used
+		hasPrev = filter.PageCursor != nil
+
+		// next cursor is calculated when there are more pages to come
+		hasNext bool
+
+		tryFilter systemType.DataPrivacyRequestCommentFilter
+	)
+
+	set = make([]*systemType.DataPrivacyRequestComment, 0, DefaultSliceCapacity)
+
+	for try := 0; try < MaxRefetches; try++ {
+		// Copy filter & apply custom sorting that might be affected by cursor
+		tryFilter = filter
+		tryFilter.Sort = sort
+
+		if limit > 0 {
+			// fetching + 1 to peak ahead if there are more items
+			// we can fetch (next-page cursor)
+			tryFilter.Limit = limit + 1
+		}
+
+		if aux, hasNext, err = s.QueryDataPrivacyRequestComments(ctx, tryFilter); err != nil {
+			return nil, nil, nil, err
+		}
+
+		if len(aux) == 0 {
+			// nothing fetched
+			break
+		}
+
+		// append fetched items
+		set = append(set, aux...)
+
+		if reqItems == 0 || !hasNext {
+			// no max requested items specified, break out
+			break
+		}
+
+		collected := uint(len(set))
+
+		if reqItems > collected {
+			// not enough items fetched, try again with adjusted limit
+			limit = reqItems - collected
+
+			if limit < MinEnsureFetchLimit {
+				// In case limit is set very low and we've missed records in the first fetch,
+				// make sure next fetch limit is a bit higher
+				limit = MinEnsureFetchLimit
+			}
+
+			// Update cursor so that it points to the last item fetched
+			tryFilter.PageCursor = s.collectDataPrivacyRequestCommentCursorValues(set[collected-1], filter.Sort...)
+
+			// Copy reverse flag from sorting
+			tryFilter.PageCursor.LThen = filter.Sort.Reversed()
+			continue
+		}
+
+		if reqItems < collected {
+			set = set[:reqItems]
+		}
+
+		break
+	}
+
+	collected := len(set)
+
+	if collected == 0 {
+		return nil, nil, nil, nil
+	}
+
+	if reversedOrder {
+		// Fetched set needs to be reversed because we've forced a descending order to get the previous page
+		for i, j := 0, collected-1; i < j; i, j = i+1, j-1 {
+			set[i], set[j] = set[j], set[i]
+		}
+
+		// when in reverse-order rules on what cursor to return change
+		hasPrev, hasNext = hasNext, hasPrev
+	}
+
+	if hasPrev {
+		prev = s.collectDataPrivacyRequestCommentCursorValues(set[0], filter.Sort...)
+		prev.ROrder = true
+		prev.LThen = !filter.Sort.Reversed()
+	}
+
+	if hasNext {
+		next = s.collectDataPrivacyRequestCommentCursorValues(set[collected-1], filter.Sort...)
+		next.LThen = filter.Sort.Reversed()
+	}
+
+	return set, prev, next, nil
+}
+
+// QueryDataPrivacyRequestComments queries the database, converts and checks each row and returns collected set
+//
+// With generics, we can remove this per-resource-generated function
+// and replace it with a single utility fetcher
+//
+// This function is auto-generated
+func (s *Store) QueryDataPrivacyRequestComments(
+	ctx context.Context,
+	f systemType.DataPrivacyRequestCommentFilter,
+) (_ []*systemType.DataPrivacyRequestComment, more bool, err error) {
+	var (
+		ok bool
+
+		set         = make([]*systemType.DataPrivacyRequestComment, 0, DefaultSliceCapacity)
+		res         *systemType.DataPrivacyRequestComment
+		aux         *auxDataPrivacyRequestComment
+		rows        *sql.Rows
+		count       uint
+		expr, tExpr []goqu.Expression
+
+		sortExpr []exp.OrderedExpression
+	)
+
+	if s.Filters.DataPrivacyRequestComment != nil {
+		// extended filter set
+		tExpr, f, err = s.Filters.DataPrivacyRequestComment(s, f)
+	} else {
+		// using generated filter
+		tExpr, f, err = DataPrivacyRequestCommentFilter(f)
+	}
+
+	if err != nil {
+		err = fmt.Errorf("could generate filter expression for DataPrivacyRequestComment: %w", err)
+		return
+	}
+
+	expr = append(expr, tExpr...)
+
+	// paging feature is enabled
+	if f.PageCursor != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableDataPrivacyRequestCommentFields()); err != nil {
+			return
+		} else {
+			expr = append(expr, tExpr...)
+		}
+	}
+
+	query := dataPrivacyRequestCommentSelectQuery(s.Dialect).Where(expr...)
+
+	// sorting feature is enabled
+	if sortExpr, err = order(f.Sort, s.sortableDataPrivacyRequestCommentFields()); err != nil {
+		err = fmt.Errorf("could generate order expression for DataPrivacyRequestComment: %w", err)
+		return
+	}
+
+	if len(sortExpr) > 0 {
+		query = query.Order(sortExpr...)
+	}
+
+	if f.Limit > 0 {
+		query = query.Limit(f.Limit)
+	}
+
+	rows, err = s.Query(ctx, query)
+	if err != nil {
+		err = fmt.Errorf("could not query DataPrivacyRequestComment: %w", err)
+		return
+	}
+
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("could not query DataPrivacyRequestComment: %w", err)
+		return
+	}
+
+	defer func() {
+		closeError := rows.Close()
+		if err == nil {
+			// return error from close
+			err = closeError
+		}
+	}()
+
+	for rows.Next() {
+		if err = rows.Err(); err != nil {
+			err = fmt.Errorf("could not query DataPrivacyRequestComment: %w", err)
+			return
+		}
+
+		aux = new(auxDataPrivacyRequestComment)
+		if err = aux.scan(rows); err != nil {
+			err = fmt.Errorf("could not scan rows for DataPrivacyRequestComment: %w", err)
+			return
+		}
+
+		count++
+		if res, err = aux.decode(); err != nil {
+			err = fmt.Errorf("could not decode DataPrivacyRequestComment: %w", err)
+			return
+		}
+
+		// check fn set, call it and see if it passed the test
+		// if not, skip the item
+		if f.Check != nil {
+			if ok, err = f.Check(res); err != nil {
+				return
+			} else if !ok {
+				continue
+			}
+		}
+
+		set = append(set, res)
+	}
+
+	return set, f.Limit > 0 && count >= f.Limit, err
+
+}
+
+// sortableDataPrivacyRequestCommentFields returns all <no value> columns flagged as sortable
+//
+// With optional string arg, all columns are returned aliased
+//
+// This function is auto-generated
+func (Store) sortableDataPrivacyRequestCommentFields() map[string]string {
+	return map[string]string{
+		"created_at": "created_at",
+		"createdat":  "created_at",
+		"deleted_at": "deleted_at",
+		"deletedat":  "deleted_at",
+		"id":         "id",
+		"updated_at": "updated_at",
+		"updatedat":  "updated_at",
+	}
+}
+
+// collectDataPrivacyRequestCommentCursorValues collects values from the given resource that and sets them to the cursor
+// to be used for pagination
+//
+// Values that are collected must come from sortable, unique or primary columns/fields
+// At least one of the collected columns must be flagged as unique, otherwise fn appends primary keys at the end
+//
+// Known issue:
+//   when collecting cursor values for query that sorts by unique column with partial index (ie: unique handle on
+//   undeleted items)
+//
+// This function is auto-generated
+func (s *Store) collectDataPrivacyRequestCommentCursorValues(res *systemType.DataPrivacyRequestComment, cc ...*filter.SortExpr) *filter.PagingCursor {
+	var (
+		cur = &filter.PagingCursor{LThen: filter.SortExprSet(cc).Reversed()}
+
+		hasUnique bool
+
+		pkID bool
+
+		collect = func(cc ...*filter.SortExpr) {
+			for _, c := range cc {
+				switch c.Column {
+				case "id":
+					cur.Set(c.Column, res.ID, c.Descending)
+					pkID = true
+				case "createdAt":
+					cur.Set(c.Column, res.CreatedAt, c.Descending)
+				case "updatedAt":
+					cur.Set(c.Column, res.UpdatedAt, c.Descending)
+				case "deletedAt":
+					cur.Set(c.Column, res.DeletedAt, c.Descending)
+				}
+			}
+		}
+	)
+
+	collect(cc...)
+	if !hasUnique || !pkID {
+		collect(&filter.SortExpr{Column: "id", Descending: false})
+	}
+
+	return cur
+
+}
+
+// checkDataPrivacyRequestCommentConstraints performs lookups (on valid) resource to check if any of the values on unique fields
+// already exists in the store
+//
+// Using built-in constraint checking would be more performant, but unfortunately we cannot rely
+// on the full support (MySQL does not support conditional indexes)
+//
+// This function is auto-generated
+func (s *Store) checkDataPrivacyRequestCommentConstraints(ctx context.Context, res *systemType.DataPrivacyRequestComment) (err error) {
+	return nil
+}
+
 // CreateFederationExposedModule creates one or more rows in federationExposedModule collection
 //
 // This function is auto-generated
@@ -10533,7 +11475,7 @@ func (s *Store) QueryFederationExposedModules(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableFederationExposedModuleFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -11019,7 +11961,7 @@ func (s *Store) QueryFederationModuleMappings(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableFederationModuleMappingFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -11892,7 +12834,7 @@ func (s *Store) QueryFederationNodeSyncs(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableFederationNodeSyncFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -12414,7 +13356,7 @@ func (s *Store) QueryFederationSharedModules(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableFederationSharedModuleFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -13507,7 +14449,7 @@ func (s *Store) QueryQueues(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableQueueFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -14027,7 +14969,7 @@ func (s *Store) QueryQueueMessages(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableQueueMessageFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -14708,7 +15650,7 @@ func (s *Store) QueryReminders(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableReminderFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -15202,7 +16144,7 @@ func (s *Store) QueryReports(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableReportFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -15997,7 +16939,7 @@ func (s *Store) QueryResourceTranslations(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableResourceTranslationFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -16470,7 +17412,7 @@ func (s *Store) QueryRoles(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableRoleFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -17640,7 +18582,7 @@ func (s *Store) QueryTemplates(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableTemplateFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)
@@ -18202,7 +19144,7 @@ func (s *Store) QueryUsers(
 
 	// paging feature is enabled
 	if f.PageCursor != nil {
-		if tExpr, err = cursor(f.PageCursor); err != nil {
+		if tExpr, err = cursorWithSorting(f.PageCursor, s.sortableUserFields()); err != nil {
 			return
 		} else {
 			expr = append(expr, tExpr...)

--- a/store/adapters/rdbms/upgrade_tables.go
+++ b/store/adapters/rdbms/upgrade_tables.go
@@ -74,6 +74,8 @@ func Tables() []*Table {
 		tableApigwRoute(),
 		tableApigwFilter(),
 		tableResourceActivityLog(),
+		tableDataPrivacyRequests(),
+		tableDataPrivacyRequestComments(),
 	}
 }
 
@@ -741,5 +743,31 @@ func tableResourceActivityLog() *Table {
 
 		AddIndex("rel_resource", IColumn("rel_resource")),
 		AddIndex("ts", IColumn("ts")),
+	)
+}
+
+func tableDataPrivacyRequests() *Table {
+	return TableDef("data_privacy_requests",
+		ID,
+		ColumnDef("kind", ColumnTypeText, ColumnTypeLength(handleLength)),
+		ColumnDef("status", ColumnTypeVarchar, ColumnTypeLength(handleLength)),
+		ColumnDef("requested_at", ColumnTypeTimestamp),
+		ColumnDef("requested_by", ColumnTypeIdentifier),
+		ColumnDef("completed_at", ColumnTypeTimestamp, Null),
+		ColumnDef("completed_by", ColumnTypeIdentifier, DefaultValue("0")),
+		CUDTimestamps,
+		CUDUsers,
+
+		AddIndex("status", IColumn("status")),
+	)
+}
+
+func tableDataPrivacyRequestComments() *Table {
+	return TableDef("data_privacy_request_comments",
+		ID,
+		ColumnDef("rel_request", ColumnTypeIdentifier),
+		ColumnDef("comment", ColumnTypeText),
+		CUDTimestamps,
+		CUDUsers,
 	)
 }

--- a/store/interfaces.gen.go
+++ b/store/interfaces.gen.go
@@ -62,6 +62,8 @@ type (
 		Credentials
 		DalConnections
 		DalSensitivityLevels
+		DataPrivacyRequests
+		DataPrivacyRequestComments
 		FederationExposedModules
 		FederationModuleMappings
 		FederationNodes
@@ -361,6 +363,27 @@ type (
 		DeleteDalSensitivityLevelByID(ctx context.Context, id uint64) error
 		TruncateDalSensitivityLevels(ctx context.Context) error
 		LookupDalSensitivityLevelByID(ctx context.Context, id uint64) (*systemType.DalSensitivityLevel, error)
+	}
+
+	DataPrivacyRequests interface {
+		SearchDataPrivacyRequests(ctx context.Context, f systemType.DataPrivacyRequestFilter) (systemType.DataPrivacyRequestSet, systemType.DataPrivacyRequestFilter, error)
+		CreateDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) error
+		UpdateDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) error
+		UpsertDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) error
+		DeleteDataPrivacyRequest(ctx context.Context, rr ...*systemType.DataPrivacyRequest) error
+		DeleteDataPrivacyRequestByID(ctx context.Context, id uint64) error
+		TruncateDataPrivacyRequests(ctx context.Context) error
+		LookupDataPrivacyRequestByID(ctx context.Context, id uint64) (*systemType.DataPrivacyRequest, error)
+	}
+
+	DataPrivacyRequestComments interface {
+		SearchDataPrivacyRequestComments(ctx context.Context, f systemType.DataPrivacyRequestCommentFilter) (systemType.DataPrivacyRequestCommentSet, systemType.DataPrivacyRequestCommentFilter, error)
+		CreateDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) error
+		UpdateDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) error
+		UpsertDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) error
+		DeleteDataPrivacyRequestComment(ctx context.Context, rr ...*systemType.DataPrivacyRequestComment) error
+		DeleteDataPrivacyRequestCommentByID(ctx context.Context, id uint64) error
+		TruncateDataPrivacyRequestComments(ctx context.Context) error
 	}
 
 	FederationExposedModules interface {
@@ -2099,6 +2122,113 @@ func TruncateDalSensitivityLevels(ctx context.Context, s DalSensitivityLevels) e
 // This function is auto-generated
 func LookupDalSensitivityLevelByID(ctx context.Context, s DalSensitivityLevels, id uint64) (*systemType.DalSensitivityLevel, error) {
 	return s.LookupDalSensitivityLevelByID(ctx, id)
+}
+
+// SearchDataPrivacyRequests returns all matching DataPrivacyRequests from store
+//
+// This function is auto-generated
+func SearchDataPrivacyRequests(ctx context.Context, s DataPrivacyRequests, f systemType.DataPrivacyRequestFilter) (systemType.DataPrivacyRequestSet, systemType.DataPrivacyRequestFilter, error) {
+	return s.SearchDataPrivacyRequests(ctx, f)
+}
+
+// CreateDataPrivacyRequest creates one or more DataPrivacyRequests in store
+//
+// This function is auto-generated
+func CreateDataPrivacyRequest(ctx context.Context, s DataPrivacyRequests, rr ...*systemType.DataPrivacyRequest) error {
+	return s.CreateDataPrivacyRequest(ctx, rr...)
+}
+
+// UpdateDataPrivacyRequest updates one or more (existing) DataPrivacyRequests in store
+//
+// This function is auto-generated
+func UpdateDataPrivacyRequest(ctx context.Context, s DataPrivacyRequests, rr ...*systemType.DataPrivacyRequest) error {
+	return s.UpdateDataPrivacyRequest(ctx, rr...)
+}
+
+// UpsertDataPrivacyRequest creates new or updates existing one or more DataPrivacyRequests in store
+//
+// This function is auto-generated
+func UpsertDataPrivacyRequest(ctx context.Context, s DataPrivacyRequests, rr ...*systemType.DataPrivacyRequest) error {
+	return s.UpsertDataPrivacyRequest(ctx, rr...)
+}
+
+// DeleteDataPrivacyRequest deletes one or more DataPrivacyRequests from store
+//
+// This function is auto-generated
+func DeleteDataPrivacyRequest(ctx context.Context, s DataPrivacyRequests, rr ...*systemType.DataPrivacyRequest) error {
+	return s.DeleteDataPrivacyRequest(ctx, rr...)
+}
+
+// DeleteDataPrivacyRequestByID deletes one or more DataPrivacyRequests from store
+//
+// This function is auto-generated
+func DeleteDataPrivacyRequestByID(ctx context.Context, s DataPrivacyRequests, id uint64) error {
+	return s.DeleteDataPrivacyRequestByID(ctx, id)
+}
+
+// TruncateDataPrivacyRequests Deletes all DataPrivacyRequests from store
+//
+// This function is auto-generated
+func TruncateDataPrivacyRequests(ctx context.Context, s DataPrivacyRequests) error {
+	return s.TruncateDataPrivacyRequests(ctx)
+}
+
+// LookupDataPrivacyRequestByID searches for data privacy request by ID
+//
+// It returns data privacy request even if deleted
+//
+// This function is auto-generated
+func LookupDataPrivacyRequestByID(ctx context.Context, s DataPrivacyRequests, id uint64) (*systemType.DataPrivacyRequest, error) {
+	return s.LookupDataPrivacyRequestByID(ctx, id)
+}
+
+// SearchDataPrivacyRequestComments returns all matching DataPrivacyRequestComments from store
+//
+// This function is auto-generated
+func SearchDataPrivacyRequestComments(ctx context.Context, s DataPrivacyRequestComments, f systemType.DataPrivacyRequestCommentFilter) (systemType.DataPrivacyRequestCommentSet, systemType.DataPrivacyRequestCommentFilter, error) {
+	return s.SearchDataPrivacyRequestComments(ctx, f)
+}
+
+// CreateDataPrivacyRequestComment creates one or more DataPrivacyRequestComments in store
+//
+// This function is auto-generated
+func CreateDataPrivacyRequestComment(ctx context.Context, s DataPrivacyRequestComments, rr ...*systemType.DataPrivacyRequestComment) error {
+	return s.CreateDataPrivacyRequestComment(ctx, rr...)
+}
+
+// UpdateDataPrivacyRequestComment updates one or more (existing) DataPrivacyRequestComments in store
+//
+// This function is auto-generated
+func UpdateDataPrivacyRequestComment(ctx context.Context, s DataPrivacyRequestComments, rr ...*systemType.DataPrivacyRequestComment) error {
+	return s.UpdateDataPrivacyRequestComment(ctx, rr...)
+}
+
+// UpsertDataPrivacyRequestComment creates new or updates existing one or more DataPrivacyRequestComments in store
+//
+// This function is auto-generated
+func UpsertDataPrivacyRequestComment(ctx context.Context, s DataPrivacyRequestComments, rr ...*systemType.DataPrivacyRequestComment) error {
+	return s.UpsertDataPrivacyRequestComment(ctx, rr...)
+}
+
+// DeleteDataPrivacyRequestComment deletes one or more DataPrivacyRequestComments from store
+//
+// This function is auto-generated
+func DeleteDataPrivacyRequestComment(ctx context.Context, s DataPrivacyRequestComments, rr ...*systemType.DataPrivacyRequestComment) error {
+	return s.DeleteDataPrivacyRequestComment(ctx, rr...)
+}
+
+// DeleteDataPrivacyRequestCommentByID deletes one or more DataPrivacyRequestComments from store
+//
+// This function is auto-generated
+func DeleteDataPrivacyRequestCommentByID(ctx context.Context, s DataPrivacyRequestComments, id uint64) error {
+	return s.DeleteDataPrivacyRequestCommentByID(ctx, id)
+}
+
+// TruncateDataPrivacyRequestComments Deletes all DataPrivacyRequestComments from store
+//
+// This function is auto-generated
+func TruncateDataPrivacyRequestComments(ctx context.Context, s DataPrivacyRequestComments) error {
+	return s.TruncateDataPrivacyRequestComments(ctx)
 }
 
 // SearchFederationExposedModules returns all matching FederationExposedModules from store

--- a/store/tests/all_test.go
+++ b/store/tests/all_test.go
@@ -83,6 +83,12 @@ func testAllGenerated(t *testing.T, s store.Storer) {
 	t.Run("dalSensitivityLevel", func(t *testing.T) {
 		testDalSensitivityLevels(t, s)
 	})
+	t.Run("dataPrivacyRequest", func(t *testing.T) {
+		testDataPrivacyRequests(t, s)
+	})
+	t.Run("dataPrivacyRequestComment", func(t *testing.T) {
+		testDataPrivacyRequestComments(t, s)
+	})
 	t.Run("federationExposedModule", func(t *testing.T) {
 		testFederationExposedModules(t, s)
 	})

--- a/system/component.cue
+++ b/system/component.cue
@@ -8,27 +8,29 @@ component: schema.#component & {
 	handle: "system"
 
 	resources: {
-		"attachment":            attachment
-		"application":           application
-		"apigw-route":           apigw_route
-		"apigw-filter":          apigw_filter
-		"auth-client":           auth_client
-		"auth-confirmed-client": auth_confirmed_client
-		"auth-session":          auth_session
-		"auth-oa2token":         auth_oa2token
-		"credential":            credential
-		"queue":                 queue
-		"queue_message":         queue_message
-		"reminder":              reminder
-		"report":                report
-		"resource-translation":  resource_translation
-		"role":                  role
-		"role_member":           role_member
-		"settings":              settings
-		"template":              template
-		"user":                  user
-		"dal_connection":        dal_connection
-		"dal_sensitivity_level": dal_sensitivity_level
+		"attachment":            				attachment
+		"application":           				application
+		"apigw-route":           				apigw_route
+		"apigw-filter":          				apigw_filter
+		"auth-client":           				auth_client
+		"auth-confirmed-client": 				auth_confirmed_client
+		"auth-session":          				auth_session
+		"auth-oa2token":         				auth_oa2token
+		"credential":            				credential
+		"data-privacy-request":  				data_privacy_request
+		"data-privacy-request_comment": data_privacy_request_comment
+		"queue":                 				queue
+		"queue_message":         				queue_message
+		"reminder":              				reminder
+		"report":                				report
+		"resource-translation":  				resource_translation
+		"role":                  				role
+		"role_member":           				role_member
+		"settings":              				settings
+		"template":              				template
+		"user":                  				user
+		"dal_connection":        				dal_connection
+		"dal_sensitivity_level": 				dal_sensitivity_level
 	}
 
 	rbac: operations: {
@@ -70,5 +72,8 @@ component: schema.#component & {
 		"apigw-routes.search": description: "List search or filter API gateway routes"
 
 		"resource-translations.manage": description: "List, search, create, or update resource translations"
+
+		"data-privacy-request.create": description:  "Create data privacy requests"
+		"data-privacy-requests.search": description: "List, search or filter data privacy requests"
 	}
 }

--- a/system/data_privacy_request.cue
+++ b/system/data_privacy_request.cue
@@ -1,0 +1,65 @@
+package system
+
+import (
+	"github.com/cortezaproject/corteza-server/codegen/schema"
+)
+
+data_privacy_request: schema.#Resource & {
+	features: {
+		labels: false
+	}
+
+	struct: {
+		id: schema.IdField
+		kind: { goType: "types.RequestKind", sortable: true }
+		status: { goType: "types.RequestStatus", sortable: true }
+
+		requested_at: schema.SortableTimestampField
+		requested_by: { goType: "uint64" }
+		completed_at: schema.SortableTimestampNilField
+		completed_by: { goType: "uint64" }
+
+		created_at: schema.SortableTimestampField
+		updated_at: schema.SortableTimestampNilField
+		deleted_at: schema.SortableTimestampNilField
+		created_by: { goType: "uint64" }
+		updated_by: { goType: "uint64" }
+		deleted_by: { goType: "uint64" }
+	}
+
+	filter: {
+		struct: {
+			request_id: {goType: "[]uint64", ident: "requestID", storeIdent: "id" }
+			kind: {goType: "[]types.RequestKind"}
+			status: {goType: "[]types.RequestStatus"}
+		}
+
+		query: ["kind", "status"]
+		byValue: ["kind", "status"]
+	}
+
+	rbac: {
+		operations: {
+			read:
+				description: "Read data privacy request"
+			approve:
+				description: "Approve/Reject data privacy request"
+		}
+	}
+
+	store: {
+		api: {
+			lookups: [
+				{
+					fields: ["id"]
+					description: """
+						searches for data privacy request by ID
+
+						It returns data privacy request even if deleted
+						"""
+				}
+			]
+			functions: []
+		}
+	}
+}

--- a/system/data_privacy_request_comment.cue
+++ b/system/data_privacy_request_comment.cue
@@ -1,0 +1,43 @@
+package system
+
+import (
+	"github.com/cortezaproject/corteza-server/codegen/schema"
+)
+
+data_privacy_request_comment: schema.#Resource & {
+	features: {
+		labels: false
+	}
+
+	struct: {
+		id: schema.IdField
+		request_id: { ident: "requestID", goType: "uint64", storeIdent: "rel_request" }
+		comment: { goType: "string" }
+
+		created_at: schema.SortableTimestampField
+		updated_at: schema.SortableTimestampNilField
+		deleted_at: schema.SortableTimestampNilField
+		created_by: { goType: "uint64" }
+		updated_by: { goType: "uint64" }
+		deleted_by: { goType: "uint64" }
+	}
+
+	filter: {
+		struct: {
+			request_id: {goType: "[]uint64", ident: "requestID", storeIdent: "rel_request" }
+		}
+
+		query: []
+		byValue: ["request_id"]
+	}
+
+	rbac: {
+		operations: {}
+	}
+
+	store: {
+		api: {
+			functions: []
+		}
+	}
+}

--- a/system/rest.yaml
+++ b/system/rest.yaml
@@ -2198,3 +2198,67 @@ endpoints:
       path:
       - { type: string, name: lang,      required: true,  title: Language  }
       - { type: string, name: application, required: true, title: Application name }
+
+- title: Data Privacy Request
+  entrypoint: dataPrivacyRequest
+  path: "/data-privacy/requests"
+  apis:
+    - name: list
+      method: GET
+      title: List data privacy requests
+      path: "/"
+      parameters:
+        get:
+          - { name: query,              type: "string",     title: "Filter requests" }
+          - { name: kind,               type: "[]string",   title: "Filter by kind: correct, delete, export" }
+          - { name: status,             type: "[]string",   title: "Filter by status: pending, cancel, approve, reject" }
+          - { name: limit,              type: "uint",       title: "Limit" }
+          - { name: pageCursor,         type: "string",     title: "Page cursor" }
+          - { name: sort,               type: "string",     title: "Sort items" }
+    - name: create
+      method: POST
+      title: Create data privacy request
+      path: "/"
+      parameters:
+        post:
+          - { name: kind,         type: "string",   title: "Request Kind", required: true }
+    - name: update status
+      method: PATCH
+      title: Update data privacy request status
+      path: "/{requestID}/status/{status}"
+      parameters:
+        path:
+          - { name: requestID,     type: "uint64",   title: "ID",             required: true }
+          - { name: status,        type: "string",   title: "Request Status", required: true }
+    - name: read
+      method: GET
+      title: Get details about specific request
+      path: "/{requestID}"
+      parameters:
+        path:
+          - { name: requestID, type: "uint64",     title: "Request ID", required: true }
+
+- title: Data Privacy Request Comment
+  entrypoint: dataPrivacyRequestComment
+  path: "/data-privacy/requests/{requestID}/comments"
+  parameters:
+    path:
+      - { name: requestID, type: "uint64",     title: "Request ID", required: true }
+  apis:
+    - name: list
+      method: GET
+      title: List data privacy request comments
+      path: "/"
+      parameters:
+        get:
+          - { name: limit,              type: "uint",       title: "Limit" }
+          - { name: pageCursor,         type: "string",     title: "Page cursor" }
+          - { name: sort,               type: "string",     title: "Sort items" }
+    - name: create
+      method: POST
+      title: Create data privacy request comment
+      path: "/"
+      parameters:
+        post:
+          - { name: comment,            type: "string",   title: "Comment description", required: true }
+

--- a/system/rest/data_privacy_request.go
+++ b/system/rest/data_privacy_request.go
@@ -1,0 +1,145 @@
+package rest
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
+	"github.com/cortezaproject/corteza-server/system/rest/request"
+	"github.com/cortezaproject/corteza-server/system/service"
+	"github.com/cortezaproject/corteza-server/system/types"
+)
+
+type (
+	DataPrivacyRequest struct {
+		dataPrivacy service.DataPrivacyService
+		ac          dataPrivacyAccessController
+	}
+
+	dataPrivacyRequestSetPayload struct {
+		Filter types.DataPrivacyRequestFilter `json:"filter"`
+		Set    types.DataPrivacyRequestSet    `json:"set"`
+	}
+
+	dataPrivacyAccessController interface {
+		CanGrant(context.Context) bool
+	}
+
+	DataPrivacyRequestComment struct {
+		dataPrivacy service.DataPrivacyService
+		ac          dataPrivacyAccessController
+	}
+
+	dataPrivacyRequestCommentSetPayload struct {
+		Filter types.DataPrivacyRequestCommentFilter `json:"filter"`
+		Set    types.DataPrivacyRequestCommentSet    `json:"set"`
+	}
+)
+
+func (DataPrivacyRequest) New() *DataPrivacyRequest {
+	return &DataPrivacyRequest{
+		dataPrivacy: service.DefaultDataPrivacy,
+		ac:          service.DefaultAccessControl,
+	}
+}
+
+func (ctrl DataPrivacyRequest) List(ctx context.Context, r *request.DataPrivacyRequestList) (interface{}, error) {
+	var (
+		err error
+		f   = types.DataPrivacyRequestFilter{
+			Query:  r.Query,
+			Kind:   r.Kind,
+			Status: r.Status,
+		}
+	)
+
+	if f.Paging, err = filter.NewPaging(r.Limit, r.PageCursor); err != nil {
+		return nil, err
+	}
+
+	if f.Sorting, err = filter.NewSorting(r.Sort); err != nil {
+		return nil, err
+	}
+
+	set, f, err := ctrl.dataPrivacy.FindRequests(ctx, f)
+	return ctrl.makeFilterPayload(ctx, set, f, err)
+}
+
+func (ctrl DataPrivacyRequest) makeFilterPayload(_ context.Context, rr types.DataPrivacyRequestSet, f types.DataPrivacyRequestFilter, err error) (*dataPrivacyRequestSetPayload, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rr) == 0 {
+		rr = make([]*types.DataPrivacyRequest, 0)
+	}
+
+	return &dataPrivacyRequestSetPayload{Filter: f, Set: rr}, nil
+}
+
+func (ctrl DataPrivacyRequest) Create(ctx context.Context, r *request.DataPrivacyRequestCreate) (interface{}, error) {
+	req := &types.DataPrivacyRequest{
+		Kind: types.CastToRequestKind(r.Kind),
+	}
+
+	return ctrl.dataPrivacy.CreateRequest(ctx, req)
+}
+
+func (ctrl DataPrivacyRequest) UpdateStatus(ctx context.Context, r *request.DataPrivacyRequestUpdateStatus) (interface{}, error) {
+	req := &types.DataPrivacyRequest{
+		ID:     r.RequestID,
+		Status: types.CastToRequestStatus(r.Status),
+	}
+
+	return ctrl.dataPrivacy.UpdateRequestStatus(ctx, req)
+}
+
+func (ctrl DataPrivacyRequest) Read(ctx context.Context, r *request.DataPrivacyRequestRead) (interface{}, error) {
+	return ctrl.dataPrivacy.FindRequestByID(ctx, r.RequestID)
+}
+
+func (DataPrivacyRequestComment) New() *DataPrivacyRequestComment {
+	return &DataPrivacyRequestComment{
+		dataPrivacy: service.DefaultDataPrivacy,
+		ac:          service.DefaultAccessControl,
+	}
+}
+
+func (ctrl DataPrivacyRequestComment) List(ctx context.Context, r *request.DataPrivacyRequestCommentList) (interface{}, error) {
+	var (
+		err error
+		f   = types.DataPrivacyRequestCommentFilter{
+			RequestID: []uint64{r.RequestID},
+		}
+	)
+
+	if f.Paging, err = filter.NewPaging(r.Limit, r.PageCursor); err != nil {
+		return nil, err
+	}
+
+	if f.Sorting, err = filter.NewSorting(r.Sort); err != nil {
+		return nil, err
+	}
+
+	set, f, err := ctrl.dataPrivacy.FindRequestComments(ctx, f)
+	return ctrl.makeFilterPayload(ctx, set, f, err)
+}
+
+func (ctrl DataPrivacyRequestComment) makeFilterPayload(_ context.Context, rr types.DataPrivacyRequestCommentSet, f types.DataPrivacyRequestCommentFilter, err error) (*dataPrivacyRequestCommentSetPayload, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rr) == 0 {
+		rr = make([]*types.DataPrivacyRequestComment, 0)
+	}
+
+	return &dataPrivacyRequestCommentSetPayload{Filter: f, Set: rr}, nil
+}
+
+func (ctrl DataPrivacyRequestComment) Create(ctx context.Context, r *request.DataPrivacyRequestCommentCreate) (interface{}, error) {
+	req := &types.DataPrivacyRequestComment{
+		RequestID: r.RequestID,
+		Comment:   r.Comment,
+	}
+
+	return ctrl.dataPrivacy.CreateRequestComment(ctx, req)
+}

--- a/system/rest/handlers/dataPrivacyRequest.go
+++ b/system/rest/handlers/dataPrivacyRequest.go
@@ -1,0 +1,114 @@
+package handlers
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+//
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/api"
+	"github.com/cortezaproject/corteza-server/system/rest/request"
+	"github.com/go-chi/chi/v5"
+	"net/http"
+)
+
+type (
+	// Internal API interface
+	DataPrivacyRequestAPI interface {
+		List(context.Context, *request.DataPrivacyRequestList) (interface{}, error)
+		Create(context.Context, *request.DataPrivacyRequestCreate) (interface{}, error)
+		UpdateStatus(context.Context, *request.DataPrivacyRequestUpdateStatus) (interface{}, error)
+		Read(context.Context, *request.DataPrivacyRequestRead) (interface{}, error)
+	}
+
+	// HTTP API interface
+	DataPrivacyRequest struct {
+		List         func(http.ResponseWriter, *http.Request)
+		Create       func(http.ResponseWriter, *http.Request)
+		UpdateStatus func(http.ResponseWriter, *http.Request)
+		Read         func(http.ResponseWriter, *http.Request)
+	}
+)
+
+func NewDataPrivacyRequest(h DataPrivacyRequestAPI) *DataPrivacyRequest {
+	return &DataPrivacyRequest{
+		List: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewDataPrivacyRequestList()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.List(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+		Create: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewDataPrivacyRequestCreate()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.Create(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+		UpdateStatus: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewDataPrivacyRequestUpdateStatus()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.UpdateStatus(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+		Read: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewDataPrivacyRequestRead()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.Read(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+	}
+}
+
+func (h DataPrivacyRequest) MountRoutes(r chi.Router, middlewares ...func(http.Handler) http.Handler) {
+	r.Group(func(r chi.Router) {
+		r.Use(middlewares...)
+		r.Get("/data-privacy/requests/", h.List)
+		r.Post("/data-privacy/requests/", h.Create)
+		r.Patch("/data-privacy/requests/{requestID}/status/{status}", h.UpdateStatus)
+		r.Get("/data-privacy/requests/{requestID}", h.Read)
+	})
+}

--- a/system/rest/handlers/dataPrivacyRequestComment.go
+++ b/system/rest/handlers/dataPrivacyRequestComment.go
@@ -1,0 +1,76 @@
+package handlers
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+//
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/api"
+	"github.com/cortezaproject/corteza-server/system/rest/request"
+	"github.com/go-chi/chi/v5"
+	"net/http"
+)
+
+type (
+	// Internal API interface
+	DataPrivacyRequestCommentAPI interface {
+		List(context.Context, *request.DataPrivacyRequestCommentList) (interface{}, error)
+		Create(context.Context, *request.DataPrivacyRequestCommentCreate) (interface{}, error)
+	}
+
+	// HTTP API interface
+	DataPrivacyRequestComment struct {
+		List   func(http.ResponseWriter, *http.Request)
+		Create func(http.ResponseWriter, *http.Request)
+	}
+)
+
+func NewDataPrivacyRequestComment(h DataPrivacyRequestCommentAPI) *DataPrivacyRequestComment {
+	return &DataPrivacyRequestComment{
+		List: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewDataPrivacyRequestCommentList()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.List(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+		Create: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewDataPrivacyRequestCommentCreate()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.Create(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
+	}
+}
+
+func (h DataPrivacyRequestComment) MountRoutes(r chi.Router, middlewares ...func(http.Handler) http.Handler) {
+	r.Group(func(r chi.Router) {
+		r.Use(middlewares...)
+		r.Get("/data-privacy/requests/{requestID}/comments/", h.List)
+		r.Post("/data-privacy/requests/{requestID}/comments/", h.Create)
+	})
+}

--- a/system/rest/request/dataPrivacyRequest.go
+++ b/system/rest/request/dataPrivacyRequest.go
@@ -1,0 +1,345 @@
+package request
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+//
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/payload"
+	"github.com/go-chi/chi/v5"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+)
+
+// dummy vars to prevent
+// unused imports complain
+var (
+	_ = chi.URLParam
+	_ = multipart.ErrMessageTooLarge
+	_ = payload.ParseUint64s
+	_ = strings.ToLower
+	_ = io.EOF
+	_ = fmt.Errorf
+	_ = json.NewEncoder
+)
+
+type (
+	// Internal API interface
+	DataPrivacyRequestList struct {
+		// Query GET parameter
+		//
+		// Filter requests
+		Query string
+
+		// Kind GET parameter
+		//
+		// Filter by kind: correct, delete, export
+		Kind []string
+
+		// Status GET parameter
+		//
+		// Filter by status: pending, cancel, approve, reject
+		Status []string
+
+		// Limit GET parameter
+		//
+		// Limit
+		Limit uint
+
+		// PageCursor GET parameter
+		//
+		// Page cursor
+		PageCursor string
+
+		// Sort GET parameter
+		//
+		// Sort items
+		Sort string
+	}
+
+	DataPrivacyRequestCreate struct {
+		// Kind POST parameter
+		//
+		// Request Kind
+		Kind string
+	}
+
+	DataPrivacyRequestUpdateStatus struct {
+		// RequestID PATH parameter
+		//
+		// ID
+		RequestID uint64 `json:",string"`
+
+		// Status PATH parameter
+		//
+		// Request Status
+		Status string
+	}
+
+	DataPrivacyRequestRead struct {
+		// RequestID PATH parameter
+		//
+		// Request ID
+		RequestID uint64 `json:",string"`
+	}
+)
+
+// NewDataPrivacyRequestList request
+func NewDataPrivacyRequestList() *DataPrivacyRequestList {
+	return &DataPrivacyRequestList{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"query":      r.Query,
+		"kind":       r.Kind,
+		"status":     r.Status,
+		"limit":      r.Limit,
+		"pageCursor": r.PageCursor,
+		"sort":       r.Sort,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) GetQuery() string {
+	return r.Query
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) GetKind() []string {
+	return r.Kind
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) GetStatus() []string {
+	return r.Status
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) GetLimit() uint {
+	return r.Limit
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) GetPageCursor() string {
+	return r.PageCursor
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestList) GetSort() string {
+	return r.Sort
+}
+
+// Fill processes request and fills internal variables
+func (r *DataPrivacyRequestList) Fill(req *http.Request) (err error) {
+
+	{
+		// GET params
+		tmp := req.URL.Query()
+
+		if val, ok := tmp["query"]; ok && len(val) > 0 {
+			r.Query, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["kind[]"]; ok {
+			r.Kind, err = val, nil
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["kind"]; ok {
+			r.Kind, err = val, nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["status[]"]; ok {
+			r.Status, err = val, nil
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["status"]; ok {
+			r.Status, err = val, nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["limit"]; ok && len(val) > 0 {
+			r.Limit, err = payload.ParseUint(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["pageCursor"]; ok && len(val) > 0 {
+			r.PageCursor, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["sort"]; ok && len(val) > 0 {
+			r.Sort, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return err
+}
+
+// NewDataPrivacyRequestCreate request
+func NewDataPrivacyRequestCreate() *DataPrivacyRequestCreate {
+	return &DataPrivacyRequestCreate{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCreate) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"kind": r.Kind,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCreate) GetKind() string {
+	return r.Kind
+}
+
+// Fill processes request and fills internal variables
+func (r *DataPrivacyRequestCreate) Fill(req *http.Request) (err error) {
+
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		err = json.NewDecoder(req.Body).Decode(r)
+
+		switch {
+		case err == io.EOF:
+			err = nil
+		case err != nil:
+			return fmt.Errorf("error parsing http request body: %w", err)
+		}
+	}
+
+	{
+		// Caching 32MB to memory, the rest to disk
+		if err = req.ParseMultipartForm(32 << 20); err != nil && err != http.ErrNotMultipart {
+			return err
+		} else if err == nil {
+			// Multipart params
+
+			if val, ok := req.MultipartForm.Value["kind"]; ok && len(val) > 0 {
+				r.Kind, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	{
+		if err = req.ParseForm(); err != nil {
+			return err
+		}
+
+		// POST params
+
+		if val, ok := req.Form["kind"]; ok && len(val) > 0 {
+			r.Kind, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return err
+}
+
+// NewDataPrivacyRequestUpdateStatus request
+func NewDataPrivacyRequestUpdateStatus() *DataPrivacyRequestUpdateStatus {
+	return &DataPrivacyRequestUpdateStatus{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestUpdateStatus) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"requestID": r.RequestID,
+		"status":    r.Status,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestUpdateStatus) GetRequestID() uint64 {
+	return r.RequestID
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestUpdateStatus) GetStatus() string {
+	return r.Status
+}
+
+// Fill processes request and fills internal variables
+func (r *DataPrivacyRequestUpdateStatus) Fill(req *http.Request) (err error) {
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "requestID")
+		r.RequestID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+		val = chi.URLParam(req, "status")
+		r.Status, err = val, nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewDataPrivacyRequestRead request
+func NewDataPrivacyRequestRead() *DataPrivacyRequestRead {
+	return &DataPrivacyRequestRead{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestRead) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"requestID": r.RequestID,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestRead) GetRequestID() uint64 {
+	return r.RequestID
+}
+
+// Fill processes request and fills internal variables
+func (r *DataPrivacyRequestRead) Fill(req *http.Request) (err error) {
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "requestID")
+		r.RequestID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}

--- a/system/rest/request/dataPrivacyRequestComment.go
+++ b/system/rest/request/dataPrivacyRequestComment.go
@@ -1,0 +1,229 @@
+package request
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+//
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/payload"
+	"github.com/go-chi/chi/v5"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+)
+
+// dummy vars to prevent
+// unused imports complain
+var (
+	_ = chi.URLParam
+	_ = multipart.ErrMessageTooLarge
+	_ = payload.ParseUint64s
+	_ = strings.ToLower
+	_ = io.EOF
+	_ = fmt.Errorf
+	_ = json.NewEncoder
+)
+
+type (
+	// Internal API interface
+	DataPrivacyRequestCommentList struct {
+		// RequestID PATH parameter
+		//
+		// Request ID
+		RequestID uint64 `json:",string"`
+
+		// Limit GET parameter
+		//
+		// Limit
+		Limit uint
+
+		// PageCursor GET parameter
+		//
+		// Page cursor
+		PageCursor string
+
+		// Sort GET parameter
+		//
+		// Sort items
+		Sort string
+	}
+
+	DataPrivacyRequestCommentCreate struct {
+		// RequestID PATH parameter
+		//
+		// Request ID
+		RequestID uint64 `json:",string"`
+
+		// Comment POST parameter
+		//
+		// Comment description
+		Comment string
+	}
+)
+
+// NewDataPrivacyRequestCommentList request
+func NewDataPrivacyRequestCommentList() *DataPrivacyRequestCommentList {
+	return &DataPrivacyRequestCommentList{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentList) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"requestID":  r.RequestID,
+		"limit":      r.Limit,
+		"pageCursor": r.PageCursor,
+		"sort":       r.Sort,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentList) GetRequestID() uint64 {
+	return r.RequestID
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentList) GetLimit() uint {
+	return r.Limit
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentList) GetPageCursor() string {
+	return r.PageCursor
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentList) GetSort() string {
+	return r.Sort
+}
+
+// Fill processes request and fills internal variables
+func (r *DataPrivacyRequestCommentList) Fill(req *http.Request) (err error) {
+
+	{
+		// GET params
+		tmp := req.URL.Query()
+
+		if val, ok := tmp["limit"]; ok && len(val) > 0 {
+			r.Limit, err = payload.ParseUint(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["pageCursor"]; ok && len(val) > 0 {
+			r.PageCursor, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["sort"]; ok && len(val) > 0 {
+			r.Sort, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "requestID")
+		r.RequestID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewDataPrivacyRequestCommentCreate request
+func NewDataPrivacyRequestCommentCreate() *DataPrivacyRequestCommentCreate {
+	return &DataPrivacyRequestCommentCreate{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentCreate) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"requestID": r.RequestID,
+		"comment":   r.Comment,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentCreate) GetRequestID() uint64 {
+	return r.RequestID
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r DataPrivacyRequestCommentCreate) GetComment() string {
+	return r.Comment
+}
+
+// Fill processes request and fills internal variables
+func (r *DataPrivacyRequestCommentCreate) Fill(req *http.Request) (err error) {
+
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		err = json.NewDecoder(req.Body).Decode(r)
+
+		switch {
+		case err == io.EOF:
+			err = nil
+		case err != nil:
+			return fmt.Errorf("error parsing http request body: %w", err)
+		}
+	}
+
+	{
+		// Caching 32MB to memory, the rest to disk
+		if err = req.ParseMultipartForm(32 << 20); err != nil && err != http.ErrNotMultipart {
+			return err
+		} else if err == nil {
+			// Multipart params
+
+			if val, ok := req.MultipartForm.Value["comment"]; ok && len(val) > 0 {
+				r.Comment, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	{
+		if err = req.ParseForm(); err != nil {
+			return err
+		}
+
+		// POST params
+
+		if val, ok := req.Form["comment"]; ok && len(val) > 0 {
+			r.Comment, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "requestID")
+		r.RequestID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}

--- a/system/rest/router.go
+++ b/system/rest/router.go
@@ -47,6 +47,8 @@ func MountRoutes() func(r chi.Router) {
 			handlers.NewApigwRoute(ApigwRoute{}.New()).MountRoutes(r)
 			handlers.NewApigwFilter(ApigwFilter{}.New()).MountRoutes(r)
 			handlers.NewApigwProfiler(ApigwProfiler{}.New()).MountRoutes(r)
+			handlers.NewDataPrivacyRequest(DataPrivacyRequest{}.New()).MountRoutes(r)
+			handlers.NewDataPrivacyRequestComment(DataPrivacyRequestComment{}.New()).MountRoutes(r)
 		})
 	}
 }

--- a/system/service/access_control.gen.go
+++ b/system/service/access_control.gen.go
@@ -105,6 +105,16 @@ func (svc accessControl) List() (out []map[string]string) {
 			"op":   "authorize",
 		},
 		{
+			"type": types.DataPrivacyRequestResourceType,
+			"any":  types.DataPrivacyRequestRbacResource(0),
+			"op":   "read",
+		},
+		{
+			"type": types.DataPrivacyRequestResourceType,
+			"any":  types.DataPrivacyRequestRbacResource(0),
+			"op":   "approve",
+		},
+		{
 			"type": types.QueueResourceType,
 			"any":  types.QueueRbacResource(0),
 			"op":   "read",
@@ -404,6 +414,16 @@ func (svc accessControl) List() (out []map[string]string) {
 			"any":  types.ComponentRbacResource(),
 			"op":   "resource-translations.manage",
 		},
+		{
+			"type": types.ComponentResourceType,
+			"any":  types.ComponentRbacResource(),
+			"op":   "data-privacy-request.create",
+		},
+		{
+			"type": types.ComponentResourceType,
+			"any":  types.ComponentRbacResource(),
+			"op":   "data-privacy-requests.search",
+		},
 	}
 
 	func(svc interface{}) {
@@ -545,6 +565,20 @@ func (svc accessControl) CanDeleteAuthClient(ctx context.Context, r *types.AuthC
 // This function is auto-generated
 func (svc accessControl) CanAuthorizeAuthClient(ctx context.Context, r *types.AuthClient) bool {
 	return svc.can(ctx, "authorize", r)
+}
+
+// CanReadDataPrivacyRequest checks if current user can read data privacy request
+//
+// This function is auto-generated
+func (svc accessControl) CanReadDataPrivacyRequest(ctx context.Context, r *types.DataPrivacyRequest) bool {
+	return svc.can(ctx, "read", r)
+}
+
+// CanApproveDataPrivacyRequest checks if current user can approve/reject data privacy request
+//
+// This function is auto-generated
+func (svc accessControl) CanApproveDataPrivacyRequest(ctx context.Context, r *types.DataPrivacyRequest) bool {
+	return svc.can(ctx, "approve", r)
 }
 
 // CanReadQueue checks if current user can read queue
@@ -994,6 +1028,22 @@ func (svc accessControl) CanManageResourceTranslations(ctx context.Context) bool
 	return svc.can(ctx, "resource-translations.manage", r)
 }
 
+// CanCreateDataPrivacyRequest checks if current user can create data privacy requests
+//
+// This function is auto-generated
+func (svc accessControl) CanCreateDataPrivacyRequest(ctx context.Context) bool {
+	r := &types.Component{}
+	return svc.can(ctx, "data-privacy-request.create", r)
+}
+
+// CanSearchDataPrivacyRequests checks if current user can list, search or filter data privacy requests
+//
+// This function is auto-generated
+func (svc accessControl) CanSearchDataPrivacyRequests(ctx context.Context) bool {
+	r := &types.Component{}
+	return svc.can(ctx, "data-privacy-requests.search", r)
+}
+
 // rbacResourceValidator validates known component's resource by routing it to the appropriate validator
 //
 // This function is auto-generated
@@ -1005,6 +1055,10 @@ func rbacResourceValidator(r string, oo ...string) error {
 		return rbacApigwRouteResourceValidator(r, oo...)
 	case types.AuthClientResourceType:
 		return rbacAuthClientResourceValidator(r, oo...)
+	case types.DataPrivacyRequestResourceType:
+		return rbacDataPrivacyRequestResourceValidator(r, oo...)
+	case types.DataPrivacyRequestCommentResourceType:
+		return rbacDataPrivacyRequestCommentResourceValidator(r, oo...)
 	case types.QueueResourceType:
 		return rbacQueueResourceValidator(r, oo...)
 	case types.QueueMessageResourceType:
@@ -1052,6 +1106,13 @@ func rbacResourceOperations(r string) map[string]bool {
 			"delete":    true,
 			"authorize": true,
 		}
+	case types.DataPrivacyRequestResourceType:
+		return map[string]bool{
+			"read":    true,
+			"approve": true,
+		}
+	case types.DataPrivacyRequestCommentResourceType:
+		return map[string]bool{}
 	case types.QueueResourceType:
 		return map[string]bool{
 			"read":        true,
@@ -1137,6 +1198,8 @@ func rbacResourceOperations(r string) map[string]bool {
 			"apigw-route.create":           true,
 			"apigw-routes.search":          true,
 			"resource-translations.manage": true,
+			"data-privacy-request.create":  true,
+			"data-privacy-requests.search": true,
 		}
 	}
 
@@ -1265,6 +1328,94 @@ func rbacAuthClientResourceValidator(r string, oo ...string) error {
 		if pp[i] != "*" {
 			if i > 0 && pp[i-1] == "*" {
 				return fmt.Errorf("invalid path wildcard level (%d) for authClient resource", i)
+			}
+
+			if _, err := cast.ToUint64E(pp[i]); err != nil {
+				return fmt.Errorf("invalid reference for %s: '%s'", prc[i], pp[i])
+			}
+		}
+	}
+	return nil
+}
+
+// rbacDataPrivacyRequestResourceValidator checks validity of RBAC resource and operations
+//
+// Can be called without operations to check for validity of resource string only
+//
+// This function is auto-generated
+func rbacDataPrivacyRequestResourceValidator(r string, oo ...string) error {
+	if !strings.HasPrefix(r, types.DataPrivacyRequestResourceType) {
+		// expecting resource to always include path
+		return fmt.Errorf("invalid resource type")
+	}
+
+	defOps := rbacResourceOperations(r)
+	for _, o := range oo {
+		if !defOps[o] {
+			return fmt.Errorf("invalid operation '%s' for dataPrivacyRequest resource", o)
+		}
+	}
+
+	const sep = "/"
+	var (
+		pp  = strings.Split(strings.Trim(r[len(types.DataPrivacyRequestResourceType):], sep), sep)
+		prc = []string{
+			"ID",
+		}
+	)
+
+	if len(pp) != len(prc) {
+		return fmt.Errorf("invalid resource path structure")
+	}
+
+	for i := 0; i < len(pp); i++ {
+		if pp[i] != "*" {
+			if i > 0 && pp[i-1] == "*" {
+				return fmt.Errorf("invalid path wildcard level (%d) for dataPrivacyRequest resource", i)
+			}
+
+			if _, err := cast.ToUint64E(pp[i]); err != nil {
+				return fmt.Errorf("invalid reference for %s: '%s'", prc[i], pp[i])
+			}
+		}
+	}
+	return nil
+}
+
+// rbacDataPrivacyRequestCommentResourceValidator checks validity of RBAC resource and operations
+//
+// Can be called without operations to check for validity of resource string only
+//
+// This function is auto-generated
+func rbacDataPrivacyRequestCommentResourceValidator(r string, oo ...string) error {
+	if !strings.HasPrefix(r, types.DataPrivacyRequestCommentResourceType) {
+		// expecting resource to always include path
+		return fmt.Errorf("invalid resource type")
+	}
+
+	defOps := rbacResourceOperations(r)
+	for _, o := range oo {
+		if !defOps[o] {
+			return fmt.Errorf("invalid operation '%s' for dataPrivacyRequestComment resource", o)
+		}
+	}
+
+	const sep = "/"
+	var (
+		pp  = strings.Split(strings.Trim(r[len(types.DataPrivacyRequestCommentResourceType):], sep), sep)
+		prc = []string{
+			"ID",
+		}
+	)
+
+	if len(pp) != len(prc) {
+		return fmt.Errorf("invalid resource path structure")
+	}
+
+	for i := 0; i < len(pp); i++ {
+		if pp[i] != "*" {
+			if i > 0 && pp[i-1] == "*" {
+				return fmt.Errorf("invalid path wildcard level (%d) for dataPrivacyRequestComment resource", i)
 			}
 
 			if _, err := cast.ToUint64E(pp[i]); err != nil {

--- a/system/service/data_privacy.go
+++ b/system/service/data_privacy.go
@@ -1,0 +1,241 @@
+package service
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/actionlog"
+	a "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/errors"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/service/event"
+	"github.com/cortezaproject/corteza-server/system/types"
+)
+
+type (
+	dataPrivacy struct {
+		actionlog actionlog.Recorder
+
+		ac       dataPrivacyAccessController
+		eventbus eventDispatcher
+
+		store store.Storer
+	}
+
+	dataPrivacyAccessController interface {
+		CanSearchDataPrivacyRequests(context.Context) bool
+		CanCreateDataPrivacyRequest(context.Context) bool
+		CanReadDataPrivacyRequest(context.Context, *types.DataPrivacyRequest) bool
+		CanApproveDataPrivacyRequest(context.Context, *types.DataPrivacyRequest) bool
+	}
+
+	DataPrivacyService interface {
+		FindRequestByID(ctx context.Context, requestID uint64) (*types.DataPrivacyRequest, error)
+		FindRequests(context.Context, types.DataPrivacyRequestFilter) (types.DataPrivacyRequestSet, types.DataPrivacyRequestFilter, error)
+		CreateRequest(ctx context.Context, request *types.DataPrivacyRequest) (*types.DataPrivacyRequest, error)
+		UpdateRequestStatus(ctx context.Context, request *types.DataPrivacyRequest) (*types.DataPrivacyRequest, error)
+
+		FindRequestComments(ctx context.Context, filter types.DataPrivacyRequestCommentFilter) (rr types.DataPrivacyRequestCommentSet, f types.DataPrivacyRequestCommentFilter, err error)
+		CreateRequestComment(ctx context.Context, new *types.DataPrivacyRequestComment) (r *types.DataPrivacyRequestComment, err error)
+	}
+)
+
+func DataPrivacy(s store.Storer, ac dataPrivacyAccessController, al actionlog.Recorder, eb eventDispatcher) *dataPrivacy {
+	return &dataPrivacy{
+		actionlog: al,
+		ac:        ac,
+		eventbus:  eb,
+		store:     s,
+	}
+}
+
+func (svc dataPrivacy) FindRequestByID(ctx context.Context, requestID uint64) (r *types.DataPrivacyRequest, err error) {
+	var (
+		raProps = &dataPrivacyActionProps{dataPrivacyRequest: &types.DataPrivacyRequest{ID: requestID}}
+	)
+
+	err = func() error {
+		if requestID == 0 {
+			return DataPrivacyErrInvalidID()
+		}
+
+		r, err = store.LookupDataPrivacyRequestByID(ctx, svc.store, requestID)
+		if r, err = svc.procRequest(ctx, r, err); err != nil {
+			return err
+		}
+
+		raProps.setDataPrivacyRequest(r)
+
+		if !svc.ac.CanReadDataPrivacyRequest(ctx, r) {
+			return DataPrivacyErrNotAllowedToRead()
+		}
+
+		return nil
+	}()
+
+	return r, svc.recordAction(ctx, raProps, DataPrivacyActionLookup, err)
+}
+
+func (svc dataPrivacy) procRequest(_ context.Context, r *types.DataPrivacyRequest, err error) (*types.DataPrivacyRequest, error) {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, DataPrivacyErrNotFound()
+		}
+
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (svc dataPrivacy) FindRequests(ctx context.Context, filter types.DataPrivacyRequestFilter) (rr types.DataPrivacyRequestSet, f types.DataPrivacyRequestFilter, err error) {
+	var (
+		raProps = &dataPrivacyActionProps{filter: &filter}
+	)
+
+	// For each fetched item, store backend will check if it is valid or not
+	filter.Check = func(req *types.DataPrivacyRequest) (bool, error) {
+		if !svc.ac.CanReadDataPrivacyRequest(ctx, req) {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	err = func() error {
+		if !svc.ac.CanSearchDataPrivacyRequests(ctx) {
+			return DataPrivacyErrNotAllowedToSearch()
+		}
+
+		if rr, f, err = store.SearchDataPrivacyRequests(ctx, svc.store, filter); err != nil {
+			return err
+		}
+
+		return nil
+	}()
+
+	return rr, f, svc.recordAction(ctx, raProps, DataPrivacyActionSearch, err)
+}
+
+func (svc dataPrivacy) CreateRequest(ctx context.Context, new *types.DataPrivacyRequest) (r *types.DataPrivacyRequest, err error) {
+	var (
+		raProps = &dataPrivacyActionProps{new: new}
+	)
+
+	err = func() (err error) {
+		if len(new.Kind.String()) == 0 {
+			return DataPrivacyErrInvalidKind()
+		}
+
+		if !svc.ac.CanCreateDataPrivacyRequest(ctx) {
+			return DataPrivacyErrNotAllowedToCreate()
+		}
+
+		if err = svc.eventbus.WaitFor(ctx, event.DataPrivacyRequestBeforeCreate(new, r)); err != nil {
+			return
+		}
+
+		new.ID = nextID()
+		new.Status = types.RequestStatusPending
+		new.RequestedAt = *now()
+		new.RequestedBy = a.GetIdentityFromContext(ctx).Identity()
+		new.CreatedAt = *now()
+
+		if err = store.CreateDataPrivacyRequest(ctx, svc.store, new); err != nil {
+			return
+		}
+
+		r = new
+
+		svc.eventbus.Dispatch(ctx, event.DataPrivacyRequestAfterCreate(new, r))
+		return
+	}()
+
+	return r, svc.recordAction(ctx, raProps, DataPrivacyActionCreate, err)
+}
+
+func (svc dataPrivacy) UpdateRequestStatus(ctx context.Context, upd *types.DataPrivacyRequest) (r *types.DataPrivacyRequest, err error) {
+	var (
+		raProps = &dataPrivacyActionProps{update: upd}
+	)
+
+	err = func() (err error) {
+		if upd.ID == 0 {
+			return DataPrivacyErrInvalidID()
+		}
+
+		if len(upd.Status.String()) == 0 {
+			return DataPrivacyErrInvalidStatus()
+		}
+
+		if upd.Status == types.RequestStatusPending {
+			return DataPrivacyErrInvalidStatus()
+		}
+
+		if upd.Status == types.RequestStatusApproved || upd.Status == types.RequestStatusRejected {
+			if !svc.ac.CanApproveDataPrivacyRequest(ctx, upd) {
+				return DataPrivacyErrNotAllowedToApprove()
+			}
+		}
+
+		if r, err = store.LookupDataPrivacyRequestByID(ctx, svc.store, upd.ID); err != nil {
+			return
+		}
+
+		raProps.setDataPrivacyRequest(r)
+
+		if err = svc.eventbus.WaitFor(ctx, event.DataPrivacyRequestBeforeUpdate(upd, r)); err != nil {
+			return
+		}
+
+		r.Status = upd.Status
+		r.CompletedAt = now()
+		r.CompletedBy = a.GetIdentityFromContext(ctx).Identity()
+		r.UpdatedAt = now()
+
+		// Assign changed values
+		if err = store.UpdateDataPrivacyRequest(ctx, svc.store, r); err != nil {
+			return err
+		}
+
+		svc.eventbus.Dispatch(ctx, event.DataPrivacyRequestAfterUpdate(upd, r))
+
+		return nil
+	}()
+
+	return r, svc.recordAction(ctx, raProps, DataPrivacyActionApprove, err)
+}
+
+func (svc dataPrivacy) FindRequestComments(ctx context.Context, filter types.DataPrivacyRequestCommentFilter) (rr types.DataPrivacyRequestCommentSet, f types.DataPrivacyRequestCommentFilter, err error) {
+	err = func() error {
+		if rr, f, err = store.SearchDataPrivacyRequestComments(ctx, svc.store, filter); err != nil {
+			return err
+		}
+
+		return nil
+	}()
+
+	return rr, f, err
+}
+
+func (svc dataPrivacy) CreateRequestComment(ctx context.Context, new *types.DataPrivacyRequestComment) (r *types.DataPrivacyRequestComment, err error) {
+	err = func() (err error) {
+
+		_, err = svc.FindRequestByID(ctx, new.RequestID)
+		if err != nil {
+			return
+		}
+
+		new.ID = nextID()
+		new.CreatedBy = a.GetIdentityFromContext(ctx).Identity()
+		new.CreatedAt = *now()
+
+		if err = store.CreateDataPrivacyRequestComment(ctx, svc.store, new); err != nil {
+			return
+		}
+
+		r = new
+
+		return
+	}()
+
+	return r, err
+}

--- a/system/service/data_privacy_request_actions.gen.go
+++ b/system/service/data_privacy_request_actions.gen.go
@@ -1,0 +1,706 @@
+package service
+
+// This file is auto-generated.
+//
+// Changes to this file may cause incorrect behavior and will be lost if
+// the code is regenerated.
+//
+// Definitions file that controls how this file is generated:
+// system/service/data_privacy_request_actions.yaml
+
+import (
+	"context"
+	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/actionlog"
+	"github.com/cortezaproject/corteza-server/pkg/errors"
+	"github.com/cortezaproject/corteza-server/pkg/locale"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"strings"
+	"time"
+)
+
+type (
+	dataPrivacyActionProps struct {
+		dataPrivacyRequest *types.DataPrivacyRequest
+		new                *types.DataPrivacyRequest
+		update             *types.DataPrivacyRequest
+		filter             *types.DataPrivacyRequestFilter
+	}
+
+	dataPrivacyAction struct {
+		timestamp time.Time
+		resource  string
+		action    string
+		log       string
+		severity  actionlog.Severity
+
+		// prefix for error when action fails
+		errorMessage string
+
+		props *dataPrivacyActionProps
+	}
+
+	dataPrivacyLogMetaKey   struct{}
+	dataPrivacyPropsMetaKey struct{}
+)
+
+var (
+	// just a placeholder to cover template cases w/o fmt package use
+	_ = fmt.Println
+)
+
+// *********************************************************************************************************************
+// *********************************************************************************************************************
+// Props methods
+// setDataPrivacyRequest updates dataPrivacyActionProps's dataPrivacyRequest
+//
+// Allows method chaining
+//
+// This function is auto-generated.
+//
+func (p *dataPrivacyActionProps) setDataPrivacyRequest(dataPrivacyRequest *types.DataPrivacyRequest) *dataPrivacyActionProps {
+	p.dataPrivacyRequest = dataPrivacyRequest
+	return p
+}
+
+// setNew updates dataPrivacyActionProps's new
+//
+// Allows method chaining
+//
+// This function is auto-generated.
+//
+func (p *dataPrivacyActionProps) setNew(new *types.DataPrivacyRequest) *dataPrivacyActionProps {
+	p.new = new
+	return p
+}
+
+// setUpdate updates dataPrivacyActionProps's update
+//
+// Allows method chaining
+//
+// This function is auto-generated.
+//
+func (p *dataPrivacyActionProps) setUpdate(update *types.DataPrivacyRequest) *dataPrivacyActionProps {
+	p.update = update
+	return p
+}
+
+// setFilter updates dataPrivacyActionProps's filter
+//
+// Allows method chaining
+//
+// This function is auto-generated.
+//
+func (p *dataPrivacyActionProps) setFilter(filter *types.DataPrivacyRequestFilter) *dataPrivacyActionProps {
+	p.filter = filter
+	return p
+}
+
+// Serialize converts dataPrivacyActionProps to actionlog.Meta
+//
+// This function is auto-generated.
+//
+func (p dataPrivacyActionProps) Serialize() actionlog.Meta {
+	var (
+		m = make(actionlog.Meta)
+	)
+
+	if p.dataPrivacyRequest != nil {
+		m.Set("dataPrivacyRequest.kind", p.dataPrivacyRequest.Kind, true)
+		m.Set("dataPrivacyRequest.ID", p.dataPrivacyRequest.ID, true)
+	}
+	if p.new != nil {
+		m.Set("new.kind", p.new.Kind, true)
+		m.Set("new.ID", p.new.ID, true)
+	}
+	if p.update != nil {
+		m.Set("update.kind", p.update.Kind, true)
+		m.Set("update.ID", p.update.ID, true)
+	}
+	if p.filter != nil {
+		m.Set("filter.kind", p.filter.Kind, true)
+		m.Set("filter.sort", p.filter.Sort, true)
+	}
+
+	return m
+}
+
+// tr translates string and replaces meta value placeholder with values
+//
+// This function is auto-generated.
+//
+func (p dataPrivacyActionProps) Format(in string, err error) string {
+	var (
+		pairs = []string{"{{err}}"}
+		// first non-empty string
+		fns = func(ii ...interface{}) string {
+			for _, i := range ii {
+				if s := fmt.Sprintf("%v", i); len(s) > 0 {
+					return s
+				}
+			}
+
+			return ""
+		}
+	)
+
+	if err != nil {
+		pairs = append(pairs, err.Error())
+	} else {
+		pairs = append(pairs, "nil")
+	}
+
+	if p.dataPrivacyRequest != nil {
+		// replacement for "{{dataPrivacyRequest}}" (in order how fields are defined)
+		pairs = append(
+			pairs,
+			"{{dataPrivacyRequest}}",
+			fns(
+				p.dataPrivacyRequest.Kind,
+				p.dataPrivacyRequest.ID,
+			),
+		)
+		pairs = append(pairs, "{{dataPrivacyRequest.kind}}", fns(p.dataPrivacyRequest.Kind))
+		pairs = append(pairs, "{{dataPrivacyRequest.ID}}", fns(p.dataPrivacyRequest.ID))
+	}
+
+	if p.new != nil {
+		// replacement for "{{new}}" (in order how fields are defined)
+		pairs = append(
+			pairs,
+			"{{new}}",
+			fns(
+				p.new.Kind,
+				p.new.ID,
+			),
+		)
+		pairs = append(pairs, "{{new.kind}}", fns(p.new.Kind))
+		pairs = append(pairs, "{{new.ID}}", fns(p.new.ID))
+	}
+
+	if p.update != nil {
+		// replacement for "{{update}}" (in order how fields are defined)
+		pairs = append(
+			pairs,
+			"{{update}}",
+			fns(
+				p.update.Kind,
+				p.update.ID,
+			),
+		)
+		pairs = append(pairs, "{{update.kind}}", fns(p.update.Kind))
+		pairs = append(pairs, "{{update.ID}}", fns(p.update.ID))
+	}
+
+	if p.filter != nil {
+		// replacement for "{{filter}}" (in order how fields are defined)
+		pairs = append(
+			pairs,
+			"{{filter}}",
+			fns(
+				p.filter.Kind,
+				p.filter.Sort,
+			),
+		)
+		pairs = append(pairs, "{{filter.kind}}", fns(p.filter.Kind))
+		pairs = append(pairs, "{{filter.sort}}", fns(p.filter.Sort))
+	}
+	return strings.NewReplacer(pairs...).Replace(in)
+}
+
+// *********************************************************************************************************************
+// *********************************************************************************************************************
+// Action methods
+
+// String returns loggable description as string
+//
+// This function is auto-generated.
+//
+func (a *dataPrivacyAction) String() string {
+	var props = &dataPrivacyActionProps{}
+
+	if a.props != nil {
+		props = a.props
+	}
+
+	return props.Format(a.log, nil)
+}
+
+func (e *dataPrivacyAction) ToAction() *actionlog.Action {
+	return &actionlog.Action{
+		Resource:    e.resource,
+		Action:      e.action,
+		Severity:    e.severity,
+		Description: e.String(),
+		Meta:        e.props.Serialize(),
+	}
+}
+
+// *********************************************************************************************************************
+// *********************************************************************************************************************
+// Action constructors
+
+// DataPrivacyActionSearch returns "system:data-privacy-request.search" action
+//
+// This function is auto-generated.
+//
+func DataPrivacyActionSearch(props ...*dataPrivacyActionProps) *dataPrivacyAction {
+	a := &dataPrivacyAction{
+		timestamp: time.Now(),
+		resource:  "system:data-privacy-request",
+		action:    "search",
+		log:       "searched for data privacy requests",
+		severity:  actionlog.Info,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// DataPrivacyActionLookup returns "system:data-privacy-request.lookup" action
+//
+// This function is auto-generated.
+//
+func DataPrivacyActionLookup(props ...*dataPrivacyActionProps) *dataPrivacyAction {
+	a := &dataPrivacyAction{
+		timestamp: time.Now(),
+		resource:  "system:data-privacy-request",
+		action:    "lookup",
+		log:       "looked-up for a {{dataPrivacyRequest}}",
+		severity:  actionlog.Info,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// DataPrivacyActionCreate returns "system:data-privacy-request.create" action
+//
+// This function is auto-generated.
+//
+func DataPrivacyActionCreate(props ...*dataPrivacyActionProps) *dataPrivacyAction {
+	a := &dataPrivacyAction{
+		timestamp: time.Now(),
+		resource:  "system:data-privacy-request",
+		action:    "create",
+		log:       "created {{dataPrivacyRequest}}",
+		severity:  actionlog.Notice,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// DataPrivacyActionUpdate returns "system:data-privacy-request.update" action
+//
+// This function is auto-generated.
+//
+func DataPrivacyActionUpdate(props ...*dataPrivacyActionProps) *dataPrivacyAction {
+	a := &dataPrivacyAction{
+		timestamp: time.Now(),
+		resource:  "system:data-privacy-request",
+		action:    "update",
+		log:       "updated {{dataPrivacyRequest}}",
+		severity:  actionlog.Notice,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// DataPrivacyActionApprove returns "system:data-privacy-request.approve" action
+//
+// This function is auto-generated.
+//
+func DataPrivacyActionApprove(props ...*dataPrivacyActionProps) *dataPrivacyAction {
+	a := &dataPrivacyAction{
+		timestamp: time.Now(),
+		resource:  "system:data-privacy-request",
+		action:    "approve",
+		log:       "approved {{dataPrivacyRequest}}",
+		severity:  actionlog.Notice,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// *********************************************************************************************************************
+// *********************************************************************************************************************
+// Error constructors
+
+// DataPrivacyErrGeneric returns "system:data-privacy-request.generic" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrGeneric(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("failed to complete request due to internal error", nil),
+
+		errors.Meta("type", "generic"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		// action log entry; no formatting, it will be applied inside recordAction fn.
+		errors.Meta(dataPrivacyLogMetaKey{}, "{err}"),
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.generic"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrNotFound returns "system:data-privacy-request.notFound" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrNotFound(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("data privacy request not found", nil),
+
+		errors.Meta("type", "notFound"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notFound"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrInvalidID returns "system:data-privacy-request.invalidID" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrInvalidID(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("invalid ID", nil),
+
+		errors.Meta("type", "invalidID"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.invalidID"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrInvalidKind returns "system:data-privacy-request.invalidKind" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrInvalidKind(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("invalid Kind", nil),
+
+		errors.Meta("type", "invalidKind"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.invalidKind"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrInvalidStatus returns "system:data-privacy-request.invalidStatus" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrInvalidStatus(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("invalid Status", nil),
+
+		errors.Meta("type", "invalidStatus"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.invalidStatus"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrNotAllowedToRead returns "system:data-privacy-request.notAllowedToRead" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrNotAllowedToRead(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("not allowed to read this data privacy request", nil),
+
+		errors.Meta("type", "notAllowedToRead"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		// action log entry; no formatting, it will be applied inside recordAction fn.
+		errors.Meta(dataPrivacyLogMetaKey{}, "failed to read data privacy request; insufficient permissions"),
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToRead"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrNotAllowedToSearch returns "system:data-privacy-request.notAllowedToSearch" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrNotAllowedToSearch(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("not allowed to search or list data privacy request", nil),
+
+		errors.Meta("type", "notAllowedToSearch"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		// action log entry; no formatting, it will be applied inside recordAction fn.
+		errors.Meta(dataPrivacyLogMetaKey{}, "failed to search or list data privacy requests; insufficient permissions"),
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToSearch"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrNotAllowedToCreate returns "system:data-privacy-request.notAllowedToCreate" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrNotAllowedToCreate(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("not allowed to create data privacy request", nil),
+
+		errors.Meta("type", "notAllowedToCreate"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		// action log entry; no formatting, it will be applied inside recordAction fn.
+		errors.Meta(dataPrivacyLogMetaKey{}, "failed to create data privacy request; insufficient permissions"),
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToCreate"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// DataPrivacyErrNotAllowedToApprove returns "system:data-privacy-request.notAllowedToApprove" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DataPrivacyErrNotAllowedToApprove(mm ...*dataPrivacyActionProps) *errors.Error {
+	var p = &dataPrivacyActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("not allowed to approve/reject data privacy request", nil),
+
+		errors.Meta("type", "notAllowedToApprove"),
+		errors.Meta("resource", "system:data-privacy-request"),
+
+		// action log entry; no formatting, it will be applied inside recordAction fn.
+		errors.Meta(dataPrivacyLogMetaKey{}, "failed to approve/reject data privacy request; insufficient permissions"),
+		errors.Meta(dataPrivacyPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToApprove"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// *********************************************************************************************************************
+// *********************************************************************************************************************
+
+// recordAction is a service helper function wraps function that can return error
+//
+// It will wrap unrecognized/internal errors with generic errors.
+//
+// This function is auto-generated.
+//
+func (svc dataPrivacy) recordAction(ctx context.Context, props *dataPrivacyActionProps, actionFn func(...*dataPrivacyActionProps) *dataPrivacyAction, err error) error {
+	if svc.actionlog == nil || actionFn == nil {
+		// action log disabled or no action fn passed, return error as-is
+		return err
+	} else if err == nil {
+		// action completed w/o error, record it
+		svc.actionlog.Record(ctx, actionFn(props).ToAction())
+		return nil
+	}
+
+	a := actionFn(props).ToAction()
+
+	// Extracting error information and recording it as action
+	a.Error = err.Error()
+
+	switch c := err.(type) {
+	case *errors.Error:
+		m := c.Meta()
+
+		a.Error = err.Error()
+		a.Severity = actionlog.Severity(m.AsInt("severity"))
+		a.Description = props.Format(m.AsString(dataPrivacyLogMetaKey{}), err)
+
+		if p, has := m[dataPrivacyPropsMetaKey{}]; has {
+			a.Meta = p.(*dataPrivacyActionProps).Serialize()
+		}
+
+		svc.actionlog.Record(ctx, a)
+	default:
+		svc.actionlog.Record(ctx, a)
+	}
+
+	// Original error is passed on
+	return err
+}

--- a/system/service/data_privacy_request_actions.yaml
+++ b/system/service/data_privacy_request_actions.yaml
@@ -1,0 +1,79 @@
+# List of loggable service actions
+
+resource: system:data-privacy-request
+service: dataPrivacy
+
+# Default sensitivity for actions
+defaultActionSeverity: notice
+
+# default severity for errors
+defaultErrorSeverity: alert
+
+import:
+  - github.com/cortezaproject/corteza-server/system/types
+
+props:
+  - name: dataPrivacyRequest
+    type: "*types.DataPrivacyRequest"
+    fields: [ kind, ID ]
+  - name: new
+    type: "*types.DataPrivacyRequest"
+    fields: [ kind, ID ]
+  - name: update
+    type: "*types.DataPrivacyRequest"
+    fields: [ kind, ID ]
+  - name: filter
+    type: "*types.DataPrivacyRequestFilter"
+    fields: [ kind, sort ]
+
+actions:
+  - action: search
+    log: "searched for data privacy requests"
+    severity: info
+
+  - action: lookup
+    log: "looked-up for a {{dataPrivacyRequest}}"
+    severity: info
+
+  - action: create
+    log: "created {{dataPrivacyRequest}}"
+
+  - action: update
+    log: "updated {{dataPrivacyRequest}}"
+
+  - action: approve
+    log: "approved {{dataPrivacyRequest}}"
+
+
+errors:
+  - error: notFound
+    message: "data privacy request not found"
+    severity: warning
+
+  - error: invalidID
+    message: "invalid ID"
+    severity: warning
+
+  - error: invalidKind
+    message: "invalid Kind"
+    severity: warning
+
+  - error: invalidStatus
+    message: "invalid Status"
+    severity: warning
+
+  - error: notAllowedToRead
+    message: "not allowed to read this data privacy request"
+    log: "failed to read data privacy request; insufficient permissions"
+
+  - error: notAllowedToSearch
+    message: "not allowed to search or list data privacy request"
+    log: "failed to search or list data privacy requests; insufficient permissions"
+
+  - error: notAllowedToCreate
+    message: "not allowed to create data privacy request"
+    log: "failed to create data privacy request; insufficient permissions"
+
+  - error: notAllowedToApprove
+    message: "not allowed to approve/reject data privacy request"
+    log: "failed to approve/reject data privacy request; insufficient permissions"

--- a/system/service/event/data_privacy_request.go
+++ b/system/service/event/data_privacy_request.go
@@ -1,0 +1,19 @@
+package event
+
+import (
+	"github.com/cortezaproject/corteza-server/pkg/eventbus"
+)
+
+var _ = eventbus.ConstraintMaker
+
+// Match returns false if given conditions do not match event & resource internals
+func (res dataPrivacyRequestBase) Match(c eventbus.ConstraintMatcher) bool {
+	// By default we match no mather what kind of constraints we receive
+	//
+	// Function will be called multiple times - once for every trigger constraint
+	// All should match (return true):
+	//   constraint#1 AND constraint#2 AND constraint#3 ...
+	//
+	// When there are multiple values, Match() can decide how to treat them (OR, AND...)
+	return true
+}

--- a/system/service/event/events.gen.go
+++ b/system/service/event/events.gen.go
@@ -206,6 +206,65 @@ type (
 		*authClientBase
 	}
 
+	// dataPrivacyRequestBase
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestBase struct {
+		immutable             bool
+		dataPrivacyRequest    *types.DataPrivacyRequest
+		oldDataPrivacyRequest *types.DataPrivacyRequest
+		invoker               auth.Identifiable
+	}
+
+	// dataPrivacyRequestOnManual
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestOnManual struct {
+		*dataPrivacyRequestBase
+	}
+
+	// dataPrivacyRequestBeforeCreate
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestBeforeCreate struct {
+		*dataPrivacyRequestBase
+	}
+
+	// dataPrivacyRequestBeforeUpdate
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestBeforeUpdate struct {
+		*dataPrivacyRequestBase
+	}
+
+	// dataPrivacyRequestBeforeDelete
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestBeforeDelete struct {
+		*dataPrivacyRequestBase
+	}
+
+	// dataPrivacyRequestAfterCreate
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestAfterCreate struct {
+		*dataPrivacyRequestBase
+	}
+
+	// dataPrivacyRequestAfterUpdate
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestAfterUpdate struct {
+		*dataPrivacyRequestBase
+	}
+
+	// dataPrivacyRequestAfterDelete
+	//
+	// This type is auto-generated.
+	dataPrivacyRequestAfterDelete struct {
+		*dataPrivacyRequestBase
+	}
+
 	// mailBase
 	//
 	// This type is auto-generated.
@@ -1728,6 +1787,415 @@ func (res *authClientBase) DecodeVars(vars *expr.Vars) (err error) {
 	}
 	// Could not find expression-type counterpart for *types.AuthClient
 	// oldAuthClient marked as immutable
+	// Could not find expression-type counterpart for auth.Identifiable
+
+	return
+}
+
+// ResourceType returns "system:data-privacy-request"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestBase) ResourceType() string {
+	return "system:data-privacy-request"
+}
+
+// EventType on dataPrivacyRequestOnManual returns "onManual"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestOnManual) EventType() string {
+	return "onManual"
+}
+
+// EventType on dataPrivacyRequestBeforeCreate returns "beforeCreate"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestBeforeCreate) EventType() string {
+	return "beforeCreate"
+}
+
+// EventType on dataPrivacyRequestBeforeUpdate returns "beforeUpdate"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestBeforeUpdate) EventType() string {
+	return "beforeUpdate"
+}
+
+// EventType on dataPrivacyRequestBeforeDelete returns "beforeDelete"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestBeforeDelete) EventType() string {
+	return "beforeDelete"
+}
+
+// EventType on dataPrivacyRequestAfterCreate returns "afterCreate"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestAfterCreate) EventType() string {
+	return "afterCreate"
+}
+
+// EventType on dataPrivacyRequestAfterUpdate returns "afterUpdate"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestAfterUpdate) EventType() string {
+	return "afterUpdate"
+}
+
+// EventType on dataPrivacyRequestAfterDelete returns "afterDelete"
+//
+// This function is auto-generated.
+func (dataPrivacyRequestAfterDelete) EventType() string {
+	return "afterDelete"
+}
+
+// DataPrivacyRequestOnManual creates onManual for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestOnManual(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestOnManual {
+	return &dataPrivacyRequestOnManual{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestOnManualImmutable creates onManual for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestOnManualImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestOnManual {
+	return &dataPrivacyRequestOnManual{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestBeforeCreate creates beforeCreate for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestBeforeCreate(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestBeforeCreate {
+	return &dataPrivacyRequestBeforeCreate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestBeforeCreateImmutable creates beforeCreate for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestBeforeCreateImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestBeforeCreate {
+	return &dataPrivacyRequestBeforeCreate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestBeforeUpdate creates beforeUpdate for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestBeforeUpdate(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestBeforeUpdate {
+	return &dataPrivacyRequestBeforeUpdate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestBeforeUpdateImmutable creates beforeUpdate for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestBeforeUpdateImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestBeforeUpdate {
+	return &dataPrivacyRequestBeforeUpdate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestBeforeDelete creates beforeDelete for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestBeforeDelete(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestBeforeDelete {
+	return &dataPrivacyRequestBeforeDelete{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestBeforeDeleteImmutable creates beforeDelete for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestBeforeDeleteImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestBeforeDelete {
+	return &dataPrivacyRequestBeforeDelete{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestAfterCreate creates afterCreate for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestAfterCreate(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestAfterCreate {
+	return &dataPrivacyRequestAfterCreate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestAfterCreateImmutable creates afterCreate for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestAfterCreateImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestAfterCreate {
+	return &dataPrivacyRequestAfterCreate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestAfterUpdate creates afterUpdate for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestAfterUpdate(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestAfterUpdate {
+	return &dataPrivacyRequestAfterUpdate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestAfterUpdateImmutable creates afterUpdate for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestAfterUpdateImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestAfterUpdate {
+	return &dataPrivacyRequestAfterUpdate{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestAfterDelete creates afterDelete for system:data-privacy-request resource
+//
+// This function is auto-generated.
+func DataPrivacyRequestAfterDelete(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestAfterDelete {
+	return &dataPrivacyRequestAfterDelete{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             false,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// DataPrivacyRequestAfterDeleteImmutable creates afterDelete for system:data-privacy-request resource
+//
+// None of the arguments will be mutable!
+//
+// This function is auto-generated.
+func DataPrivacyRequestAfterDeleteImmutable(
+	argDataPrivacyRequest *types.DataPrivacyRequest,
+	argOldDataPrivacyRequest *types.DataPrivacyRequest,
+) *dataPrivacyRequestAfterDelete {
+	return &dataPrivacyRequestAfterDelete{
+		dataPrivacyRequestBase: &dataPrivacyRequestBase{
+			immutable:             true,
+			dataPrivacyRequest:    argDataPrivacyRequest,
+			oldDataPrivacyRequest: argOldDataPrivacyRequest,
+		},
+	}
+}
+
+// SetDataPrivacyRequest sets new dataPrivacyRequest value
+//
+// This function is auto-generated.
+func (res *dataPrivacyRequestBase) SetDataPrivacyRequest(argDataPrivacyRequest *types.DataPrivacyRequest) {
+	res.dataPrivacyRequest = argDataPrivacyRequest
+}
+
+// DataPrivacyRequest returns dataPrivacyRequest
+//
+// This function is auto-generated.
+func (res dataPrivacyRequestBase) DataPrivacyRequest() *types.DataPrivacyRequest {
+	return res.dataPrivacyRequest
+}
+
+// OldDataPrivacyRequest returns oldDataPrivacyRequest
+//
+// This function is auto-generated.
+func (res dataPrivacyRequestBase) OldDataPrivacyRequest() *types.DataPrivacyRequest {
+	return res.oldDataPrivacyRequest
+}
+
+// SetInvoker sets new invoker value
+//
+// This function is auto-generated.
+func (res *dataPrivacyRequestBase) SetInvoker(argInvoker auth.Identifiable) {
+	res.invoker = argInvoker
+}
+
+// Invoker returns invoker
+//
+// This function is auto-generated.
+func (res dataPrivacyRequestBase) Invoker() auth.Identifiable {
+	return res.invoker
+}
+
+// Encode internal data to be passed as event params & arguments to triggered Corredor script
+func (res dataPrivacyRequestBase) Encode() (args map[string][]byte, err error) {
+	args = make(map[string][]byte)
+
+	if args["dataPrivacyRequest"], err = json.Marshal(res.dataPrivacyRequest); err != nil {
+		return nil, err
+	}
+
+	if args["oldDataPrivacyRequest"], err = json.Marshal(res.oldDataPrivacyRequest); err != nil {
+		return nil, err
+	}
+
+	if args["invoker"], err = json.Marshal(res.invoker); err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+// Encode internal data to be passed as event params & arguments to workflow
+func (res dataPrivacyRequestBase) EncodeVars() (out *expr.Vars, err error) {
+	out = &expr.Vars{}
+	var v expr.TypedValue
+
+	// Could not found expression-type counterpart for *types.DataPrivacyRequest
+
+	// Could not found expression-type counterpart for *types.DataPrivacyRequest
+
+	// Could not found expression-type counterpart for auth.Identifiable
+
+	_ = v
+	return
+}
+
+// Decode return values from Corredor script into struct props
+func (res *dataPrivacyRequestBase) Decode(results map[string][]byte) (err error) {
+	if res.immutable {
+		// Respect immutability
+		return
+	}
+	if res.dataPrivacyRequest != nil {
+		if r, ok := results["result"]; ok && len(results) == 1 {
+			if err = json.Unmarshal(r, res.dataPrivacyRequest); err != nil {
+				return
+			}
+		}
+	}
+
+	if res.dataPrivacyRequest != nil {
+		if r, ok := results["dataPrivacyRequest"]; ok {
+			if err = json.Unmarshal(r, res.dataPrivacyRequest); err != nil {
+				return
+			}
+		}
+	}
+
+	// Do not decode oldDataPrivacyRequest; marked as immutable
+
+	if res.invoker != nil {
+		if r, ok := results["invoker"]; ok {
+			if err = json.Unmarshal(r, res.invoker); err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+func (res *dataPrivacyRequestBase) DecodeVars(vars *expr.Vars) (err error) {
+	if res.immutable {
+		// Respect immutability
+		return
+	}
+	// Could not find expression-type counterpart for *types.DataPrivacyRequest
+	// oldDataPrivacyRequest marked as immutable
 	// Could not find expression-type counterpart for auth.Identifiable
 
 	return

--- a/system/service/event/events.yaml
+++ b/system/service/event/events.yaml
@@ -118,3 +118,15 @@ system:queue:
       type: '*types.QueueMessage'
   constraints:
     - name: payload.queue
+
+system:data-privacy-request:
+  on: ['manual']
+  ba: ['create', 'update', 'delete']
+  props:
+    - name: 'dataPrivacyRequest'
+      type: '*types.DataPrivacyRequest'
+    - name: 'oldDataPrivacyRequest'
+      type: '*types.DataPrivacyRequest'
+      immutable: true
+  constraints:
+    - name: role.name

--- a/system/service/service.go
+++ b/system/service/service.go
@@ -89,6 +89,7 @@ var (
 	DefaultApigwProfiler       *apigwProfiler
 	DefaultReport              *report
 	primaryConnectionConfig    *types.DalConnection
+	DefaultDataPrivacy         *dataPrivacy
 
 	DefaultStatistics *statistics
 
@@ -213,6 +214,7 @@ func Initialize(ctx context.Context, log *zap.Logger, s store.Storer, primaryCon
 	DefaultApigwRoute = Route()
 	DefaultApigwProfiler = Profiler()
 	DefaultApigwFilter = Filter()
+	DefaultDataPrivacy = DataPrivacy(DefaultStore, DefaultAccessControl, DefaultActionlog, eventbus.Service())
 
 	if err = initRoles(ctx, log.Named("rbac.roles"), c.RBAC, eventbus.Service(), rbac.Global()); err != nil {
 		return err

--- a/system/types/data_privacy.go
+++ b/system/types/data_privacy.go
@@ -1,0 +1,130 @@
+package types
+
+import (
+	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/filter"
+)
+
+type (
+	DataPrivacyRequest struct {
+		ID uint64 `json:"requestID,string"`
+
+		Kind   RequestKind   `json:"kind"`
+		Status RequestStatus `json:"status"`
+
+		RequestedAt time.Time  `json:"requestedAt,omitempty"`
+		RequestedBy uint64     `json:"requestedBy,string"`
+		CompletedAt *time.Time `json:"completedAt,omitempty"`
+		CompletedBy uint64     `json:"completedBy,string,omitempty" `
+
+		CreatedAt time.Time  `json:"createdAt,omitempty"`
+		CreatedBy uint64     `json:"createdBy,string" `
+		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+		UpdatedBy uint64     `json:"updatedBy,string,omitempty"`
+		DeletedAt *time.Time `json:"deletedAt,omitempty"`
+		DeletedBy uint64     `json:"deletedBy,string,omitempty"`
+	}
+
+	DataPrivacyRequestFilter struct {
+		RequestID []uint64 `json:"requestID"`
+		Query     string   `json:"query"`
+
+		Kind   []string `json:"kind"`
+		Status []string `json:"status"`
+
+		// Check fn is called by store backend for each resource found function can
+		// modify the resource and return false if store should not return it
+		//
+		// Store then loads additional resources to satisfy the paging parameters
+		Check func(request *DataPrivacyRequest) (bool, error) `json:"-"`
+
+		// Standard helpers for paging and sorting
+		filter.Sorting
+		filter.Paging
+	}
+
+	DataPrivacyRequestComment struct {
+		ID        uint64 `json:"commentID,string"`
+		RequestID uint64 `json:"requestID,string"`
+		Comment   string `json:"comment"`
+
+		CreatedAt time.Time  `json:"createdAt,omitempty"`
+		CreatedBy uint64     `json:"createdBy,string" `
+		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+		UpdatedBy uint64     `json:"updatedBy,string,omitempty"`
+		DeletedAt *time.Time `json:"deletedAt,omitempty"`
+		DeletedBy uint64     `json:"deletedBy,string,omitempty"`
+	}
+
+	DataPrivacyRequestCommentFilter struct {
+		RequestID []uint64 `json:"requestID"`
+
+		// Check fn is called by store backend for each resource found function can
+		// modify the resource and return false if store should not return it
+		//
+		// Store then loads additional resources to satisfy the paging parameters
+		Check func(request *DataPrivacyRequestComment) (bool, error) `json:"-"`
+
+		// Standard helpers for paging and sorting
+		filter.Sorting
+		filter.Paging
+	}
+
+	RequestStatus string
+	RequestKind   string
+)
+
+const (
+	// RequestKindCorrect to correct module fields
+	RequestKindCorrect RequestKind = "correct"
+	// RequestKindDelete to delete module fields
+	RequestKindDelete RequestKind = "delete"
+	// RequestKindExport to export module fields
+	RequestKindExport RequestKind = "export"
+
+	// RequestStatusPending initially request will be in pending status
+	RequestStatusPending RequestStatus = "pending"
+	// RequestStatusCanceled owner of request has cancelled the request
+	RequestStatusCanceled RequestStatus = "canceled"
+	// RequestStatusApproved data officer has of request has cancelled the request
+	RequestStatusApproved RequestStatus = "approved"
+	// RequestStatusRejected data officer has denied the request
+	RequestStatusRejected RequestStatus = "rejected"
+)
+
+func CastToRequestKind(s string) RequestKind {
+	switch s {
+	case "correct":
+		return RequestKindCorrect
+	case "delete":
+		return RequestKindCorrect
+	case "export":
+		return RequestKindCorrect
+	default:
+		return ""
+	}
+}
+
+func (k RequestKind) String() string {
+	return string(k)
+}
+
+func CastToRequestStatus(s string) RequestStatus {
+	switch s {
+	case "pending":
+		return RequestStatusPending
+	case "canceled":
+		return RequestStatusCanceled
+	case "approved":
+		return RequestStatusApproved
+	case "rejected":
+		return RequestStatusRejected
+	default:
+		return ""
+	}
+}
+
+func (s RequestStatus) String() string {
+	return string(s)
+}

--- a/system/types/rbac.gen.go
+++ b/system/types/rbac.gen.go
@@ -24,18 +24,20 @@ var (
 )
 
 const (
-	ApplicationResourceType         = "corteza::system:application"
-	ApigwRouteResourceType          = "corteza::system:apigw-route"
-	AuthClientResourceType          = "corteza::system:auth-client"
-	QueueResourceType               = "corteza::system:queue"
-	QueueMessageResourceType        = "corteza::system:queue_message"
-	ReportResourceType              = "corteza::system:report"
-	RoleResourceType                = "corteza::system:role"
-	TemplateResourceType            = "corteza::system:template"
-	UserResourceType                = "corteza::system:user"
-	DalConnectionResourceType       = "corteza::system:dal_connection"
-	DalSensitivityLevelResourceType = "corteza::system:dal_sensitivity_level"
-	ComponentResourceType           = "corteza::system"
+	ApplicationResourceType               = "corteza::system:application"
+	ApigwRouteResourceType                = "corteza::system:apigw-route"
+	AuthClientResourceType                = "corteza::system:auth-client"
+	DataPrivacyRequestResourceType        = "corteza::system:data-privacy-request"
+	DataPrivacyRequestCommentResourceType = "corteza::system:data-privacy-request_comment"
+	QueueResourceType                     = "corteza::system:queue"
+	QueueMessageResourceType              = "corteza::system:queue_message"
+	ReportResourceType                    = "corteza::system:report"
+	RoleResourceType                      = "corteza::system:role"
+	TemplateResourceType                  = "corteza::system:template"
+	UserResourceType                      = "corteza::system:user"
+	DalConnectionResourceType             = "corteza::system:dal_connection"
+	DalSensitivityLevelResourceType       = "corteza::system:dal_sensitivity_level"
+	ComponentResourceType                 = "corteza::system"
 )
 
 // RbacResource returns string representation of RBAC resource for Application by calling ApplicationRbacResource fn
@@ -125,6 +127,66 @@ func AuthClientRbacResource(id uint64) string {
 }
 
 func AuthClientRbacResourceTpl() string {
+	return "%s/%s"
+}
+
+// RbacResource returns string representation of RBAC resource for DataPrivacyRequest by calling DataPrivacyRequestRbacResource fn
+//
+// RBAC resource is in the corteza::system:data-privacy-request/... format
+//
+// This function is auto-generated
+func (r DataPrivacyRequest) RbacResource() string {
+	return DataPrivacyRequestRbacResource(r.ID)
+}
+
+// DataPrivacyRequestRbacResource returns string representation of RBAC resource for DataPrivacyRequest
+//
+// RBAC resource is in the corteza::system:data-privacy-request/... format
+//
+// This function is auto-generated
+func DataPrivacyRequestRbacResource(id uint64) string {
+	cpts := []interface{}{DataPrivacyRequestResourceType}
+	if id != 0 {
+		cpts = append(cpts, strconv.FormatUint(id, 10))
+	} else {
+		cpts = append(cpts, "*")
+	}
+
+	return fmt.Sprintf(DataPrivacyRequestRbacResourceTpl(), cpts...)
+
+}
+
+func DataPrivacyRequestRbacResourceTpl() string {
+	return "%s/%s"
+}
+
+// RbacResource returns string representation of RBAC resource for DataPrivacyRequestComment by calling DataPrivacyRequestCommentRbacResource fn
+//
+// RBAC resource is in the corteza::system:data-privacy-request_comment/... format
+//
+// This function is auto-generated
+func (r DataPrivacyRequestComment) RbacResource() string {
+	return DataPrivacyRequestCommentRbacResource(r.ID)
+}
+
+// DataPrivacyRequestCommentRbacResource returns string representation of RBAC resource for DataPrivacyRequestComment
+//
+// RBAC resource is in the corteza::system:data-privacy-request_comment/... format
+//
+// This function is auto-generated
+func DataPrivacyRequestCommentRbacResource(id uint64) string {
+	cpts := []interface{}{DataPrivacyRequestCommentResourceType}
+	if id != 0 {
+		cpts = append(cpts, strconv.FormatUint(id, 10))
+	} else {
+		cpts = append(cpts, "*")
+	}
+
+	return fmt.Sprintf(DataPrivacyRequestCommentRbacResourceTpl(), cpts...)
+
+}
+
+func DataPrivacyRequestCommentRbacResourceTpl() string {
 	return "%s/%s"
 }
 

--- a/system/types/type_set.gen.go
+++ b/system/types/type_set.gen.go
@@ -75,6 +75,16 @@ type (
 	// This type is auto-generated.
 	DalSensitivityLevelSet []*DalSensitivityLevel
 
+	// DataPrivacyRequestSet slice of DataPrivacyRequest
+	//
+	// This type is auto-generated.
+	DataPrivacyRequestSet []*DataPrivacyRequest
+
+	// DataPrivacyRequestCommentSet slice of DataPrivacyRequestComment
+	//
+	// This type is auto-generated.
+	DataPrivacyRequestCommentSet []*DataPrivacyRequestComment
+
 	// QueueSet slice of Queue
 	//
 	// This type is auto-generated.
@@ -741,6 +751,118 @@ func (set DalSensitivityLevelSet) FindByID(ID uint64) *DalSensitivityLevel {
 //
 // This function is auto-generated.
 func (set DalSensitivityLevelSet) IDs() (IDs []uint64) {
+	IDs = make([]uint64, len(set))
+
+	for i := range set {
+		IDs[i] = set[i].ID
+	}
+
+	return
+}
+
+// Walk iterates through every slice item and calls w(DataPrivacyRequest) err
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestSet) Walk(w func(*DataPrivacyRequest) error) (err error) {
+	for i := range set {
+		if err = w(set[i]); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// Filter iterates through every slice item, calls f(DataPrivacyRequest) (bool, err) and return filtered slice
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestSet) Filter(f func(*DataPrivacyRequest) (bool, error)) (out DataPrivacyRequestSet, err error) {
+	var ok bool
+	out = DataPrivacyRequestSet{}
+	for i := range set {
+		if ok, err = f(set[i]); err != nil {
+			return
+		} else if ok {
+			out = append(out, set[i])
+		}
+	}
+
+	return
+}
+
+// FindByID finds items from slice by its ID property
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestSet) FindByID(ID uint64) *DataPrivacyRequest {
+	for i := range set {
+		if set[i].ID == ID {
+			return set[i]
+		}
+	}
+
+	return nil
+}
+
+// IDs returns a slice of uint64s from all items in the set
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestSet) IDs() (IDs []uint64) {
+	IDs = make([]uint64, len(set))
+
+	for i := range set {
+		IDs[i] = set[i].ID
+	}
+
+	return
+}
+
+// Walk iterates through every slice item and calls w(DataPrivacyRequestComment) err
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestCommentSet) Walk(w func(*DataPrivacyRequestComment) error) (err error) {
+	for i := range set {
+		if err = w(set[i]); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// Filter iterates through every slice item, calls f(DataPrivacyRequestComment) (bool, err) and return filtered slice
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestCommentSet) Filter(f func(*DataPrivacyRequestComment) (bool, error)) (out DataPrivacyRequestCommentSet, err error) {
+	var ok bool
+	out = DataPrivacyRequestCommentSet{}
+	for i := range set {
+		if ok, err = f(set[i]); err != nil {
+			return
+		} else if ok {
+			out = append(out, set[i])
+		}
+	}
+
+	return
+}
+
+// FindByID finds items from slice by its ID property
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestCommentSet) FindByID(ID uint64) *DataPrivacyRequestComment {
+	for i := range set {
+		if set[i].ID == ID {
+			return set[i]
+		}
+	}
+
+	return nil
+}
+
+// IDs returns a slice of uint64s from all items in the set
+//
+// This function is auto-generated.
+func (set DataPrivacyRequestCommentSet) IDs() (IDs []uint64) {
 	IDs = make([]uint64, len(set))
 
 	for i := range set {

--- a/system/types/type_set.gen_test.go
+++ b/system/types/type_set.gen_test.go
@@ -1048,6 +1048,186 @@ func TestDalSensitivityLevelSetIDs(t *testing.T) {
 	}
 }
 
+func TestDataPrivacyRequestSetWalk(t *testing.T) {
+	var (
+		value = make(DataPrivacyRequestSet, 3)
+		req   = require.New(t)
+	)
+
+	// check walk with no errors
+	{
+		err := value.Walk(func(*DataPrivacyRequest) error {
+			return nil
+		})
+		req.NoError(err)
+	}
+
+	// check walk with error
+	req.Error(value.Walk(func(*DataPrivacyRequest) error { return fmt.Errorf("walk error") }))
+}
+
+func TestDataPrivacyRequestSetFilter(t *testing.T) {
+	var (
+		value = make(DataPrivacyRequestSet, 3)
+		req   = require.New(t)
+	)
+
+	// filter nothing
+	{
+		set, err := value.Filter(func(*DataPrivacyRequest) (bool, error) {
+			return true, nil
+		})
+		req.NoError(err)
+		req.Equal(len(set), len(value))
+	}
+
+	// filter one item
+	{
+		found := false
+		set, err := value.Filter(func(*DataPrivacyRequest) (bool, error) {
+			if !found {
+				found = true
+				return found, nil
+			}
+			return false, nil
+		})
+		req.NoError(err)
+		req.Len(set, 1)
+	}
+
+	// filter error
+	{
+		_, err := value.Filter(func(*DataPrivacyRequest) (bool, error) {
+			return false, fmt.Errorf("filter error")
+		})
+		req.Error(err)
+	}
+}
+
+func TestDataPrivacyRequestSetIDs(t *testing.T) {
+	var (
+		value = make(DataPrivacyRequestSet, 3)
+		req   = require.New(t)
+	)
+
+	// construct objects
+	value[0] = new(DataPrivacyRequest)
+	value[1] = new(DataPrivacyRequest)
+	value[2] = new(DataPrivacyRequest)
+	// set ids
+	value[0].ID = 1
+	value[1].ID = 2
+	value[2].ID = 3
+
+	// Find existing
+	{
+		val := value.FindByID(2)
+		req.Equal(uint64(2), val.ID)
+	}
+
+	// Find non-existing
+	{
+		val := value.FindByID(4)
+		req.Nil(val)
+	}
+
+	// List IDs from set
+	{
+		val := value.IDs()
+		req.Equal(len(val), len(value))
+	}
+}
+
+func TestDataPrivacyRequestCommentSetWalk(t *testing.T) {
+	var (
+		value = make(DataPrivacyRequestCommentSet, 3)
+		req   = require.New(t)
+	)
+
+	// check walk with no errors
+	{
+		err := value.Walk(func(*DataPrivacyRequestComment) error {
+			return nil
+		})
+		req.NoError(err)
+	}
+
+	// check walk with error
+	req.Error(value.Walk(func(*DataPrivacyRequestComment) error { return fmt.Errorf("walk error") }))
+}
+
+func TestDataPrivacyRequestCommentSetFilter(t *testing.T) {
+	var (
+		value = make(DataPrivacyRequestCommentSet, 3)
+		req   = require.New(t)
+	)
+
+	// filter nothing
+	{
+		set, err := value.Filter(func(*DataPrivacyRequestComment) (bool, error) {
+			return true, nil
+		})
+		req.NoError(err)
+		req.Equal(len(set), len(value))
+	}
+
+	// filter one item
+	{
+		found := false
+		set, err := value.Filter(func(*DataPrivacyRequestComment) (bool, error) {
+			if !found {
+				found = true
+				return found, nil
+			}
+			return false, nil
+		})
+		req.NoError(err)
+		req.Len(set, 1)
+	}
+
+	// filter error
+	{
+		_, err := value.Filter(func(*DataPrivacyRequestComment) (bool, error) {
+			return false, fmt.Errorf("filter error")
+		})
+		req.Error(err)
+	}
+}
+
+func TestDataPrivacyRequestCommentSetIDs(t *testing.T) {
+	var (
+		value = make(DataPrivacyRequestCommentSet, 3)
+		req   = require.New(t)
+	)
+
+	// construct objects
+	value[0] = new(DataPrivacyRequestComment)
+	value[1] = new(DataPrivacyRequestComment)
+	value[2] = new(DataPrivacyRequestComment)
+	// set ids
+	value[0].ID = 1
+	value[1].ID = 2
+	value[2].ID = 3
+
+	// Find existing
+	{
+		val := value.FindByID(2)
+		req.Equal(uint64(2), val.ID)
+	}
+
+	// Find non-existing
+	{
+		val := value.FindByID(4)
+		req.Nil(val)
+	}
+
+	// List IDs from set
+	{
+		val := value.IDs()
+		req.Equal(len(val), len(value))
+	}
+}
+
 func TestQueueSetWalk(t *testing.T) {
 	var (
 		value = make(QueueSet, 3)

--- a/system/types/types.yaml
+++ b/system/types/types.yaml
@@ -35,3 +35,5 @@ types:
   Queue: {}
   QueueMessage:
     noIdField: true
+  DataPrivacyRequest: {}
+  DataPrivacyRequestComment: {}

--- a/tests/system/data_privacy_request_comment_test.go
+++ b/tests/system/data_privacy_request_comment_test.go
@@ -1,0 +1,102 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/service"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"github.com/cortezaproject/corteza-server/tests/helpers"
+	"github.com/spf13/cast"
+	jsonpath "github.com/steinfletcher/apitest-jsonpath"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func (h helper) clearDataPrivacyRequestComments() {
+	h.noError(store.TruncateDataPrivacyRequestComments(context.Background(), service.DefaultStore))
+}
+
+func (h helper) createDataPrivacyRequestComment(comment string, requestID uint64) *types.DataPrivacyRequestComment {
+	res := &types.DataPrivacyRequestComment{
+		ID:        id.Next(),
+		RequestID: requestID,
+		Comment:   comment,
+		CreatedAt: time.Now(),
+	}
+
+	h.a.NoError(store.CreateDataPrivacyRequestComment(context.Background(), service.DefaultStore, res))
+
+	return res
+}
+
+func (h helper) createSampleDataPrivacyRequestComment(requestID ...uint64) *types.DataPrivacyRequestComment {
+	rID := id.Next()
+	if len(requestID) == 1 {
+		rID = requestID[0]
+	}
+	return h.createDataPrivacyRequestComment(rs(20), rID)
+}
+
+func TestDataPrivacyRequestCommentList(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+	h.clearDataPrivacyRequestComments()
+
+	request := h.createSampleDataPrivacyRequest()
+	reqID := request.ID
+	h.createSampleDataPrivacyRequestComment(reqID)
+	h.createSampleDataPrivacyRequestComment(reqID)
+	h.createSampleDataPrivacyRequestComment()
+	h.createSampleDataPrivacyRequestComment()
+
+	h.apiInit().
+		Get(fmt.Sprintf("/data-privacy/requests/%d/comments/", reqID)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Len(`$.response.set`, 2)).
+		End()
+}
+
+func TestDataPrivacyRequestCreateComment(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequestComments()
+
+	request := h.createSampleDataPrivacyRequest()
+	reqID := request.ID
+	comment := rs(20)
+
+	helpers.AllowMe(h, types.DataPrivacyRequestRbacResource(0), "read")
+
+	h.apiInit().
+		Post(fmt.Sprintf("/data-privacy/requests/%d/comments/", reqID)).
+		Header("Accept", "application/json").
+		FormData("comment", comment).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Present(`$.response.requestID`)).
+		Assert(jsonpath.Present(`$.response.createdAt`)).
+		Assert(jsonpath.Present(`$.response.createdBy`)).
+		Assert(jsonpath.Equal(`$.response.requestID`, cast.ToString(reqID))).
+		Assert(jsonpath.Equal(`$.response.comment`, comment)).
+		End()
+}
+
+func TestDataPrivacyRequestCreateCommentForbidden(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequestComments()
+	comment := rs(20)
+
+	h.apiInit().
+		Post(fmt.Sprintf("/data-privacy/requests/%d/comments/", id.Next())).
+		Header("Accept", "application/json").
+		FormData("comment", comment).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertError("dataPrivacy.errors.notFound")).
+		End()
+}

--- a/tests/system/data_privacy_request_test.go
+++ b/tests/system/data_privacy_request_test.go
@@ -1,0 +1,214 @@
+package system
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/service"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"github.com/cortezaproject/corteza-server/tests/helpers"
+	jsonpath "github.com/steinfletcher/apitest-jsonpath"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func (h helper) clearDataPrivacyRequests() {
+	h.noError(store.TruncateDataPrivacyRequests(context.Background(), service.DefaultStore))
+}
+
+func (h helper) createDataPrivacyRequest(kind types.RequestKind, status types.RequestStatus) *types.DataPrivacyRequest {
+	res := &types.DataPrivacyRequest{
+		ID:          id.Next(),
+		Kind:        types.RequestKindCorrect,
+		Status:      types.RequestStatusPending,
+		RequestedAt: time.Now(),
+		RequestedBy: 0,
+		CreatedAt:   time.Now(),
+	}
+
+	if len(kind) > 0 {
+		res.Kind = kind
+	}
+
+	if len(status) > 0 {
+		res.Status = status
+	}
+
+	h.a.NoError(store.CreateDataPrivacyRequest(context.Background(), service.DefaultStore, res))
+
+	return res
+}
+
+func (h helper) createSampleDataPrivacyRequest() *types.DataPrivacyRequest {
+	return h.createDataPrivacyRequest("", "")
+}
+
+func TestDataPrivacyRequestList(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	h.createSampleDataPrivacyRequest()
+	h.createSampleDataPrivacyRequest()
+
+	helpers.AllowMe(h, types.ComponentRbacResource(), "data-privacy-requests.search")
+	helpers.AllowMe(h, types.DataPrivacyRequestRbacResource(0), "read")
+
+	h.apiInit().
+		Get("/data-privacy/requests/").
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Len(`$.response.set`, 2)).
+		End()
+}
+
+func TestDataPrivacyRequestListWithPaging(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	seedCount := 40
+	for i := 0; i < seedCount; i++ {
+		h.createSampleDataPrivacyRequest()
+	}
+
+	helpers.AllowMe(h, types.ComponentRbacResource(), "data-privacy-requests.search")
+	helpers.AllowMe(h, types.DataPrivacyRequestRbacResource(0), "read")
+
+	var aux = struct {
+		Response struct {
+			Filter struct {
+				NextPage *string
+				PrevPage *string
+			}
+		}
+	}{}
+
+	h.apiInit().
+		Get("/data-privacy/requests/").
+		Query("limit", "10").
+		Query("sort", "kind,createdAt+DESC").
+		Header("Accept", "application/json").
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Present(`$.response.filter`)).
+		Assert(jsonpath.Present(`$.response.set`)).
+		Assert(jsonpath.Len(`$.response.set`, 10)).
+		Assert(jsonpath.Present(`$.response.filter.nextPage`)).
+		End().
+		JSON(&aux)
+
+	h.a.NotNil(aux.Response.Filter.NextPage)
+
+	h.apiInit().
+		Get("/data-privacy/requests/").
+		Header("Accept", "application/json").
+		Query("limit", "10").
+		Query("sort", "kind,createdAt+DESC").
+		Query("pageCursor", *aux.Response.Filter.NextPage).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(jsonpath.Len(`$.response.set`, 10)).
+		Assert(jsonpath.Present(`$.response.filter.prevPage`)).
+		Assert(jsonpath.Present(`$.response.filter.nextPage`)).
+		End().
+		JSON(&aux)
+
+	h.a.NotNil(aux.Response.Filter.PrevPage)
+	h.a.NotNil(aux.Response.Filter.NextPage)
+}
+
+func TestDataPrivacyRequestListFilters(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	h.createSampleDataPrivacyRequest()
+	h.createSampleDataPrivacyRequest()
+	h.createDataPrivacyRequest("", types.RequestStatusApproved)
+	h.createDataPrivacyRequest(types.RequestKindExport, types.RequestStatusApproved)
+
+	helpers.AllowMe(h, types.ComponentRbacResource(), "data-privacy-requests.search")
+	helpers.AllowMe(h, types.DataPrivacyRequestRbacResource(0), "read")
+
+	h.apiInit().
+		Get("/data-privacy/requests/").
+		Query("query", types.RequestStatusApproved.String()).
+		Query("kind", types.RequestKindExport.String()).
+		Query("incTotal", "true").
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Len(`$.response.set`, 1)).
+		End()
+}
+
+func TestDataPrivacyRequestRead(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	client := h.createSampleDataPrivacyRequest()
+
+	helpers.AllowMe(h, types.DataPrivacyRequestRbacResource(0), "read")
+
+	h.apiInit().
+		Getf("/data-privacy/requests/%d", client.ID).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		End()
+}
+
+func TestDataPrivacyRequestCreate(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	helpers.AllowMe(h, types.ComponentRbacResource(), "data-privacy-request.create")
+
+	h.apiInit().
+		Post("/data-privacy/requests/").
+		Header("Accept", "application/json").
+		FormData("kind", "correct").
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Present(`$.response.requestID`)).
+		Assert(jsonpath.Equal(`$.response.kind`, types.RequestKindCorrect.String())).
+		Assert(jsonpath.Equal(`$.response.status`, types.RequestStatusPending.String())).
+		End()
+}
+
+func TestDataPrivacyRequestUpdateStatus(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	req := h.createSampleDataPrivacyRequest()
+
+	helpers.AllowMe(h, types.DataPrivacyRequestRbacResource(0), "approve")
+
+	h.apiInit().
+		Patchf("/data-privacy/requests/%d/status/approved", req.ID).
+		Header("Accept", "application/json").
+		JSON(helpers.JSON(req)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertNoErrors).
+		Assert(jsonpath.Equal(`$.response.status`, types.RequestStatusApproved.String())).
+		End()
+}
+
+func TestDataPrivacyRequestUpdateStatusForbidden(t *testing.T) {
+	h := newHelper(t)
+	h.clearDataPrivacyRequests()
+
+	req := h.createSampleDataPrivacyRequest()
+
+	h.apiInit().
+		Patchf("/data-privacy/requests/%d/status/approved", req.ID).
+		Header("Accept", "application/json").
+		JSON(helpers.JSON(req)).
+		Expect(t).
+		Status(http.StatusOK).
+		Assert(helpers.AssertError("dataPrivacy.errors.notAllowedToApprove")).
+		End()
+}

--- a/tests/system/resource_activity_log_test.go
+++ b/tests/system/resource_activity_log_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (h helper) clearActivityLog() {
-	h.noError(store.TruncateResourceActivityLogs(context.Background(), service.DefaultStore))
+	h.noError(store.TruncateResourceActivitys(context.Background(), service.DefaultStore))
 }
 
 func (h helper) repoMakeActivityLog() *discoveryType.ResourceActivity {
@@ -22,7 +22,7 @@ func (h helper) repoMakeActivityLog() *discoveryType.ResourceActivity {
 		ResourceAction: "create",
 	}
 
-	h.a.NoError(store.CreateResourceActivityLog(context.Background(), service.DefaultStore, res))
+	h.a.NoError(store.CreateResourceActivity(context.Background(), service.DefaultStore, res))
 
 	return res
 }


### PR DESCRIPTION
Add data privacy request route and implementation

- Introduces new role for data-privacy-officer(Role allows user to manage data privacy requests)
- along with a new system resource for data privacy requests and its access control
- Routes as per access control to create data privacy request, list request and filter it based on their kind and status, and update data privacy request status

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
