### PR TITLE
Add filters to permissions route for role

### DIFF
--- a/automation/rest.yaml
+++ b/automation/rest.yaml
@@ -276,6 +276,7 @@ endpoints:
   - Client ID
   - Session ID
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/filter
     - github.com/cortezaproject/corteza-server/pkg/rbac
   apis:
   - name: list
@@ -318,6 +319,15 @@ endpoints:
         type: uint64
         required: true
         title: Role ID
+      get:
+      - name: specific
+        required: false
+        title: Exclude (0, default), include (1) or return only (2) specific rules
+        type: "filter.State"
+      - name: resource
+        type: "[]string"
+        required: false
+        title: Show only rules for a specific resource
   - name: delete
     path: "/{roleID}/rules"
     method: DELETE

--- a/automation/rest/permissions.go
+++ b/automation/rest/permissions.go
@@ -2,11 +2,11 @@ package rest
 
 import (
 	"context"
-
 	"github.com/cortezaproject/corteza-server/automation/rest/request"
 	"github.com/cortezaproject/corteza-server/automation/service"
 	"github.com/cortezaproject/corteza-server/automation/types"
 	"github.com/cortezaproject/corteza-server/pkg/api"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 )
 
@@ -20,6 +20,7 @@ type (
 		Trace(context.Context, uint64, []uint64, ...string) ([]*rbac.Trace, error)
 		List() []map[string]string
 		FindRulesByRoleID(context.Context, uint64) (rbac.RuleSet, error)
+		FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (rbac.RuleSet, error)
 		Grant(ctx context.Context, rr ...*rbac.Rule) error
 	}
 )
@@ -43,7 +44,7 @@ func (ctrl Permissions) List(ctx context.Context, r *request.PermissionsList) (i
 }
 
 func (ctrl Permissions) Read(ctx context.Context, r *request.PermissionsRead) (interface{}, error) {
-	return ctrl.ac.FindRulesByRoleID(ctx, r.RoleID)
+	return ctrl.ac.FindRules(ctx, r.RoleID, r.Specific, r.Resource...)
 }
 
 func (ctrl Permissions) Delete(ctx context.Context, r *request.PermissionsDelete) (interface{}, error) {

--- a/automation/service/access_control.gen.go
+++ b/automation/service/access_control.gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cortezaproject/corteza-server/automation/types"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
 	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	systemTypes "github.com/cortezaproject/corteza-server/system/types"
 	"github.com/spf13/cast"
@@ -257,6 +258,55 @@ func (svc accessControl) logGrants(ctx context.Context, rr []*rbac.Rule) {
 
 		svc.actionlog.Record(ctx, g.ToAction())
 	}
+}
+
+// FindRules find all rules based on filters
+//
+// This function is auto-generated
+func (svc accessControl) FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (out rbac.RuleSet, err error) {
+	if !svc.CanGrant(ctx) {
+		return nil, AccessControlErrNotAllowedToSetPermissions()
+	}
+
+	rules, err := svc.FindRulesByRoleID(ctx, roleID)
+	if err != nil {
+		return
+	}
+
+	// Filter based on resource
+	if len(rr) > 0 {
+		ruleMap := make(map[string]bool)
+		uniqRuleID := func(r *rbac.Rule) string {
+			return fmt.Sprintf("%s|%s|%d", r.Resource, r.Operation, r.RoleID)
+		}
+		for _, r := range rr {
+			if err = rbacResourceValidator(r); err != nil {
+				return nil, fmt.Errorf("can not use resource %q: %w", r, err)
+			}
+
+			res := rbac.NewResource(r)
+			for _, rule := range rules.FilterResource(res.RbacResource()) {
+				if _, ok := ruleMap[uniqRuleID(rule)]; !ok {
+					out = append(out, rule)
+					ruleMap[uniqRuleID(rule)] = true
+				}
+			}
+		}
+	} else {
+		out = append(out, rules...)
+	}
+
+	// Filter for Excluded, Include, or Exclusive specific rules
+	switch specific {
+	// Exclude all the specific rules
+	case filter.StateExcluded:
+		out = out.FilterRules(false)
+	// Returns only all the specific rules
+	case filter.StateExclusive:
+		out = out.FilterRules(true)
+	}
+
+	return
 }
 
 // FindRulesByRoleID find all rules for a specific role

