### PR TITLE
fix(rdbms): check number regex

### DIFF
--- a/store/adapters/rdbms/drivers/cast.go
+++ b/store/adapters/rdbms/drivers/cast.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	CheckID          = exp.NewLiteralExpression(`'^[0-9]+$'`)
-	CheckNumber      = exp.NewLiteralExpression(`'^[0-9]+(\.[0-9])*$'`)
+    CheckNumber      = exp.NewLiteralExpression(`'^[0-9]+(\.[0-9]+)?$'`)
 	CheckFullISO8061 = exp.NewLiteralExpression(`'^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2}(?:\.[0-9]*)?)((-([0-9]{2}):([0-9]{2})|Z)?)$'`)
 	CheckDateISO8061 = exp.NewLiteralExpression(`'^([0-9]{4})-([0-9]{2})-([0-9]{2})(T([0-9]{2}):([0-9]{2}):([0-9]{2}(?:\.[0-9]*)?)((-([0-9]{2}):([0-9]{2})|Z)?))?$'`)
 	CheckTimeISO8061 = exp.NewLiteralExpression(`'^(([0-9]{4})-([0-9]{2})-([0-9]{2}))?T([0-9]{2}):([0-9]{2}):([0-9]{2}(?:\.[0-9]*)?)((-([0-9]{2}):([0-9]{2})|Z)?)$'`)

--- a/store/adapters/rdbms/drivers/cast.go
+++ b/store/adapters/rdbms/drivers/cast.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	CheckID          = exp.NewLiteralExpression(`'^[0-9]+$'`)
-    CheckNumber      = exp.NewLiteralExpression(`'^[0-9]+(\.[0-9]+)?$'`)
+	CheckNumber      = exp.NewLiteralExpression(`'^[0-9]+(\.[0-9]+)?$'`)
 	CheckFullISO8061 = exp.NewLiteralExpression(`'^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2}(?:\.[0-9]*)?)((-([0-9]{2}):([0-9]{2})|Z)?)$'`)
 	CheckDateISO8061 = exp.NewLiteralExpression(`'^([0-9]{4})-([0-9]{2})-([0-9]{2})(T([0-9]{2}):([0-9]{2}):([0-9]{2}(?:\.[0-9]*)?)((-([0-9]{2}):([0-9]{2})|Z)?))?$'`)
 	CheckTimeISO8061 = exp.NewLiteralExpression(`'^(([0-9]{4})-([0-9]{2})-([0-9]{2}))?T([0-9]{2}):([0-9]{2}):([0-9]{2}(?:\.[0-9]*)?)((-([0-9]{2}):([0-9]{2})|Z)?)$'`)


### PR DESCRIPTION

Regex for checking number is (`'^[0-9]+(\.[0-9])*$'`), which makes floats with 2+ precision like 0.01 was not treat as a number.
 