### PR TITLE
Fix issue #427 (respected required fields)

### DIFF
--- a/compose/service/module.go
+++ b/compose/service/module.go
@@ -1479,31 +1479,44 @@ func moduleFieldToAttribute(f *types.ModuleField) (out *dal.Attribute, err error
 
 	switch strings.ToLower(f.Kind) {
 	case "bool", "boolean":
-		at := &dal.TypeBoolean{}
+		at := &dal.TypeBoolean{
+			Nullable: !f.Required,
+		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "datetime":
 		switch {
 		case f.IsDateOnly():
-			at := &dal.TypeDate{}
+			at := &dal.TypeDate{
+				Nullable: !f.Required,
+			}
 			out = dal.FullAttribute(f.Name, at, codec)
 		case f.IsTimeOnly():
-			at := &dal.TypeTime{}
+			at := &dal.TypeTime{
+				Nullable: !f.Required,
+			}
 			out = dal.FullAttribute(f.Name, at, codec)
 		default:
-			at := &dal.TypeTimestamp{}
+			at := &dal.TypeTimestamp{
+				Nullable: !f.Required,
+			}
 			out = dal.FullAttribute(f.Name, at, codec)
 		}
 	case "email":
-		at := &dal.TypeText{Length: emailLength}
+		at := &dal.TypeText{
+			Length: emailLength,
+			Nullable: !f.Required,
+		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "file":
 		at := &dal.TypeRef{
 			RefModel: &dal.ModelRef{Resource: "corteza::system:attachment"},
+			Nullable: !f.Required,
 		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "number":
 		at := &dal.TypeNumber{
 			Precision: int(f.Options.Precision()),
+			Nullable: !f.Required,
 		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "record":
@@ -1512,16 +1525,19 @@ func moduleFieldToAttribute(f *types.ModuleField) (out *dal.Attribute, err error
 				ResourceID:   f.Options.UInt64("moduleID"),
 				ResourceType: types.ModuleResourceType,
 			},
+			Nullable: !f.Required,
 		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "select":
 		at := &dal.TypeEnum{
 			Values: f.SelectOptions(),
+			Nullable: !f.Required,
 		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "url":
 		at := &dal.TypeText{
 			Length: urlLength,
+			Nullable: !f.Required,
 		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "user":
@@ -1529,16 +1545,21 @@ func moduleFieldToAttribute(f *types.ModuleField) (out *dal.Attribute, err error
 			RefModel: &dal.ModelRef{
 				ResourceType: systemTypes.UserResourceType,
 			},
+			Nullable: !f.Required,
 		}
 		out = dal.FullAttribute(f.Name, at, codec)
 	case "geometry":
-		at := &dal.TypeGeometry{}
+		at := &dal.TypeGeometry{
+			Nullable: !f.Required,
+		}
 		out = dal.FullAttribute(f.Name, at, codec)
 		out.Filterable = false
 		out.Sortable = false
 
 	default:
-		at := &dal.TypeText{}
+		at := &dal.TypeText{
+			Nullable: !f.Required,
+		}
 		out = dal.FullAttribute(f.Name, at, codec)
 
 	}


### PR DESCRIPTION
since ModuleField's attribute "Required" was not explicitly passed as a negated value to Attribute.Type.Nullable, Attribute.Type.Nullable's default value always persisted (false). This made all columns required.

This change makes it so the ModuleField's attribute "Required" properly maps to Attribute.Type.Nullable

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
