### PR TITLE
Fix locale error meta key

### DIFF
--- a/automation/service/access_control_actions.gen.go
+++ b/automation/service/access_control_actions.gen.go
@@ -205,7 +205,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "automation"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -239,7 +239,7 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "automation"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.notAllowedToSetPermissions"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.notAllowedToSetPermissions"),
 
 		errors.StackSkip(1),
 	)

--- a/compose/service/access_control_actions.gen.go
+++ b/compose/service/access_control_actions.gen.go
@@ -205,7 +205,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "compose"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -239,7 +239,7 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "compose"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.notAllowedToSetPermissions"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.notAllowedToSetPermissions"),
 
 		errors.StackSkip(1),
 	)

--- a/federation/service/access_control_actions.gen.go
+++ b/federation/service/access_control_actions.gen.go
@@ -205,7 +205,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -239,7 +239,7 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.notAllowedToSetPermissions"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.notAllowedToSetPermissions"),
 
 		errors.StackSkip(1),
 	)

--- a/federation/service/exposed_module_actions.gen.go
+++ b/federation/service/exposed_module_actions.gen.go
@@ -476,7 +476,7 @@ func ExposedModuleErrGeneric(mm ...*exposedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -510,7 +510,7 @@ func ExposedModuleErrNotFound(mm ...*exposedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -544,7 +544,7 @@ func ExposedModuleErrInvalidID(mm ...*exposedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -578,7 +578,7 @@ func ExposedModuleErrStaleData(mm ...*exposedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.staleData"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.staleData"),
 
 		errors.StackSkip(1),
 	)
@@ -614,7 +614,7 @@ func ExposedModuleErrNotUnique(mm ...*exposedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.notUnique"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.notUnique"),
 
 		errors.StackSkip(1),
 	)
@@ -648,7 +648,7 @@ func ExposedModuleErrNodeNotFound(mm ...*exposedModuleActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.nodeNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.nodeNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -682,7 +682,7 @@ func ExposedModuleErrComposeModuleNotFound(mm ...*exposedModuleActionProps) *err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.composeModuleNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.composeModuleNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -716,7 +716,7 @@ func ExposedModuleErrComposeNamespaceNotFound(mm ...*exposedModuleActionProps) *
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.composeNamespaceNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.composeNamespaceNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -750,7 +750,7 @@ func ExposedModuleErrRequestParametersInvalid(mm ...*exposedModuleActionProps) *
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.requestParametersInvalid"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.requestParametersInvalid"),
 
 		errors.StackSkip(1),
 	)
@@ -786,7 +786,7 @@ func ExposedModuleErrNotAllowedToCreate(mm ...*exposedModuleActionProps) *errors
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.notAllowedToCreate"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.notAllowedToCreate"),
 
 		errors.StackSkip(1),
 	)
@@ -822,7 +822,7 @@ func ExposedModuleErrNotAllowedToManage(mm ...*exposedModuleActionProps) *errors
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "exposedModule.errors.notAllowedToManage"),
+		errors.Meta(locale.ErrorMetaKey{}, "exposed-module.errors.notAllowedToManage"),
 
 		errors.StackSkip(1),
 	)

--- a/federation/service/module_mapping_actions.gen.go
+++ b/federation/service/module_mapping_actions.gen.go
@@ -372,7 +372,7 @@ func ModuleMappingErrGeneric(mm ...*moduleMappingActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -406,7 +406,7 @@ func ModuleMappingErrNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -440,7 +440,7 @@ func ModuleMappingErrComposeModuleNotFound(mm ...*moduleMappingActionProps) *err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.composeModuleNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.composeModuleNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -474,7 +474,7 @@ func ModuleMappingErrComposeNamespaceNotFound(mm ...*moduleMappingActionProps) *
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.composeNamespaceNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.composeNamespaceNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -508,7 +508,7 @@ func ModuleMappingErrFederationModuleNotFound(mm ...*moduleMappingActionProps) *
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.federationModuleNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.federationModuleNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -542,7 +542,7 @@ func ModuleMappingErrNodeNotFound(mm ...*moduleMappingActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.nodeNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.nodeNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -576,7 +576,7 @@ func ModuleMappingErrModuleMappingExists(mm ...*moduleMappingActionProps) *error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.moduleMappingExists"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.moduleMappingExists"),
 
 		errors.StackSkip(1),
 	)
