### PR TITLE
fix: report paging

### DIFF
--- a/pkg/dal/utils.go
+++ b/pkg/dal/utils.go
@@ -348,7 +348,7 @@ func prepareGenericRowTester(f internalFilter) (_ tester, err error) {
 			}
 			pcNode.Traverse(func(a *ql.ASTNode) (bool, *ql.ASTNode, error) {
 				if a.Symbol != "" {
-					a.Symbol = strings.Replace(a.Symbol, ".", "___DLMTR___", -1)
+					a.Symbol = wrapNestedGvalIdent(a.Symbol)
 				}
 				return true, a, nil
 			})

--- a/system/service/report.go
+++ b/system/service/report.go
@@ -350,7 +350,7 @@ func (svc *report) Run(ctx context.Context, reportID uint64, dd reporting.FrameD
 		// Run the reports and produce the frames
 		// @todo this can be ran in paralel
 		for _, run := range runs {
-			func() (err error) {
+			err = func() (err error) {
 				iter, err = svc.pipelineRunner.Run(ctx, run.Pipeline)
 				if err != nil {
 					return
@@ -370,6 +370,10 @@ func (svc *report) Run(ctx context.Context, reportID uint64, dd reporting.FrameD
 				out = append(out, ff...)
 				return
 			}()
+
+			if err != nil {
+				return
+			}
 		}
 
 		return nil


### PR DESCRIPTION
## fixes

1. error of report runs is not captured
2. typo: `___DLMTR___` should be `___DLTR___`, and function `wrapNestedGvalIdent` should be used here