--- a/compose/rest.yaml
+++ b/compose/rest.yaml
@@ -1291,6 +1291,7 @@ endpoints:
   - Client ID
   - Session ID
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/filter
     - github.com/cortezaproject/corteza-server/pkg/rbac
   apis:
   - name: list
@@ -1333,6 +1334,15 @@ endpoints:
         type: uint64
         required: true
         title: Role ID
+      get:
+      - name: specific
+        required: false
+        title: Exclude (0, default), include (1) or return only (2) specific rules
+        type: "filter.State"
+      - name: resource
+        type: "[]string"
+        required: false
+        title: Show only rules for a specific resource
   - name: delete
     path: "/{roleID}/rules"
     method: DELETE

--- a/compose/rest/permissions.go
+++ b/compose/rest/permissions.go
@@ -2,11 +2,11 @@ package rest
 
 import (
 	"context"
-
 	"github.com/cortezaproject/corteza-server/compose/rest/request"
 	"github.com/cortezaproject/corteza-server/compose/service"
 	"github.com/cortezaproject/corteza-server/compose/types"
 	"github.com/cortezaproject/corteza-server/pkg/api"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 )
 
@@ -20,6 +20,7 @@ type (
 		Trace(context.Context, uint64, []uint64, ...string) ([]*rbac.Trace, error)
 		List() []map[string]string
 		FindRulesByRoleID(context.Context, uint64) (rbac.RuleSet, error)
+		FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (rbac.RuleSet, error)
 		Grant(ctx context.Context, rr ...*rbac.Rule) error
 	}
 )
@@ -43,7 +44,7 @@ func (ctrl Permissions) List(ctx context.Context, r *request.PermissionsList) (i
 }
 
 func (ctrl Permissions) Read(ctx context.Context, r *request.PermissionsRead) (interface{}, error) {
-	return ctrl.ac.FindRulesByRoleID(ctx, r.RoleID)
+	return ctrl.ac.FindRules(ctx, r.RoleID, r.Specific, r.Resource...)
 }
 
 func (ctrl Permissions) Delete(ctx context.Context, r *request.PermissionsDelete) (interface{}, error) {

--- a/compose/service/access_control.gen.go
+++ b/compose/service/access_control.gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cortezaproject/corteza-server/compose/types"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
 	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	systemTypes "github.com/cortezaproject/corteza-server/system/types"
 	"github.com/spf13/cast"
@@ -367,6 +368,55 @@ func (svc accessControl) logGrants(ctx context.Context, rr []*rbac.Rule) {
 
 		svc.actionlog.Record(ctx, g.ToAction())
 	}
+}
+
+// FindRules find all rules based on filters
+//
+// This function is auto-generated
+func (svc accessControl) FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (out rbac.RuleSet, err error) {
+	if !svc.CanGrant(ctx) {
+		return nil, AccessControlErrNotAllowedToSetPermissions()
+	}
+
+	rules, err := svc.FindRulesByRoleID(ctx, roleID)
+	if err != nil {
+		return
+	}
+
+	// Filter based on resource
+	if len(rr) > 0 {
+		ruleMap := make(map[string]bool)
+		uniqRuleID := func(r *rbac.Rule) string {
+			return fmt.Sprintf("%s|%s|%d", r.Resource, r.Operation, r.RoleID)
+		}
+		for _, r := range rr {
+			if err = rbacResourceValidator(r); err != nil {
+				return nil, fmt.Errorf("can not use resource %q: %w", r, err)
+			}
+
+			res := rbac.NewResource(r)
+			for _, rule := range rules.FilterResource(res.RbacResource()) {
+				if _, ok := ruleMap[uniqRuleID(rule)]; !ok {
+					out = append(out, rule)
+					ruleMap[uniqRuleID(rule)] = true
+				}
+			}
+		}
+	} else {
+		out = append(out, rules...)
+	}
+
+	// Filter for Excluded, Include, or Exclusive specific rules
+	switch specific {
+	// Exclude all the specific rules
+	case filter.StateExcluded:
+		out = out.FilterRules(false)
+	// Returns only all the specific rules
+	case filter.StateExclusive:
+		out = out.FilterRules(true)
+	}
+
+	return
 }
 
 // FindRulesByRoleID find all rules for a specific role