@@ -612,7 +612,7 @@ func ModuleMappingErrNotAllowedToMap(mm ...*moduleMappingActionProps) *errors.Er
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "moduleMapping.errors.notAllowedToMap"),
+		errors.Meta(locale.ErrorMetaKey{}, "module-mapping.errors.notAllowedToMap"),
 
 		errors.StackSkip(1),
 	)

--- a/federation/service/node_sync_actions.gen.go
+++ b/federation/service/node_sync_actions.gen.go
@@ -252,7 +252,7 @@ func NodeSyncErrGeneric(mm ...*nodeSyncActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "nodeSync.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "node-sync.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -286,7 +286,7 @@ func NodeSyncErrNotFound(mm ...*nodeSyncActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "nodeSync.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "node-sync.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -320,7 +320,7 @@ func NodeSyncErrNodeNotFound(mm ...*nodeSyncActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "nodeSync.errors.nodeNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "node-sync.errors.nodeNotFound"),
 
 		errors.StackSkip(1),
 	)

--- a/federation/service/shared_module_actions.gen.go
+++ b/federation/service/shared_module_actions.gen.go
@@ -386,7 +386,7 @@ func SharedModuleErrGeneric(mm ...*sharedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -420,7 +420,7 @@ func SharedModuleErrNotFound(mm ...*sharedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -454,7 +454,7 @@ func SharedModuleErrInvalidID(mm ...*sharedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -488,7 +488,7 @@ func SharedModuleErrStaleData(mm ...*sharedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.staleData"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.staleData"),
 
 		errors.StackSkip(1),
 	)
@@ -524,7 +524,7 @@ func SharedModuleErrFederationSyncStructureChanged(mm ...*sharedModuleActionProp
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.federationSyncStructureChanged"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.federationSyncStructureChanged"),
 
 		errors.StackSkip(1),
 	)
@@ -560,7 +560,7 @@ func SharedModuleErrNotUnique(mm ...*sharedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.notUnique"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.notUnique"),
 
 		errors.StackSkip(1),
 	)
@@ -594,7 +594,7 @@ func SharedModuleErrNodeNotFound(mm ...*sharedModuleActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.nodeNotFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.nodeNotFound"),
 
 		errors.StackSkip(1),
 	)
@@ -630,7 +630,7 @@ func SharedModuleErrNotAllowedToCreate(mm ...*sharedModuleActionProps) *errors.E
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.notAllowedToCreate"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.notAllowedToCreate"),
 
 		errors.StackSkip(1),
 	)
@@ -666,7 +666,7 @@ func SharedModuleErrNotAllowedToManage(mm ...*sharedModuleActionProps) *errors.E
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.notAllowedToManage"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.notAllowedToManage"),
 
 		errors.StackSkip(1),
 	)
@@ -702,7 +702,7 @@ func SharedModuleErrNotAllowedToMap(mm ...*sharedModuleActionProps) *errors.Erro
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "federation"),
-		errors.Meta(locale.ErrorMetaKey{}, "sharedModule.errors.notAllowedToMap"),
+		errors.Meta(locale.ErrorMetaKey{}, "shared-module.errors.notAllowedToMap"),
 
 		errors.StackSkip(1),
 	)

