### PR TITLE
Fix fetch all records when no dedup rules

### DIFF
--- a/compose/service/record.go
+++ b/compose/service/record.go
@@ -1680,7 +1680,7 @@ func (svc record) DupDetection(ctx context.Context, m *types.Module, rec *types.
 		config = m.Config.RecordDeDup
 	)
 
-	if config.Enabled {
+	if len(config.Rules) > 0 {
 		records, _, err = svc.Find(ctx, types.RecordFilter{
 			ModuleID:    m.ID,
 			NamespaceID: m.NamespaceID,


### PR DESCRIPTION
Current dedup config of module is always enable (as front-end comment).

So the better way to control dedup is rules length.
