### PR TITLE
Add support for dropdowns in physical tables

### DIFF
--- a/store/adapters/rdbms/drivers/mysql/dialect.go
+++ b/store/adapters/rdbms/drivers/mysql/dialect.go
@@ -202,6 +202,9 @@ func (mysqlDialect) AttributeToColumn(attr *dal.Attribute) (col *ddl.Column, err
 	case *dal.TypeUUID:
 		col.Type.Name = "CHAR(36)"
 
+	case *dal.TypeEnum:
+		col.Type.Name = "TEXT"
+
 	default:
 		return nil, fmt.Errorf("unsupported column type: %s ", t.Type())
 	}

--- a/store/adapters/rdbms/drivers/postgres/dialect.go
+++ b/store/adapters/rdbms/drivers/postgres/dialect.go
@@ -178,6 +178,9 @@ func (postgresDialect) AttributeToColumn(attr *dal.Attribute) (col *ddl.Column, 
 	case *dal.TypeUUID:
 		col.Type.Name = "UUID"
 
+	case *dal.TypeEnum:
+		col.Type.Name = "TEXT"
+
 	default:
 		return nil, fmt.Errorf("unsupported column type: %s ", t.Type())
 	}

--- a/store/adapters/rdbms/drivers/sqlite/dialect.go
+++ b/store/adapters/rdbms/drivers/sqlite/dialect.go
@@ -92,6 +92,7 @@ func (sqliteDialect) AttributeCast(attr *dal.Attribute, val exp.LiteralExpressio
 }
 
 func (sqliteDialect) AttributeToColumn(attr *dal.Attribute) (col *ddl.Column, err error) {
+
 	col = &ddl.Column{
 		Ident:   attr.StoreIdent(),
 		Comment: attr.Label,
@@ -152,6 +153,8 @@ func (sqliteDialect) AttributeToColumn(attr *dal.Attribute) (col *ddl.Column, er
 	case *dal.TypeUUID:
 		col.Type.Name = "CHAR(36)"
 
+	case *dal.TypeEnum:
+		col.Type.Name = "TEXT"
 	default:
 		return nil, fmt.Errorf("unsupported column type: %s ", t.Type())
 	}


### PR DESCRIPTION
Add support in mysql and postgres type converts.
Sqlite doesn't need anything. It uses text for everything.

Please take a look.

<!--
Checklist:

1. API changes have been discussed,
2. Source code must be formatted (`go fmt`),
3. Codegen shouldn't produce modified files,
4. Builds pass,
5. Tests pass,
6. Linked to relevant issues

When you are writing pull request title and describing changes, follow
commit message format in the CONTRIBUTING.md in the codebase root.

-->