--- a/pkg/codegen/assets/actions.gen.go.tpl
+++ b/pkg/codegen/assets/actions.gen.go.tpl
@@ -254,7 +254,7 @@ func {{ camelCase "" $.Service "Err" $e.Error }}(mm ... *{{ $.Service }}ActionPr
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, {{ printf "%q" $.Component }}),
-		errors.Meta(locale.ErrorMetaKey{}, "{{ $.Service }}.errors.{{ $e.Error }}"),
+		errors.Meta(locale.ErrorMetaKey{}, "{{ kebabCase $.Service }}.errors.{{ $e.Error }}"),
 
 		errors.StackSkip(1),
 	)

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -66,6 +66,7 @@ func Proc() {
 		tplBase = template.New("").
 			Funcs(map[string]interface{}{
 				"camelCase":       camelCase,
+				"kebabCase":       kebabCase,
 				"export":          export,
 				"unexport":        unexport,
 				"removePtr":       removePtr,

--- a/pkg/codegen/templating.go
+++ b/pkg/codegen/templating.go
@@ -81,6 +81,22 @@ func camelCase(pp ...string) (out string) {
 	return out
 }
 
+func kebabCase(pp string) (out string) {
+	var buf bytes.Buffer
+	for _, p := range pp {
+		if 'A' <= p && p <= 'Z' {
+			// just convert [A-Z] to _[a-z]
+			if buf.Len() > 0 {
+				buf.WriteRune('-')
+			}
+			buf.WriteRune(p - 'A' + 'a')
+		} else {
+			buf.WriteRune(p)
+		}
+	}
+	return buf.String()
+}
+
 // PubIdent returns published identifier by uppercasing
 // input, cammelcasing it and removing ident unfriendly characters
 var nonIdentChars = regexp.MustCompile(`[\s\\/]+`)

--- a/system/service/access_control_actions.gen.go
+++ b/system/service/access_control_actions.gen.go
@@ -205,7 +205,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -239,7 +239,7 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "accessControl.errors.notAllowedToSetPermissions"),
+		errors.Meta(locale.ErrorMetaKey{}, "access-control.errors.notAllowedToSetPermissions"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/apigw_filter_actions.gen.go
+++ b/system/service/apigw_filter_actions.gen.go
@@ -322,7 +322,7 @@ func ApigwFilterErrGeneric(mm ...*apigwFilterActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwFilter.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-filter.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -356,7 +356,7 @@ func ApigwFilterErrNotFound(mm ...*apigwFilterActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwFilter.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-filter.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -390,7 +390,7 @@ func ApigwFilterErrInvalidID(mm ...*apigwFilterActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwFilter.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-filter.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -424,7 +424,7 @@ func ApigwFilterErrInvalidRoute(mm ...*apigwFilterActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwFilter.errors.invalidRoute"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-filter.errors.invalidRoute"),
 
 		errors.StackSkip(1),
 	)
@@ -460,7 +460,7 @@ func ApigwFilterErrAsyncRouteTooManyProcessers(mm ...*apigwFilterActionProps) *e
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwFilter.errors.asyncRouteTooManyProcessers"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-filter.errors.asyncRouteTooManyProcessers"),
 
 		errors.StackSkip(1),
 	)
@@ -496,7 +496,7 @@ func ApigwFilterErrAsyncRouteTooManyAfterFilters(mm ...*apigwFilterActionProps) 
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwFilter.errors.asyncRouteTooManyAfterFilters"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-filter.errors.asyncRouteTooManyAfterFilters"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/apigw_route_actions.gen.go
+++ b/system/service/apigw_route_actions.gen.go
@@ -382,7 +382,7 @@ func ApigwRouteErrGeneric(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -416,7 +416,7 @@ func ApigwRouteErrNotFound(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -450,7 +450,7 @@ func ApigwRouteErrInvalidID(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -484,7 +484,7 @@ func ApigwRouteErrInvalidEndpoint(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.invalidEndpoint"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.invalidEndpoint"),
 
 		errors.StackSkip(1),
 	)
@@ -518,7 +518,7 @@ func ApigwRouteErrExistsEndpoint(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.existsEndpoint"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.existsEndpoint"),
 
 		errors.StackSkip(1),
 	)
@@ -552,7 +552,7 @@ func ApigwRouteErrAlreadyExists(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.alreadyExists"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.alreadyExists"),
 
 		errors.StackSkip(1),
 	)
@@ -588,7 +588,7 @@ func ApigwRouteErrNotAllowedToCreate(mm ...*apigwRouteActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToCreate"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToCreate"),
 
 		errors.StackSkip(1),
 	)
@@ -624,7 +624,7 @@ func ApigwRouteErrNotAllowedToRead(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToRead"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToRead"),
 
 		errors.StackSkip(1),
 	)
@@ -660,7 +660,7 @@ func ApigwRouteErrNotAllowedToSearch(mm ...*apigwRouteActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToSearch"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToSearch"),
 
 		errors.StackSkip(1),
 	)
