### PR TITLE
2022.3.x-fix-module-fields-not-translated-on-lookup

### DIFF
--- a/compose/service/module.go
+++ b/compose/service/module.go
@@ -453,13 +453,16 @@ func (svc module) lookup(ctx context.Context, namespaceID uint64, lookup func(*m
 			return ModuleErrNotAllowedToRead()
 		}
 
-		svc.proc(ctx, m)
-
 		if err = loadModuleLabels(ctx, svc.store, m); err != nil {
 			return err
 		}
 
-		return loadModuleFields(ctx, svc.store, m)
+		if err = loadModuleFields(ctx, svc.store, m); err != nil {
+			return err
+		}
+
+		svc.proc(ctx, m)
+		return nil
 	}()
 
 	return m, svc.recordAction(ctx, aProps, ModuleActionLookup, err)


### PR DESCRIPTION
When fetching a module by API, the content/accepted language of the request is ignored and the ModuleFields label are not translated.

This come from the __lookup__ function in `compose/service/module.go` in wich __svc.proc__ is called before the moduleFields are loaded (with `loadModuleFields`).

To compare, __Find__ the function that list all module of a ns ( `compose/service/module.go`, L.90) call the __svc.proc__ function after loading the fields and everything is well translated in the response.