### PR TITLE
fix(automation): session is not created

### DIFF
--- a/automation/service/session.go
+++ b/automation/service/session.go
@@ -529,7 +529,7 @@ func (svc *session) stateChangeHandler(ctx context.Context) wfexec.StateChangeHa
 
 		default:
 			// force update on every F new frames (F=sessionStateFlushFrequency) but only when stacktrace is not nil
-			update = ses.RuntimeStacktrace != nil && len(ses.RuntimeStacktrace)%sessionStateFlushFrequency == 0
+			update = ses.RuntimeStacktrace != nil && len(ses.RuntimeStacktrace)%sessionStateFlushFrequency == 1
 		}
 
 		if !update {


### PR DESCRIPTION
## Problem

Automation session is created when status changes from activate to completed through `store.UpsertAutomationSession(...)` api. It is not created when starting. So we **can not** get this session util it completes or fails.

## Fix

Call `store.CreateAutomationSession(...)` when session starts.