@@ -696,7 +696,7 @@ func ApigwRouteErrNotAllowedToUpdate(mm ...*apigwRouteActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToUpdate"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToUpdate"),
 
 		errors.StackSkip(1),
 	)
@@ -732,7 +732,7 @@ func ApigwRouteErrNotAllowedToDelete(mm ...*apigwRouteActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToDelete"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToDelete"),
 
 		errors.StackSkip(1),
 	)
@@ -768,7 +768,7 @@ func ApigwRouteErrNotAllowedToUndelete(mm ...*apigwRouteActionProps) *errors.Err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToUndelete"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToUndelete"),
 
 		errors.StackSkip(1),
 	)
@@ -804,7 +804,7 @@ func ApigwRouteErrNotAllowedToExec(mm ...*apigwRouteActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "apigwRoute.errors.notAllowedToExec"),
+		errors.Meta(locale.ErrorMetaKey{}, "apigw-route.errors.notAllowedToExec"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/auth_client_actions.gen.go
+++ b/system/service/auth_client_actions.gen.go
@@ -432,7 +432,7 @@ func AuthClientErrGeneric(mm ...*authClientActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -466,7 +466,7 @@ func AuthClientErrNotFound(mm ...*authClientActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -500,7 +500,7 @@ func AuthClientErrInvalidID(mm ...*authClientActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -534,7 +534,7 @@ func AuthClientErrUnknownGrantType(mm ...*authClientActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.unknownGrantType"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.unknownGrantType"),
 
 		errors.StackSkip(1),
 	)
@@ -568,7 +568,7 @@ func AuthClientErrUnknownScope(mm ...*authClientActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.unknownScope"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.unknownScope"),
 
 		errors.StackSkip(1),
 	)
@@ -604,7 +604,7 @@ func AuthClientErrUnableToChangeDefaultClientHandle(mm ...*authClientActionProps
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.unableToChangeDefaultClientHandle"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.unableToChangeDefaultClientHandle"),
 
 		errors.StackSkip(1),
 	)
@@ -640,7 +640,7 @@ func AuthClientErrUnableToDisableDefaultClient(mm ...*authClientActionProps) *er
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.unableToDisableDefaultClient"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.unableToDisableDefaultClient"),
 
 		errors.StackSkip(1),
 	)
@@ -676,7 +676,7 @@ func AuthClientErrUnableToDeleteDefaultClient(mm ...*authClientActionProps) *err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.unableToDeleteDefaultClient"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.unableToDeleteDefaultClient"),
 
 		errors.StackSkip(1),
 	)
@@ -712,7 +712,7 @@ func AuthClientErrNotAllowedToRead(mm ...*authClientActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notAllowedToRead"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notAllowedToRead"),
 
 		errors.StackSkip(1),
 	)
@@ -748,7 +748,7 @@ func AuthClientErrNotAllowedToSearch(mm ...*authClientActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notAllowedToSearch"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notAllowedToSearch"),
 
 		errors.StackSkip(1),
 	)
@@ -784,7 +784,7 @@ func AuthClientErrNotAllowedToCreate(mm ...*authClientActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notAllowedToCreate"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notAllowedToCreate"),
 
 		errors.StackSkip(1),
 	)
@@ -820,7 +820,7 @@ func AuthClientErrNotAllowedToUpdate(mm ...*authClientActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notAllowedToUpdate"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notAllowedToUpdate"),
 
 		errors.StackSkip(1),
 	)
