### PR TITLE
Tweak rv sanitizer->value expression interaction

### DIFF
--- a/compose/service/values/expr_test.go
+++ b/compose/service/values/expr_test.go
@@ -2,9 +2,10 @@ package values
 
 import (
 	"context"
+	"testing"
+
 	"github.com/cortezaproject/corteza-server/compose/types"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestExpressions(t *testing.T) {
@@ -161,5 +162,18 @@ func TestExpressions(t *testing.T) {
 		req.Equal("a", new.Values.Get("f1", 0).Value)
 		req.Equal("b", new.Values.Get("f1", 1).Value)
 		req.Equal("c", new.Values.Get("f1", 2).Value)
+	})
+
+	t.Run("omit record value when expr returns null (nil)", func(t *testing.T) {
+		var (
+			req = require.New(t)
+			m   = makeModule("f1", "String", `null`)
+			r   = &types.Record{}
+			rve = &types.RecordValueErrorSet{}
+		)
+
+		Expression(ctx, m, r, nil, rve)
+		req.True(rve.IsValid())
+		req.Empty(r.Values)
 	})
 }

--- a/store/tests/dal_connections.go
+++ b/store/tests/dal_connections.go
@@ -1,10 +1,142 @@
 package tests
 
 import (
-	"github.com/cortezaproject/corteza-server/store"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/filter"
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/pkg/rand"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"github.com/stretchr/testify/require"
 )
 
 func testDalConnections(t *testing.T, s store.DalConnections) {
-	// @todo
+	var (
+		ctx = context.Background()
+		req = require.New(t)
+
+		makeNew = func(handle string) *types.DalConnection {
+			// minimum data set for new dalConnection
+			return &types.DalConnection{
+				ID:        id.Next(),
+				CreatedAt: time.Now(),
+				Handle:    handle,
+			}
+		}
+
+		truncAndCreate = func(t *testing.T) (*require.Assertions, *types.DalConnection) {
+			req := require.New(t)
+			req.NoError(s.TruncateDalConnections(ctx))
+			res := makeNew(string(rand.Bytes(10)))
+			req.NoError(s.CreateDalConnection(ctx, res))
+			return req, res
+		}
+	)
+
+	t.Run("create", func(t *testing.T) {
+		dalConnection := makeNew("DalConnectionCRUD")
+		req.NoError(s.CreateDalConnection(ctx, dalConnection))
+	})
+
+	t.Run("lookup by ID", func(t *testing.T) {
+		req, dalConnection := truncAndCreate(t)
+		fetched, err := s.LookupDalConnectionByID(ctx, dalConnection.ID)
+		req.NoError(err)
+		req.Equal(dalConnection.Handle, fetched.Handle)
+		req.Equal(dalConnection.ID, fetched.ID)
+		req.NotNil(fetched.CreatedAt)
+		req.Nil(fetched.UpdatedAt)
+		req.Nil(fetched.DeletedAt)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		req, dalConnection := truncAndCreate(t)
+		dalConnection.Handle = "DalConnectionCRUD-2"
+
+		req.NoError(s.UpdateDalConnection(ctx, dalConnection))
+
+		updated, err := s.LookupDalConnectionByID(ctx, dalConnection.ID)
+		req.NoError(err)
+		req.Equal(dalConnection.Handle, updated.Handle)
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		t.Run("existing", func(t *testing.T) {
+			req, dalConnection := truncAndCreate(t)
+			dalConnection.Handle = "DalConnectionCRUD-2"
+
+			req.NoError(s.UpsertDalConnection(ctx, dalConnection))
+
+			updated, err := s.LookupDalConnectionByID(ctx, dalConnection.ID)
+			req.NoError(err)
+			req.Equal(dalConnection.Handle, updated.Handle)
+		})
+
+		t.Run("new", func(t *testing.T) {
+			dalConnection := makeNew("upsert me")
+			dalConnection.Handle = "ComposeChartCRUD-2"
+
+			req.NoError(s.UpsertDalConnection(ctx, dalConnection))
+
+			upserted, err := s.LookupDalConnectionByID(ctx, dalConnection.ID)
+			req.NoError(err)
+			req.Equal(dalConnection.Handle, upserted.Handle)
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Run("by DalConnection", func(t *testing.T) {
+			req, dalConnection := truncAndCreate(t)
+			req.NoError(s.DeleteDalConnection(ctx, dalConnection))
+			_, err := s.LookupDalConnectionByID(ctx, dalConnection.ID)
+			req.EqualError(err, store.ErrNotFound.Error())
+		})
+
+		t.Run("by ID", func(t *testing.T) {
+			req, dalConnection := truncAndCreate(t)
+			req.NoError(s.DeleteDalConnectionByID(ctx, dalConnection.ID))
+			_, err := s.LookupDalConnectionByID(ctx, dalConnection.ID)
+			req.EqualError(err, store.ErrNotFound.Error())
+		})
+	})
+
+	t.Run("search", func(t *testing.T) {
+		prefill := []*types.DalConnection{
+			makeNew("/one-one"),
+			makeNew("/one-two"),
+			makeNew("/two-one"),
+			makeNew("/two-two"),
+			makeNew("/two-deleted"),
+		}
+
+		count := len(prefill)
+
+		prefill[4].DeletedAt = &prefill[4].CreatedAt
+		valid := count - 1
+
+		req.NoError(s.TruncateDalConnections(ctx))
+		req.NoError(s.CreateDalConnection(ctx, prefill...))
+
+		// search for all valid
+		set, _, err := s.SearchDalConnections(ctx, types.DalConnectionFilter{})
+		req.NoError(err)
+		req.Len(set, valid) // we've deleted one
+
+		// search for ALL
+		set, _, err = s.SearchDalConnections(ctx, types.DalConnectionFilter{Deleted: filter.StateInclusive})
+		req.NoError(err)
+		req.Len(set, count) // we've deleted one
+
+		// search for deleted only
+		set, _, err = s.SearchDalConnections(ctx, types.DalConnectionFilter{Deleted: filter.StateExclusive})
+		req.NoError(err)
+		req.Len(set, 1) // we've deleted one
+
+		set, _, err = s.SearchDalConnections(ctx, types.DalConnectionFilter{Handle: "/two-one"})
+		req.NoError(err)
+		req.Len(set, 1)
+	})
 }

--- a/store/tests/dal_sensitivity_levels.go
+++ b/store/tests/dal_sensitivity_levels.go
@@ -1,10 +1,138 @@
 package tests
 
 import (
-	"github.com/cortezaproject/corteza-server/store"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/filter"
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/pkg/rand"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"github.com/stretchr/testify/require"
 )
 
 func testDalSensitivityLevels(t *testing.T, s store.DalSensitivityLevels) {
-	// @todo
+	var (
+		ctx = context.Background()
+		req = require.New(t)
+
+		makeNew = func(handle string) *types.DalSensitivityLevel {
+			// minimum data set for new dalSensitivityLevel
+			return &types.DalSensitivityLevel{
+				ID:        id.Next(),
+				CreatedAt: time.Now(),
+				Handle:    handle,
+			}
+		}
+
+		truncAndCreate = func(t *testing.T) (*require.Assertions, *types.DalSensitivityLevel) {
+			req := require.New(t)
+			req.NoError(s.TruncateDalSensitivityLevels(ctx))
+			res := makeNew(string(rand.Bytes(10)))
+			req.NoError(s.CreateDalSensitivityLevel(ctx, res))
+			return req, res
+		}
+	)
+
+	t.Run("create", func(t *testing.T) {
+		dalSensitivityLevel := makeNew("DalSensitivityLevelCRUD")
+		req.NoError(s.CreateDalSensitivityLevel(ctx, dalSensitivityLevel))
+	})
+
+	t.Run("lookup by ID", func(t *testing.T) {
+		req, dalSensitivityLevel := truncAndCreate(t)
+		fetched, err := s.LookupDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID)
+		req.NoError(err)
+		req.Equal(dalSensitivityLevel.Handle, fetched.Handle)
+		req.Equal(dalSensitivityLevel.ID, fetched.ID)
+		req.NotNil(fetched.CreatedAt)
+		req.Nil(fetched.UpdatedAt)
+		req.Nil(fetched.DeletedAt)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		req, dalSensitivityLevel := truncAndCreate(t)
+		dalSensitivityLevel.Handle = "DalSensitivityLevelCRUD-2"
+
+		req.NoError(s.UpdateDalSensitivityLevel(ctx, dalSensitivityLevel))
+
+		updated, err := s.LookupDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID)
+		req.NoError(err)
+		req.Equal(dalSensitivityLevel.Handle, updated.Handle)
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		t.Run("existing", func(t *testing.T) {
+			req, dalSensitivityLevel := truncAndCreate(t)
+			dalSensitivityLevel.Handle = "DalSensitivityLevelCRUD-2"
+
+			req.NoError(s.UpsertDalSensitivityLevel(ctx, dalSensitivityLevel))
+
+			updated, err := s.LookupDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID)
+			req.NoError(err)
+			req.Equal(dalSensitivityLevel.Handle, updated.Handle)
+		})
+
+		t.Run("new", func(t *testing.T) {
+			dalSensitivityLevel := makeNew("upsert me")
+			dalSensitivityLevel.Handle = "ComposeChartCRUD-2"
+
+			req.NoError(s.UpsertDalSensitivityLevel(ctx, dalSensitivityLevel))
+
+			upserted, err := s.LookupDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID)
+			req.NoError(err)
+			req.Equal(dalSensitivityLevel.Handle, upserted.Handle)
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Run("by DalSensitivityLevel", func(t *testing.T) {
+			req, dalSensitivityLevel := truncAndCreate(t)
+			req.NoError(s.DeleteDalSensitivityLevel(ctx, dalSensitivityLevel))
+			_, err := s.LookupDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID)
+			req.EqualError(err, store.ErrNotFound.Error())
+		})
+
+		t.Run("by ID", func(t *testing.T) {
+			req, dalSensitivityLevel := truncAndCreate(t)
+			req.NoError(s.DeleteDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID))
+			_, err := s.LookupDalSensitivityLevelByID(ctx, dalSensitivityLevel.ID)
+			req.EqualError(err, store.ErrNotFound.Error())
+		})
+	})
+
+	t.Run("search", func(t *testing.T) {
+		prefill := []*types.DalSensitivityLevel{
+			makeNew("/one-one"),
+			makeNew("/one-two"),
+			makeNew("/two-one"),
+			makeNew("/two-two"),
+			makeNew("/two-deleted"),
+		}
+
+		count := len(prefill)
+
+		prefill[4].DeletedAt = &prefill[4].CreatedAt
+		valid := count - 1
+
+		req.NoError(s.TruncateDalSensitivityLevels(ctx))
+		req.NoError(s.CreateDalSensitivityLevel(ctx, prefill...))
+
+		// search for all valid
+		set, _, err := s.SearchDalSensitivityLevels(ctx, types.DalSensitivityLevelFilter{})
+		req.NoError(err)
+		req.Len(set, valid) // we've deleted one
+
+		// search for ALL
+		set, _, err = s.SearchDalSensitivityLevels(ctx, types.DalSensitivityLevelFilter{Deleted: filter.StateInclusive})
+		req.NoError(err)
+		req.Len(set, count) // we've deleted one
+
+		// search for deleted only
+		set, _, err = s.SearchDalSensitivityLevels(ctx, types.DalSensitivityLevelFilter{Deleted: filter.StateExclusive})
+		req.NoError(err)
+		req.Len(set, 1) // we've deleted one
+	})
 }

