### PR TITLE
Fix marshal expr.Type into empty object bug

### DIFF
--- a/pkg/expr/func_json.go
+++ b/pkg/expr/func_json.go
@@ -13,6 +13,9 @@ func JsonFunctions() []gval.Language {
 }
 
 func toJSON(f interface{}) string {
+	if _, is := f.(json.Marshaler); !is {
+		f = UntypedValue(f)
+	}
 	b, _ := json.Marshal(f)
 	return string(b)
 }

--- a/pkg/expr/func_json_test.go
+++ b/pkg/expr/func_json_test.go
@@ -17,3 +17,21 @@ func Example_toJSON() {
 	// output:
 	// {"k1":{"@value":"v1","@type":"String"},"k2":{"@value":"v2","@type":"String"}}
 }
+
+func Example_kv_toJSON() {
+	var (
+		p = map[string]interface{}{
+			"kv": Must(NewKV(
+				&KV{value: map[string]string{
+					"k1": "v1",
+					"k2": "v2",
+				}},
+			)),
+		}
+	)
+
+	eval(`toJSON(kv)`, p)
+
+	// output:
+	// {"k1":"v1","k2":"v2"}
+}


### PR DESCRIPTION
When using to_json(...) marshal expr.Type into string will get empty object {} if this Type doesn't implement marshal method. 

So UntypedValue obj before json.Marshal if this obj isn't json.Marshaler.
