### PR TITLE
Reload only existing route on save

### DIFF
--- a/pkg/apigw/service_test.go
+++ b/pkg/apigw/service_test.go
@@ -186,3 +186,65 @@ func Test_serviceInit(t *testing.T) {
 func (h mockExistingHandler) Merge(params []byte) (types.Handler, error) {
 	return h.merge(params)
 }
+
+func Test_serviceAppendRoutes(t *testing.T) {
+	var (
+		req = require.New(t)
+
+		routes = func(rr ...*route) []*route {
+			return rr
+		}
+
+		r1 = &route{
+			method:   "GET",
+			endpoint: "/test",
+		}
+		r2 = &route{
+			method:   "POST",
+			endpoint: "/test",
+		}
+		r3 = &route{
+			method:   "PUT",
+			endpoint: "/test",
+		}
+		r4 = &route{
+			method:   "DELETE",
+			endpoint: "/test",
+		}
+		r5 = &route{
+			endpoint: "GET",
+			method:   "/test2",
+		}
+
+		tests = []struct {
+			name     string
+			ag       apigw
+			routes   []*route
+			expected []*route
+		}{
+			{
+				name: "add new",
+				ag: apigw{
+					routes: routes(r1, r2, r3),
+				},
+				routes:   routes(r4),
+				expected: routes(r1, r2, r3, r4),
+			},
+			{
+				name: "no duplicates",
+				ag: apigw{
+					routes: routes(r1, r2, r3, r4, r5),
+				},
+				routes:   routes(r1, r5),
+				expected: routes(r1, r2, r3, r4, r5),
+			},
+		}
+	)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.ag.AppendRoutes(tt.routes...)
+			req.Equal(tt.expected, tt.ag.routes)
+		})
+	}
+}

--- a/system/service/apigw_filter.go
+++ b/system/service/apigw_filter.go
@@ -95,9 +95,11 @@ func (svc *apigwFilter) Create(ctx context.Context, new *types.ApigwFilter) (q *
 
 		q = new
 
-		// send the signal to reload all routes
+		// send the signal to reload current route
 		if r.Enabled {
-			apigw.Service().Reload(ctx)
+			if err = apigw.Service().ReloadEndpoint(ctx, r.Endpoint); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -168,9 +170,11 @@ func (svc *apigwFilter) Update(ctx context.Context, upd *types.ApigwFilter) (q *
 
 		q = upd
 
-		// send the signal to reload all routes
+		// send the signal to reload current route
 		if r.Enabled {
-			apigw.Service().Reload(ctx)
+			if err = apigw.Service().ReloadEndpoint(ctx, r.Endpoint); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -210,9 +214,11 @@ func (svc *apigwFilter) DeleteByID(ctx context.Context, ID uint64) (err error) {
 			return
 		}
 
-		// send the signal to reload all routes
+		// send the signal to reload current route
 		if r.Enabled {
-			apigw.Service().Reload(ctx)
+			if err = apigw.Service().ReloadEndpoint(ctx, r.Endpoint); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -252,9 +258,11 @@ func (svc *apigwFilter) UndeleteByID(ctx context.Context, ID uint64) (err error)
 			return
 		}
 
-		// send the signal to reload all routes
+		// send the signal to reload current route
 		if r.Enabled {
-			apigw.Service().Reload(ctx)
+			if err = apigw.Service().ReloadEndpoint(ctx, r.Endpoint); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/system/service/apigw_profiler.go
+++ b/system/service/apigw_profiler.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cortezaproject/corteza-server/pkg/apigw"
 	"github.com/cortezaproject/corteza-server/pkg/apigw/profiler"
-
 	"github.com/cortezaproject/corteza-server/system/types"
 )
 

--- a/system/service/apigw_route.go
+++ b/system/service/apigw_route.go
@@ -2,10 +2,10 @@ package service
 
 import (
 	"context"
+	"github.com/cortezaproject/corteza-server/pkg/apigw"
 	"github.com/cortezaproject/corteza-server/pkg/errors"
 
 	"github.com/cortezaproject/corteza-server/pkg/actionlog"
-	"github.com/cortezaproject/corteza-server/pkg/apigw"
 	a "github.com/cortezaproject/corteza-server/pkg/auth"
 
 	"github.com/cortezaproject/corteza-server/store"
@@ -85,9 +85,9 @@ func (svc *apigwRoute) Create(ctx context.Context, new *types.ApigwRoute) (q *ty
 
 		q = new
 
-		// send the signal to reload all routes
+		// send the signal to reload new route
 		if new.Enabled {
-			if err = apigw.Service().Reload(ctx); err != nil {
+			if err = apigw.Service().ReloadEndpoint(ctx, new.Endpoint); err != nil {
 				return err
 			}
 		}
@@ -129,9 +129,16 @@ func (svc *apigwRoute) Update(ctx context.Context, upd *types.ApigwRoute) (q *ty
 
 		q = upd
 
-		// send the signal to reload all route
-		if qq.Enabled != upd.Enabled || qq.Enabled && upd.Enabled {
-			if err = apigw.Service().Reload(ctx); err != nil {
+		ags := apigw.Service()
+
+		// If method or endpoint doesn't match then attach 404 handler
+		if qq.Enabled != upd.Enabled || qq.Method != upd.Method || qq.Endpoint != upd.Endpoint {
+			ags.NotFound(ctx, qq.Method, qq.Endpoint)
+		}
+
+		// send the signal to reload updated route
+		if upd.Enabled {
+			if err = ags.ReloadEndpoint(ctx, upd.Endpoint); err != nil {
 				return err
 			}
 		}
@@ -166,11 +173,9 @@ func (svc *apigwRoute) DeleteByID(ctx context.Context, ID uint64) (err error) {
 			return
 		}
 
-		// send the signal to reload all queues
+		// send the signal to reload deleted route
 		if q.Enabled {
-			if err = apigw.Service().Reload(ctx); err != nil {
-				return err
-			}
+			apigw.Service().NotFound(ctx, q.Method, q.Endpoint)
 		}
 
 		return nil
@@ -205,7 +210,7 @@ func (svc *apigwRoute) UndeleteByID(ctx context.Context, ID uint64) (err error) 
 
 		// send the signal to reload all queues
 		if q.Enabled {
-			if err = apigw.Service().Reload(ctx); err != nil {
+			if err = apigw.Service().ReloadEndpoint(ctx, q.Endpoint); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Adds reloadByEndpoint to refresh only saved/update route as needed and for the routes no longer exist we attach the 404 handler.

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