--- a/store/tests/data_privacy_request_comments.go
+++ b/store/tests/data_privacy_request_comments.go
@@ -1,10 +1,97 @@
 package tests
 
 import (
-	"github.com/cortezaproject/corteza-server/store"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/pkg/rand"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"github.com/stretchr/testify/require"
 )
 
 func testDataPrivacyRequestComments(t *testing.T, s store.DataPrivacyRequestComments) {
-	// @todo
+	var (
+		ctx = context.Background()
+		req = require.New(t)
+
+		makeNew = func(handle string) *types.DataPrivacyRequestComment {
+			// minimum data set for new dataPrivacyRequestComment
+			return &types.DataPrivacyRequestComment{
+				ID:        id.Next(),
+				CreatedAt: time.Now(),
+			}
+		}
+
+		truncAndCreate = func(t *testing.T) (*require.Assertions, *types.DataPrivacyRequestComment) {
+			req := require.New(t)
+			req.NoError(s.TruncateDataPrivacyRequestComments(ctx))
+			res := makeNew(string(rand.Bytes(10)))
+			req.NoError(s.CreateDataPrivacyRequestComment(ctx, res))
+			return req, res
+		}
+	)
+
+	t.Run("create", func(t *testing.T) {
+		dataPrivacyRequestComment := makeNew("DataPrivacyRequestCommentCRUD")
+		req.NoError(s.CreateDataPrivacyRequestComment(ctx, dataPrivacyRequestComment))
+	})
+
+	t.Run("update", func(t *testing.T) {
+		req, dataPrivacyRequestComment := truncAndCreate(t)
+		dataPrivacyRequestComment.Comment = "DataPrivacyRequestCommentCRUD-2"
+
+		req.NoError(s.UpdateDataPrivacyRequestComment(ctx, dataPrivacyRequestComment))
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		t.Run("existing", func(t *testing.T) {
+			req, dataPrivacyRequestComment := truncAndCreate(t)
+			dataPrivacyRequestComment.Comment = "DataPrivacyRequestCommentCRUD-2"
+
+			req.NoError(s.UpsertDataPrivacyRequestComment(ctx, dataPrivacyRequestComment))
+		})
+
+		t.Run("new", func(t *testing.T) {
+			dataPrivacyRequestComment := makeNew("upsert me")
+			dataPrivacyRequestComment.Comment = "ComposeChartCRUD-2"
+
+			req.NoError(s.UpsertDataPrivacyRequestComment(ctx, dataPrivacyRequestComment))
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Run("by DataPrivacyRequestComment", func(t *testing.T) {
+			req, dataPrivacyRequestComment := truncAndCreate(t)
+			req.NoError(s.DeleteDataPrivacyRequestComment(ctx, dataPrivacyRequestComment))
+		})
+
+		t.Run("by ID", func(t *testing.T) {
+			req, dataPrivacyRequestComment := truncAndCreate(t)
+			req.NoError(s.DeleteDataPrivacyRequestCommentByID(ctx, dataPrivacyRequestComment.ID))
+		})
+	})
+
+	t.Run("search", func(t *testing.T) {
+		prefill := []*types.DataPrivacyRequestComment{
+			makeNew("/one-one"),
+			makeNew("/one-two"),
+			makeNew("/two-one"),
+			makeNew("/two-two"),
+			makeNew("/two-yes"),
+		}
+
+		count := len(prefill)
+		valid := count
+
+		req.NoError(s.TruncateDataPrivacyRequestComments(ctx))
+		req.NoError(s.CreateDataPrivacyRequestComment(ctx, prefill...))
+
+		// search for all valid
+		set, _, err := s.SearchDataPrivacyRequestComments(ctx, types.DataPrivacyRequestCommentFilter{})
+		req.NoError(err)
+		req.Len(set, valid) // we've deleted one
+	})
 }

--- a/store/tests/data_privacy_requests.go
+++ b/store/tests/data_privacy_requests.go
@@ -1,10 +1,130 @@
 package tests
 
 import (
-	"github.com/cortezaproject/corteza-server/store"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/cortezaproject/corteza-server/pkg/id"
+	"github.com/cortezaproject/corteza-server/pkg/rand"
+	"github.com/cortezaproject/corteza-server/store"
+	"github.com/cortezaproject/corteza-server/system/types"
+	"github.com/stretchr/testify/require"
 )
 
 func testDataPrivacyRequests(t *testing.T, s store.DataPrivacyRequests) {
-	// @todo
+	var (
+		ctx = context.Background()
+		req = require.New(t)
+
+		makeNew = func(handle string) *types.DataPrivacyRequest {
+			// minimum data set for new dataPrivacyRequest
+			return &types.DataPrivacyRequest{
+				ID:        id.Next(),
+				CreatedAt: time.Now(),
+				Kind:      types.RequestKindCorrect,
+			}
+		}
+
+		truncAndCreate = func(t *testing.T) (*require.Assertions, *types.DataPrivacyRequest) {
+			req := require.New(t)
+			req.NoError(s.TruncateDataPrivacyRequests(ctx))
+			res := makeNew(string(rand.Bytes(10)))
+			req.NoError(s.CreateDataPrivacyRequest(ctx, res))
+			return req, res
+		}
+	)
+
+	t.Run("create", func(t *testing.T) {
+		dataPrivacyRequest := makeNew("DataPrivacyRequestCRUD")
+		req.NoError(s.CreateDataPrivacyRequest(ctx, dataPrivacyRequest))
+	})
+
+	t.Run("lookup by ID", func(t *testing.T) {
+		req, dataPrivacyRequest := truncAndCreate(t)
+		fetched, err := s.LookupDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID)
+		req.NoError(err)
+		req.Equal(dataPrivacyRequest.Kind, fetched.Kind)
+		req.Equal(dataPrivacyRequest.ID, fetched.ID)
+		req.NotNil(fetched.CreatedAt)
+		req.Nil(fetched.UpdatedAt)
+		req.Nil(fetched.DeletedAt)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		req, dataPrivacyRequest := truncAndCreate(t)
+		dataPrivacyRequest.Kind = types.RequestKindDelete
+
+		req.NoError(s.UpdateDataPrivacyRequest(ctx, dataPrivacyRequest))
+
+		updated, err := s.LookupDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID)
+		req.NoError(err)
+		req.Equal(dataPrivacyRequest.Kind, updated.Kind)
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		t.Run("existing", func(t *testing.T) {
+			req, dataPrivacyRequest := truncAndCreate(t)
+			dataPrivacyRequest.Kind = types.RequestKindDelete
+
+			req.NoError(s.UpsertDataPrivacyRequest(ctx, dataPrivacyRequest))
+
+			updated, err := s.LookupDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID)
+			req.NoError(err)
+			req.Equal(dataPrivacyRequest.Kind, updated.Kind)
+		})
+
+		t.Run("new", func(t *testing.T) {
+			dataPrivacyRequest := makeNew("upsert me")
+			dataPrivacyRequest.Kind = "ComposeChartCRUD-2"
+
+			req.NoError(s.UpsertDataPrivacyRequest(ctx, dataPrivacyRequest))
+
+			upserted, err := s.LookupDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID)
+			req.NoError(err)
+			req.Equal(dataPrivacyRequest.Kind, upserted.Kind)
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Run("by DataPrivacyRequest", func(t *testing.T) {
+			req, dataPrivacyRequest := truncAndCreate(t)
+			req.NoError(s.DeleteDataPrivacyRequest(ctx, dataPrivacyRequest))
+			_, err := s.LookupDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID)
+			req.EqualError(err, store.ErrNotFound.Error())
+		})
+
+		t.Run("by ID", func(t *testing.T) {
+			req, dataPrivacyRequest := truncAndCreate(t)
+			req.NoError(s.DeleteDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID))
+			_, err := s.LookupDataPrivacyRequestByID(ctx, dataPrivacyRequest.ID)
+			req.EqualError(err, store.ErrNotFound.Error())
+		})
+	})
+
+	t.Run("search", func(t *testing.T) {
+		prefill := []*types.DataPrivacyRequest{
+			makeNew("/one-one"),
+			makeNew("/one-two"),
+			makeNew("/two-one"),
+			makeNew("/two-two"),
+		}
+
+		prefill[3].Kind = types.RequestKindDelete
+
+		count := len(prefill)
+		valid := count
+
+		req.NoError(s.TruncateDataPrivacyRequests(ctx))
+		req.NoError(s.CreateDataPrivacyRequest(ctx, prefill...))
+
+		// search for all valid
+		set, _, err := s.SearchDataPrivacyRequests(ctx, types.DataPrivacyRequestFilter{})
+		req.NoError(err)
+		req.Len(set, valid) // we've deleted one
+
+		set, _, err = s.SearchDataPrivacyRequests(ctx, types.DataPrivacyRequestFilter{Kind: []string{"delete"}})
+		req.NoError(err)
+		req.Len(set, 1)
+	})
 }


### PR DESCRIPTION
When record value expression returns null the value gets omitted.
Tweak value sanitizer logic for more consistency.