@@ -856,7 +856,7 @@ func AuthClientErrNotAllowedToDelete(mm ...*authClientActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notAllowedToDelete"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notAllowedToDelete"),
 
 		errors.StackSkip(1),
 	)
@@ -892,7 +892,7 @@ func AuthClientErrNotAllowedToUndelete(mm ...*authClientActionProps) *errors.Err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "authClient.errors.notAllowedToUndelete"),
+		errors.Meta(locale.ErrorMetaKey{}, "auth-client.errors.notAllowedToUndelete"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/dal_connection_actions.gen.go
+++ b/system/service/dal_connection_actions.gen.go
@@ -382,7 +382,7 @@ func DalConnectionErrGeneric(mm ...*dalConnectionActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -416,7 +416,7 @@ func DalConnectionErrNotFound(mm ...*dalConnectionActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -450,7 +450,7 @@ func DalConnectionErrInvalidID(mm ...*dalConnectionActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -484,7 +484,7 @@ func DalConnectionErrInvalidEndpoint(mm ...*dalConnectionActionProps) *errors.Er
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.invalidEndpoint"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.invalidEndpoint"),
 
 		errors.StackSkip(1),
 	)
@@ -518,7 +518,7 @@ func DalConnectionErrExistsEndpoint(mm ...*dalConnectionActionProps) *errors.Err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.existsEndpoint"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.existsEndpoint"),
 
 		errors.StackSkip(1),
 	)
@@ -552,7 +552,7 @@ func DalConnectionErrAlreadyExists(mm ...*dalConnectionActionProps) *errors.Erro
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.alreadyExists"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.alreadyExists"),
 
 		errors.StackSkip(1),
 	)
@@ -588,7 +588,7 @@ func DalConnectionErrNotAllowedToCreate(mm ...*dalConnectionActionProps) *errors
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToCreate"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToCreate"),
 
 		errors.StackSkip(1),
 	)
@@ -624,7 +624,7 @@ func DalConnectionErrNotAllowedToRead(mm ...*dalConnectionActionProps) *errors.E
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToRead"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToRead"),
 
 		errors.StackSkip(1),
 	)
@@ -660,7 +660,7 @@ func DalConnectionErrNotAllowedToSearch(mm ...*dalConnectionActionProps) *errors
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToSearch"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToSearch"),
 
 		errors.StackSkip(1),
 	)
@@ -696,7 +696,7 @@ func DalConnectionErrNotAllowedToUpdate(mm ...*dalConnectionActionProps) *errors
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToUpdate"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToUpdate"),
 
 		errors.StackSkip(1),
 	)
@@ -732,7 +732,7 @@ func DalConnectionErrNotAllowedToDelete(mm ...*dalConnectionActionProps) *errors
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToDelete"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToDelete"),
 
 		errors.StackSkip(1),
 	)
@@ -768,7 +768,7 @@ func DalConnectionErrNotAllowedToUndelete(mm ...*dalConnectionActionProps) *erro
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToUndelete"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToUndelete"),
 
 		errors.StackSkip(1),
 	)
@@ -804,7 +804,7 @@ func DalConnectionErrNotAllowedToExec(mm ...*dalConnectionActionProps) *errors.E
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalConnection.errors.notAllowedToExec"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-connection.errors.notAllowedToExec"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/dal_sensitivity_level_actions.gen.go
+++ b/system/service/dal_sensitivity_level_actions.gen.go
@@ -382,7 +382,7 @@ func DalSensitivityLevelErrGeneric(mm ...*dalSensitivityLevelActionProps) *error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -416,7 +416,7 @@ func DalSensitivityLevelErrNotFound(mm ...*dalSensitivityLevelActionProps) *erro
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -450,7 +450,7 @@ func DalSensitivityLevelErrInvalidID(mm ...*dalSensitivityLevelActionProps) *err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -484,7 +484,7 @@ func DalSensitivityLevelErrInvalidEndpoint(mm ...*dalSensitivityLevelActionProps
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.invalidEndpoint"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.invalidEndpoint"),
 
 		errors.StackSkip(1),
 	)