--- a/federation/rest.yaml
+++ b/federation/rest.yaml
@@ -503,6 +503,7 @@ endpoints:
     - Client ID
     - Session ID
     imports:
+      - github.com/cortezaproject/corteza-server/pkg/filter
       - github.com/cortezaproject/corteza-server/pkg/rbac
     apis:
     - name: list
@@ -545,6 +546,15 @@ endpoints:
           type: uint64
           required: true
           title: Role ID
+        get:
+        - name: specific
+          required: false
+          title: Exclude (0, default), include (1) or return only (2) specific rules
+          type: "filter.State"
+        - name: resource
+          type: "[]string"
+          required: false
+          title: Show only rules for a specific resource
     - name: delete
       path: "/{roleID}/rules"
       method: DELETE

--- a/federation/rest/permissions.go
+++ b/federation/rest/permissions.go
@@ -2,11 +2,11 @@ package rest
 
 import (
 	"context"
-
 	"github.com/cortezaproject/corteza-server/federation/rest/request"
 	"github.com/cortezaproject/corteza-server/federation/service"
 	"github.com/cortezaproject/corteza-server/federation/types"
 	"github.com/cortezaproject/corteza-server/pkg/api"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 )
 
@@ -20,6 +20,7 @@ type (
 		Trace(context.Context, uint64, []uint64, ...string) ([]*rbac.Trace, error)
 		List() []map[string]string
 		FindRulesByRoleID(context.Context, uint64) (rbac.RuleSet, error)
+		FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (rbac.RuleSet, error)
 		Grant(ctx context.Context, rr ...*rbac.Rule) error
 	}
 )
@@ -43,7 +44,7 @@ func (ctrl Permissions) List(ctx context.Context, r *request.PermissionsList) (i
 }
 
 func (ctrl Permissions) Read(ctx context.Context, r *request.PermissionsRead) (interface{}, error) {
-	return ctrl.ac.FindRulesByRoleID(ctx, r.RoleID)
+	return ctrl.ac.FindRules(ctx, r.RoleID, r.Specific, r.Resource...)
 }
 
 func (ctrl Permissions) Delete(ctx context.Context, r *request.PermissionsDelete) (interface{}, error) {

--- a/federation/service/access_control.gen.go
+++ b/federation/service/access_control.gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cortezaproject/corteza-server/federation/types"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
 	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	systemTypes "github.com/cortezaproject/corteza-server/system/types"
 	"github.com/spf13/cast"
@@ -244,6 +245,55 @@ func (svc accessControl) logGrants(ctx context.Context, rr []*rbac.Rule) {
 
 		svc.actionlog.Record(ctx, g.ToAction())
 	}
+}
+
+// FindRules find all rules based on filters
+//
+// This function is auto-generated
+func (svc accessControl) FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (out rbac.RuleSet, err error) {
+	if !svc.CanGrant(ctx) {
+		return nil, AccessControlErrNotAllowedToSetPermissions()
+	}
+
+	rules, err := svc.FindRulesByRoleID(ctx, roleID)
+	if err != nil {
+		return
+	}
+
+	// Filter based on resource
+	if len(rr) > 0 {
+		ruleMap := make(map[string]bool)
+		uniqRuleID := func(r *rbac.Rule) string {
+			return fmt.Sprintf("%s|%s|%d", r.Resource, r.Operation, r.RoleID)
+		}
+		for _, r := range rr {
+			if err = rbacResourceValidator(r); err != nil {
+				return nil, fmt.Errorf("can not use resource %q: %w", r, err)
+			}
+
+			res := rbac.NewResource(r)
+			for _, rule := range rules.FilterResource(res.RbacResource()) {
+				if _, ok := ruleMap[uniqRuleID(rule)]; !ok {
+					out = append(out, rule)
+					ruleMap[uniqRuleID(rule)] = true
+				}
+			}
+		}
+	} else {
+		out = append(out, rules...)
+	}
+
+	// Filter for Excluded, Include, or Exclusive specific rules
+	switch specific {
+	// Exclude all the specific rules
+	case filter.StateExcluded:
+		out = out.FilterRules(false)
+	// Returns only all the specific rules
+	case filter.StateExclusive:
+		out = out.FilterRules(true)
+	}
+
+	return
 }
 
 // FindRulesByRoleID find all rules for a specific role

