### PR TITLE
Fix length check of triggers before WF exec

### DIFF
--- a/automation/service/session.go
+++ b/automation/service/session.go
@@ -171,7 +171,7 @@ func (svc *session) PendingPrompts(ctx context.Context) (pp []*wfexec.PendingPro
 //
 // Start is an asynchronous operation
 //
-// Please note that context passed to the function is NOT the the one that is
+// Please note that context passed to the function is NOT the one that is
 // used for the execution of the workflow. See watch function!
 //
 // It does not check user's permissions to execute workflow(s) so it should be used only when !

--- a/automation/service/workflow.go
+++ b/automation/service/workflow.go
@@ -570,7 +570,7 @@ func (svc *workflow) Exec(ctx context.Context, workflowID uint64, p types.Workfl
 				return nil, err
 			}
 
-			if p.StepID == 0 && len(tt) > 0 {
+			if p.StepID == 0 && len(tt) == 1 {
 				return tt[0], nil
 			} else {
 				for _, tMatch := range tt {


### PR DESCRIPTION
It fixes issue with multiple triggers in same WF but only one trigger having child steps and other triggers without any child, so it was using first trigger fetched from store as execution step(trigger).

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