@@ -518,7 +518,7 @@ func DalSensitivityLevelErrExistsEndpoint(mm ...*dalSensitivityLevelActionProps)
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.existsEndpoint"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.existsEndpoint"),
 
 		errors.StackSkip(1),
 	)
@@ -552,7 +552,7 @@ func DalSensitivityLevelErrAlreadyExists(mm ...*dalSensitivityLevelActionProps) 
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.alreadyExists"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.alreadyExists"),
 
 		errors.StackSkip(1),
 	)
@@ -588,7 +588,7 @@ func DalSensitivityLevelErrNotAllowedToManage(mm ...*dalSensitivityLevelActionPr
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dalSensitivityLevel.errors.notAllowedToManage"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.notAllowedToManage"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/data_privacy_request_actions.gen.go
+++ b/system/service/data_privacy_request_actions.gen.go
@@ -369,7 +369,7 @@ func DataPrivacyErrGeneric(mm ...*dataPrivacyActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -403,7 +403,7 @@ func DataPrivacyErrNotFound(mm ...*dataPrivacyActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -437,7 +437,7 @@ func DataPrivacyErrInvalidID(mm ...*dataPrivacyActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -471,7 +471,7 @@ func DataPrivacyErrInvalidKind(mm ...*dataPrivacyActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.invalidKind"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.invalidKind"),
 
 		errors.StackSkip(1),
 	)
@@ -505,7 +505,7 @@ func DataPrivacyErrInvalidStatus(mm ...*dataPrivacyActionProps) *errors.Error {
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.invalidStatus"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.invalidStatus"),
 
 		errors.StackSkip(1),
 	)
@@ -541,7 +541,7 @@ func DataPrivacyErrNotAllowedToRead(mm ...*dataPrivacyActionProps) *errors.Error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToRead"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.notAllowedToRead"),
 
 		errors.StackSkip(1),
 	)
@@ -577,7 +577,7 @@ func DataPrivacyErrNotAllowedToSearch(mm ...*dataPrivacyActionProps) *errors.Err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToSearch"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.notAllowedToSearch"),
 
 		errors.StackSkip(1),
 	)
@@ -613,7 +613,7 @@ func DataPrivacyErrNotAllowedToCreate(mm ...*dataPrivacyActionProps) *errors.Err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToCreate"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.notAllowedToCreate"),
 
 		errors.StackSkip(1),
 	)
@@ -649,7 +649,7 @@ func DataPrivacyErrNotAllowedToApprove(mm ...*dataPrivacyActionProps) *errors.Er
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "dataPrivacy.errors.notAllowedToApprove"),
+		errors.Meta(locale.ErrorMetaKey{}, "data-privacy.errors.notAllowedToApprove"),
 
 		errors.StackSkip(1),
 	)

--- a/system/service/resource_translation_actions.gen.go
+++ b/system/service/resource_translation_actions.gen.go
@@ -422,7 +422,7 @@ func ResourceTranslationErrGeneric(mm ...*resourceTranslationActionProps) *error
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "resourceTranslation.errors.generic"),
+		errors.Meta(locale.ErrorMetaKey{}, "resource-translation.errors.generic"),
 
 		errors.StackSkip(1),
 	)
@@ -456,7 +456,7 @@ func ResourceTranslationErrNotFound(mm ...*resourceTranslationActionProps) *erro
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "resourceTranslation.errors.notFound"),
+		errors.Meta(locale.ErrorMetaKey{}, "resource-translation.errors.notFound"),
 
 		errors.StackSkip(1),
 	)
@@ -490,7 +490,7 @@ func ResourceTranslationErrInvalidID(mm ...*resourceTranslationActionProps) *err
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "resourceTranslation.errors.invalidID"),
+		errors.Meta(locale.ErrorMetaKey{}, "resource-translation.errors.invalidID"),
 
 		errors.StackSkip(1),
 	)