--- a/pkg/codegen/rest.go
+++ b/pkg/codegen/rest.go
@@ -220,6 +220,8 @@ func (d *restEndpointParamDef) Parser(arg string) string {
 		return fmt.Sprintf("payload.Parse%s(%s), nil", export(d.Type), arg)
 	case "string", "[]string":
 		return fmt.Sprintf("%s, nil", arg)
+	case "filter.State":
+		return fmt.Sprintf("payload.ParseFilterState(%s), nil", arg)
 	default:
 		return fmt.Sprintf("%s(%s), nil", d.Type, arg)
 	}

--- a/pkg/payload/util.go
+++ b/pkg/payload/util.go
@@ -2,6 +2,7 @@ package payload
 
 import (
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/jmoiron/sqlx/types"
 	"github.com/spf13/cast"
 	"strconv"
@@ -99,4 +100,8 @@ func ParseInt64(s string) int64 {
 // parseUInt64 parses a string to uint64
 func ParseBool(s string) bool {
 	return cast.ToBool(s)
+}
+
+func ParseFilterState(s string) filter.State {
+	return filter.State(cast.ToUint(s))
 }

--- a/pkg/payload/util_test.go
+++ b/pkg/payload/util_test.go
@@ -1,0 +1,50 @@
+package payload
+
+import (
+	"github.com/cortezaproject/corteza-server/pkg/filter"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParseFilterState(t *testing.T) {
+	var (
+		req = require.New(t)
+	)
+	tests := []struct {
+		name     string
+		input    string
+		expected filter.State
+	}{
+		{
+			"invalid string should be Excluded",
+			"zero",
+			filter.StateExcluded,
+		},
+		{
+			"empty string should be Excluded",
+			"0",
+			filter.StateExcluded,
+		},
+		{
+			"Excluded",
+			"0",
+			filter.StateExcluded,
+		},
+		{
+			"Excluded",
+			"1",
+			filter.StateInclusive,
+		},
+		{
+			"Excluded",
+			"2",
+			filter.StateExclusive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req.Equal(tt.expected, ParseFilterState(tt.input))
+		})
+	}
+}

--- a/pkg/rbac/resource.go
+++ b/pkg/rbac/resource.go
@@ -102,3 +102,29 @@ func level(r string) (score int) {
 
 	return
 }
+
+// isSpecific will return true if rule relates to a specific resource
+//
+// ns::cmp:res/xx/*    returns true
+// ns::cmp:res/xx/xx   returns true
+// ns::cmp:res/  	   returns false
+// ns::cmp:res/*/*     returns false
+func isSpecific(r string) (out bool) {
+	out = false
+	parts := strings.Split(r, pathSep)
+	// remove resource name part
+	parts = parts[1:]
+
+	// check parts for wildcard if it's not empty otherwise return false
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+
+		if p != wildcard && !out {
+			out = true
+		}
+	}
+
+	return
+}

--- a/pkg/rbac/resource_test.go
+++ b/pkg/rbac/resource_test.go
@@ -115,3 +115,27 @@ func TestLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSpecific(t *testing.T) {
+	var (
+		tcc = []struct {
+			r string
+			e bool
+		}{
+			{"corteza::test/a/b/c", true},
+			{"corteza::test/a/b/*", true},
+			{"corteza::test/a/*/*", true},
+			{"corteza::test/a/*/123", true},
+			{"corteza::test/*/*/*", false},
+			{"corteza::test/*/*", false},
+			{"corteza::test/*", false},
+			{"corteza::test/", false},
+		}
+	)
+
+	for _, tc := range tcc {
+		t.Run(tc.r, func(t *testing.T) {
+			require.Equal(t, tc.e, isSpecific(tc.r))
+		})
+	}
+}

--- a/pkg/rbac/rule.go
+++ b/pkg/rbac/rule.go
@@ -71,6 +71,18 @@ func (set RuleSet) FilterResource(res string) (out RuleSet) {
 	return
 }
 
+// FilterRules will filter the rules based on given parameter(specific),
+//		If params is true then it will return only the specific rules otherwise it will return non-specific rules
+func (set RuleSet) FilterRules(specific bool) (out RuleSet) {
+	for _, r := range set {
+		if specific == isSpecific(r.Resource) {
+			out = append(out, r)
+		}
+	}
+
+	return
+}
+
 // AllowRule helper func to create allow rule
 func AllowRule(id uint64, r, o string) *Rule {
 	return &Rule{id, r, o, Allow, false}

--- a/system/rest.yaml
+++ b/system/rest.yaml
@@ -1219,6 +1219,7 @@ endpoints:
   - Client ID
   - Session ID
   imports:
+    - github.com/cortezaproject/corteza-server/pkg/filter
     - github.com/cortezaproject/corteza-server/pkg/rbac
   apis:
   - name: list
@@ -1262,6 +1263,15 @@ endpoints:
         type: uint64
         required: true
         title: Role ID
+      get:
+        - name: specific
+          required: false
+          title: Exclude (0, default), include (1) or return only (2) specific rules
+          type: "filter.State"
+        - name: resource
+          type: "[]string"
+          required: false
+          title: Show only rules for a specific resource
   - name: delete
     path: "/{roleID}/rules"
     method: DELETE

--- a/system/rest/permissions.go
+++ b/system/rest/permissions.go
@@ -2,8 +2,8 @@ package rest
 
 import (
 	"context"
-
 	"github.com/cortezaproject/corteza-server/pkg/api"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	"github.com/cortezaproject/corteza-server/system/rest/request"
 	"github.com/cortezaproject/corteza-server/system/service"
@@ -20,6 +20,7 @@ type (
 		Trace(context.Context, uint64, []uint64, ...string) ([]*rbac.Trace, error)
 		List() []map[string]string
 		FindRulesByRoleID(context.Context, uint64) (rbac.RuleSet, error)
+		FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (rbac.RuleSet, error)
 		Grant(ctx context.Context, rr ...*rbac.Rule) error
 	}
 )
@@ -43,7 +44,7 @@ func (ctrl Permissions) List(ctx context.Context, r *request.PermissionsList) (i
 }
 
 func (ctrl Permissions) Read(ctx context.Context, r *request.PermissionsRead) (interface{}, error) {
-	return ctrl.ac.FindRulesByRoleID(ctx, r.RoleID)
+	return ctrl.ac.FindRules(ctx, r.RoleID, r.Specific, r.Resource...)
 }
 
 func (ctrl Permissions) Delete(ctx context.Context, r *request.PermissionsDelete) (interface{}, error) {

--- a/system/rest/request/permissions.go
+++ b/system/rest/request/permissions.go
@@ -11,6 +11,7 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/payload"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	"github.com/go-chi/chi/v5"
@@ -66,6 +67,16 @@ type (
 		//
 		// Role ID
 		RoleID uint64 `json:",string"`
+
+		// Specific GET parameter
+		//
+		// Exclude (0, default), include (1) or return only (2) specific rules
+		Specific filter.State
+
+		// Resource GET parameter
+		//
+		// Show only rules for a specific resource
+		Resource []string
 	}
 
 	PermissionsDelete struct {
@@ -216,7 +227,9 @@ func NewPermissionsRead() *PermissionsRead {
 // Auditable returns all auditable/loggable parameters
 func (r PermissionsRead) Auditable() map[string]interface{} {
 	return map[string]interface{}{
-		"roleID": r.RoleID,
+		"roleID":   r.RoleID,
+		"specific": r.Specific,
+		"resource": r.Resource,
 	}
 }
 
@@ -225,8 +238,42 @@ func (r PermissionsRead) GetRoleID() uint64 {
 	return r.RoleID
 }
 
+// Auditable returns all auditable/loggable parameters
+func (r PermissionsRead) GetSpecific() filter.State {
+	return r.Specific
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r PermissionsRead) GetResource() []string {
+	return r.Resource
+}
+
 // Fill processes request and fills internal variables
 func (r *PermissionsRead) Fill(req *http.Request) (err error) {
+
+	{
+		// GET params
+		tmp := req.URL.Query()
+
+		if val, ok := tmp["specific"]; ok && len(val) > 0 {
+
+			r.Specific, err = payload.ParseFilterState(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+		if val, ok := tmp["resource[]"]; ok {
+			r.Resource, err = val, nil
+			if err != nil {
+				return err
+			}
+		} else if val, ok := tmp["resource"]; ok {
+			r.Resource, err = val, nil
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	{
 		var val string

--- a/system/service/access_control.gen.go
+++ b/system/service/access_control.gen.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
 	internalAuth "github.com/cortezaproject/corteza-server/pkg/auth"
+	"github.com/cortezaproject/corteza-server/pkg/filter"
 	"github.com/cortezaproject/corteza-server/pkg/rbac"
 	"github.com/cortezaproject/corteza-server/system/types"
 	systemTypes "github.com/cortezaproject/corteza-server/system/types"
@@ -574,6 +575,55 @@ func (svc accessControl) logGrants(ctx context.Context, rr []*rbac.Rule) {
 
 		svc.actionlog.Record(ctx, g.ToAction())
 	}
+}
+
+// FindRules find all rules based on filters
+//
+// This function is auto-generated
+func (svc accessControl) FindRules(ctx context.Context, roleID uint64, specific filter.State, rr ...string) (out rbac.RuleSet, err error) {
+	if !svc.CanGrant(ctx) {
+		return nil, AccessControlErrNotAllowedToSetPermissions()
+	}
+
+	rules, err := svc.FindRulesByRoleID(ctx, roleID)
+	if err != nil {
+		return
+	}
+
+	// Filter based on resource
+	if len(rr) > 0 {
+		ruleMap := make(map[string]bool)
+		uniqRuleID := func(r *rbac.Rule) string {
+			return fmt.Sprintf("%s|%s|%d", r.Resource, r.Operation, r.RoleID)
+		}
+		for _, r := range rr {
+			if err = rbacResourceValidator(r); err != nil {
+				return nil, fmt.Errorf("can not use resource %q: %w", r, err)
+			}
+
+			res := rbac.NewResource(r)
+			for _, rule := range rules.FilterResource(res.RbacResource()) {
+				if _, ok := ruleMap[uniqRuleID(rule)]; !ok {
+					out = append(out, rule)
+					ruleMap[uniqRuleID(rule)] = true
+				}
+			}
+		}
+	} else {
+		out = append(out, rules...)
+	}
+
+	// Filter for Excluded, Include, or Exclusive specific rules
+	switch specific {
+	// Exclude all the specific rules
+	case filter.StateExcluded:
+		out = out.FilterRules(false)
+	// Returns only all the specific rules
+	case filter.StateExclusive:
+		out = out.FilterRules(true)
+	}
+
+	return
 }
 
 // FindRulesByRoleID find all rules for a specific role


### PR DESCRIPTION
It allows filtering for specific rules and also the rules which are applied to the resource, and not to a specific resource.

Introduces generic methods for RuleSet and FindRules method to access_control generation template.

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
