### PR TITLE
Federation node url generate fix

### DIFF
--- a/app/boot_levels.go
+++ b/app/boot_levels.go
@@ -521,6 +521,7 @@ func (app *CortezaApp) InitServices(ctx context.Context) (err error) {
 		err = fedService.Initialize(ctx, app.Log, app.Store, fedService.Config{
 			ActionLog:  app.Opt.ActionLog,
 			Federation: app.Opt.Federation,
+			Server:     app.Opt.HTTPServer,
 		})
 
 		if err != nil {

--- a/federation/service/node.go
+++ b/federation/service/node.go
@@ -58,7 +58,7 @@ type (
 	}
 )
 
-func Node(s store.Storer, u service.UserService, al actionlog.Recorder, th tokenIssuer, options options.FederationOpt, ac nodeAccessController) *node {
+func Node(s store.Storer, u service.UserService, al actionlog.Recorder, th tokenIssuer, options options.FederationOpt, sopt options.HttpServerOpt, ac nodeAccessController) *node {
 	return &node{
 		store:       s,
 		sysUser:     u,
@@ -68,8 +68,7 @@ func Node(s store.Storer, u service.UserService, al actionlog.Recorder, th token
 		name:        options.Label,
 		host:        options.Host,
 
-		// @todo use HTTP_API_BASE_URL (HttpServerOpt.ApiBaseUrl) to prefix URI path
-		baseURL: "/federation",
+		baseURL: fmt.Sprintf("%s/federation", strings.TrimRight(sopt.ApiBaseUrl, "/")),
 
 		handshaker: HttpHandshake(http.DefaultClient),
 	}

--- a/federation/service/service.go
+++ b/federation/service/service.go
@@ -24,6 +24,7 @@ type (
 		ActionLog  options.ActionLogOpt
 		Storage    options.ObjectStoreOpt
 		Federation options.FederationOpt
+		Server     options.HttpServerOpt
 	}
 )
 
@@ -99,6 +100,7 @@ func Initialize(_ context.Context, log *zap.Logger, s store.Storer, c Config) (e
 			)
 		},
 		c.Federation,
+		c.Server,
 		DefaultAccessControl,
 	)
 	DefaultNodeSync = NodeSync()


### PR DESCRIPTION
Fixed federation node generation url by using the `HTTP Server API base url` as a prefix when using webapps.