@@ -526,7 +526,7 @@ func ResourceTranslationErrNotAllowedToRead(mm ...*resourceTranslationActionProp
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "resourceTranslation.errors.notAllowedToRead"),
+		errors.Meta(locale.ErrorMetaKey{}, "resource-translation.errors.notAllowedToRead"),
 
 		errors.StackSkip(1),
 	)
@@ -562,7 +562,7 @@ func ResourceTranslationErrNotAllowedToSearch(mm ...*resourceTranslationActionPr
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "resourceTranslation.errors.notAllowedToSearch"),
+		errors.Meta(locale.ErrorMetaKey{}, "resource-translation.errors.notAllowedToSearch"),
 
 		errors.StackSkip(1),
 	)
@@ -598,7 +598,7 @@ func ResourceTranslationErrNotAllowedToManage(mm ...*resourceTranslationActionPr
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "resourceTranslation.errors.notAllowedToManage"),
+		errors.Meta(locale.ErrorMetaKey{}, "resource-translation.errors.notAllowedToManage"),
 
 		errors.StackSkip(1),
 	)

--- a/tests/system/apigw_test.go
+++ b/tests/system/apigw_test.go
@@ -94,7 +94,7 @@ func TestApigwRouteRead_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToRead")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToRead")).
 		End()
 }
 
@@ -157,7 +157,7 @@ func TestApigwRouteSearch_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToSearch")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToSearch")).
 		End()
 }
 
@@ -218,7 +218,7 @@ func TestApigwRouteCreate_forbidden(t *testing.T) {
 		FormData("group", "g1").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToCreate")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToCreate")).
 		End()
 }
 
@@ -257,7 +257,7 @@ func TestApigwRouteUpdate_forbidden(t *testing.T) {
 		FormData("enabled", "false").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToUpdate")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToUpdate")).
 		End()
 }
 
@@ -289,7 +289,7 @@ func TestApigwRouteDelete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToDelete")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToDelete")).
 		End()
 }
 
@@ -321,7 +321,7 @@ func TestApigwRouteUnDelete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToUndelete")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToUndelete")).
 		End()
 }
 
@@ -357,7 +357,7 @@ func TestApigwFilterRead_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToRead")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToRead")).
 		End()
 }
 
@@ -418,7 +418,7 @@ func TestApigwFilterSearch_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToRead")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToRead")).
 		End()
 }
 
@@ -499,7 +499,7 @@ func TestApigwFilterCreate_forbidden(t *testing.T) {
 		FormData("routeID", strconv.FormatUint(r.ID, 10)).
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToUpdate")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToUpdate")).
 		End()
 }
 
@@ -580,7 +580,7 @@ func TestApigwFilterUpdate_forbidden(t *testing.T) {
 		FormData("routeID", strconv.FormatUint(r.ID, 10)).
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToUpdate")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToUpdate")).
 		End()
 }
 
@@ -612,7 +612,7 @@ func TestApigwFilterDelete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToDelete")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToDelete")).
 		End()
 }
 
@@ -645,6 +645,6 @@ func TestApigwFilterUnDelete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("apigwRoute.errors.notAllowedToUndelete")).
+		Assert(helpers.AssertError("apigw-route.errors.notAllowedToUndelete")).
 		End()
 }

--- a/tests/system/dal_connection_crud_test.go
+++ b/tests/system/dal_connection_crud_test.go
@@ -107,7 +107,7 @@ func Test_dal_connection_list_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalConnection.errors.notAllowedToSearch")).
+		Assert(helpers.AssertError("dal-connection.errors.notAllowedToSearch")).
 		End()
 }
 
@@ -172,7 +172,7 @@ func Test_dal_connection_create_forbidden(t *testing.T) {
 		Header("Content-Type", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalConnection.errors.notAllowedToCreate")).
+		Assert(helpers.AssertError("dal-connection.errors.notAllowedToCreate")).
 		End()
 }
 
@@ -241,7 +241,7 @@ func Test_dal_connection_update_forbidden(t *testing.T) {
 		Body(loadScenarioRequest(t, "generic.json")).
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalConnection.errors.notAllowedToUpdate")).
+		Assert(helpers.AssertError("dal-connection.errors.notAllowedToUpdate")).
 		End()
 }
 
@@ -278,7 +278,7 @@ func Test_dal_connection_read_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalConnection.errors.notAllowedToRead")).
+		Assert(helpers.AssertError("dal-connection.errors.notAllowedToRead")).
 		End()
 }
 
@@ -315,7 +315,7 @@ func Test_dal_connection_delete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalConnection.errors.notAllowedToDelete")).
+		Assert(helpers.AssertError("dal-connection.errors.notAllowedToDelete")).
 		End()
 }
 
@@ -356,6 +356,6 @@ func Test_dal_connection_undelete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalConnection.errors.notAllowedToUndelete")).
+		Assert(helpers.AssertError("dal-connection.errors.notAllowedToUndelete")).
 		End()
 }

--- a/tests/system/dal_sensitivity_level_crud_test.go
+++ b/tests/system/dal_sensitivity_level_crud_test.go
@@ -56,7 +56,7 @@ func Test_dal_sensitivity_level_list_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalSensitivityLevel.errors.notAllowedToManage")).
+		Assert(helpers.AssertError("dal-sensitivity-level.errors.notAllowedToManage")).
 		End()
 }
 
@@ -89,7 +89,7 @@ func Test_dal_sensitivity_level_create_forbidden(t *testing.T) {
 		Header("Content-Type", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalSensitivityLevel.errors.notAllowedToManage")).
+		Assert(helpers.AssertError("dal-sensitivity-level.errors.notAllowedToManage")).
 		End()
 }
 
@@ -131,7 +131,7 @@ func Test_dal_sensitivity_level_update_forbidden(t *testing.T) {
 		Body(loadScenarioRequest(t, "generic.json")).
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalSensitivityLevel.errors.notAllowedToManage")).
+		Assert(helpers.AssertError("dal-sensitivity-level.errors.notAllowedToManage")).
 		End()
 }
 
@@ -168,7 +168,7 @@ func Test_dal_sensitivity_level_read_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalSensitivityLevel.errors.notAllowedToManage")).
+		Assert(helpers.AssertError("dal-sensitivity-level.errors.notAllowedToManage")).
 		End()
 }
 
@@ -205,7 +205,7 @@ func Test_dal_sensitivity_level_delete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalSensitivityLevel.errors.notAllowedToManage")).
+		Assert(helpers.AssertError("dal-sensitivity-level.errors.notAllowedToManage")).
 		End()
 }
 
@@ -246,6 +246,6 @@ func Test_dal_sensitivity_level_undelete_forbidden(t *testing.T) {
 		Header("Accept", "application/json").
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dalSensitivityLevel.errors.notAllowedToManage")).
+		Assert(helpers.AssertError("dal-sensitivity-level.errors.notAllowedToManage")).
 		End()
 }

--- a/tests/system/data_privacy_request_comment_test.go
+++ b/tests/system/data_privacy_request_comment_test.go
@@ -97,6 +97,6 @@ func TestDataPrivacyRequestCreateCommentForbidden(t *testing.T) {
 		FormData("comment", comment).
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dataPrivacy.errors.notFound")).
+		Assert(helpers.AssertError("data-privacy.errors.notFound")).
 		End()
 }

--- a/tests/system/data_privacy_request_test.go
+++ b/tests/system/data_privacy_request_test.go
@@ -236,6 +236,6 @@ func TestDataPrivacyRequestUpdateStatusForbidden(t *testing.T) {
 		JSON(helpers.JSON(req)).
 		Expect(t).
 		Status(http.StatusOK).
-		Assert(helpers.AssertError("dataPrivacy.errors.notAllowedToApprove")).
+		Assert(helpers.AssertError("data-privacy.errors.notAllowedToApprove")).
 		End()
 }


### PR DESCRIPTION
This will convert the locale camelCase error meta key to kebab-case to fix translation reference for converted resources.


Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
