### PR TITLE
Implement opening record page in a modal

### DIFF
--- a/client/web/compose/src/components/Common/RecordToolbar.vue
+++ b/client/web/compose/src/components/Common/RecordToolbar.vue
@@ -1,7 +1,8 @@
 <template>
   <b-container
     fluid
-    class="bg-white shadow border-top p-3"
+    :class="{'shadow border-top': !showRecordModal}"
+    class="bg-white p-3"
   >
     <b-row
       no-gutters
@@ -19,10 +20,10 @@
           @click.prevent="$emit('back')"
         >
           <font-awesome-icon
-            :icon="['fas', 'chevron-left']"
+            :icon="['fas', showRecordModal ? 'times' : 'chevron-left']"
             class="back-icon"
           />
-          {{ labels.back || $t('label.back') }}
+          {{ showRecordModal ? $t('label.close') : labels.back || $t('label.back') }}
         </b-button>
       </div>
 
@@ -172,6 +173,11 @@ export default {
     isDeleted: {
       type: Boolean,
       default: true,
+    },
+
+    showRecordModal: {
+      type: Boolean,
+      required: false,
     },
   },
 

--- a/client/web/compose/src/components/PageBlocks/RecordListBase.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListBase.vue
@@ -594,6 +594,7 @@ import { components, url } from '@cortezaproject/corteza-vue'
 import draggable from 'vuedraggable'
 import RecordListFilter from 'corteza-webapp-compose/src/components/Common/RecordListFilter'
 import ColumnPicker from 'corteza-webapp-compose/src/components/Admin/Module/Records/ColumnPicker'
+
 const { CInputSearch } = components
 
 export default {
@@ -1150,8 +1151,14 @@ export default {
         query: null,
       }
 
-      if (this.options.openInNewTab) {
+      if (this.options.recordDisplayOption === 'newTab') {
         window.open(this.$router.resolve(route).href)
+      } else if (this.options.recordDisplayOption === 'modal') {
+        this.$root.$emit('show-record-modal', {
+          moduleID: this.recordListModule.moduleID,
+          recordPageID: this.recordPageID,
+          recordID,
+        })
       } else {
         this.$router.push(route)
       }

--- a/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
@@ -250,12 +250,20 @@
         <b-form-checkbox v-model="options.selectable">
           {{ $t('recordList.selectable') }}
         </b-form-checkbox>
-        <b-form-checkbox
-          v-model="options.openInNewTab"
-        >
-          {{ $t('recordList.record.openInNewTab') }}
-        </b-form-checkbox>
       </b-form-group>
+
+      <b-form-group
+        :label="$t('recordList.record.recordDisplayOptions')"
+        :label-cols="3"
+        breakpoint="md"
+        horizontal
+      >
+        <b-form-select
+          v-model="options.recordDisplayOption"
+          :options="recordDisplayOptions"
+        />
+      </b-form-group>
+
       <b-form-group
         horizontal
         :label-cols="3"
@@ -323,6 +331,14 @@ export default {
       modules: 'module/set',
       pages: 'page/set',
     }),
+
+    recordDisplayOptions () {
+      return [
+        { value: 'sameTab', text: this.$t('recordList.record.openInSameTab') },
+        { value: 'newTab', text: this.$t('recordList.record.openInNewTab') },
+        { value: 'modal', text: this.$t('recordList.record.openInModal') },
+      ]
+    },
 
     moduleOptions () {
       return [

--- a/client/web/compose/src/components/Public/Record/Modal.vue
+++ b/client/web/compose/src/components/Public/Record/Modal.vue
@@ -1,0 +1,123 @@
+<template>
+  <b-modal
+    id="record-modal"
+    v-model="showRecordModal"
+    scrollable
+    body-class="p-0"
+    footer-class="p-0"
+    size="xl"
+    @hidden="hideModal"
+  >
+    <template #modal-title>
+      <portal-target
+        name="record-modal-header"
+      />
+    </template>
+
+    <view-record
+      :namespace="namespace"
+      :page="page"
+      :module="module"
+      :record-i-d="recordID"
+      :show-record-modal="showRecordModal"
+    />
+
+    <template #modal-footer>
+      <portal-target
+        name="record-modal-footer"
+        class="w-100 m-0"
+      />
+    </template>
+  </b-modal>
+</template>
+
+<script>
+import record from 'corteza-webapp-compose/src/mixins/record'
+import { compose } from '@cortezaproject/corteza-js'
+import ViewRecord from 'corteza-webapp-compose/src/views/Public/Pages/Records/View'
+import { mapGetters } from 'vuex'
+
+export default {
+  i18nOptions: {
+    namespaces: 'block',
+  },
+
+  name: 'RecordModal',
+
+  components: {
+    ViewRecord,
+  },
+
+  mixins: [
+    record,
+  ],
+
+  props: {
+    namespace: {
+      type: compose.Namespace,
+      required: true,
+    },
+  },
+
+  data () {
+    return {
+      showRecordModal: false,
+      recordID: null,
+      module: null,
+      page: null,
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+      getPageByID: 'page/getByID',
+    }),
+  },
+
+  created () {
+    this.$root.$on('show-record-modal', this.showModal)
+    this.showModal(this.$route.query)
+  },
+
+  beforeDestroy () {
+    this.$root.$off('show-record-modal')
+  },
+
+  methods: {
+    showModal ({ recordID, moduleID, recordPageID }) {
+      if (recordID && moduleID && recordPageID) {
+        this.recordID = recordID
+        this.module = this.getModuleByID(moduleID)
+        this.page = this.getPageByID(recordPageID)
+
+        this.showRecordModal = true
+
+        // persist the modal in the url
+        this.$router.replace({
+          query: {
+            recordID,
+            moduleID,
+            recordPageID: this.page.pageID,
+          },
+        })
+      }
+    },
+
+    hideModal () {
+      this.$router.replace({ query: { } })
+      this.recordID = null
+      this.module = null
+      this.page = null
+    },
+  },
+}
+
+</script>
+
+<style>
+#record-modal .modal-dialog {
+  height: 100%;
+  max-width: 90vw;
+}
+</style>

--- a/client/web/compose/src/mixins/record.js
+++ b/client/web/compose/src/mixins/record.js
@@ -153,6 +153,9 @@ export default {
         .then(() => {
           if (this.record.valueErrors.set) {
             this.toastWarning(this.$t('notification:record.validationWarnings'))
+          } else if (this.showRecordModal) {
+            this.inEditing = false
+            this.inCreating = false
           } else {
             this.$router.push({ name: route, params: { ...this.$route.params, recordID: this.record.recordID } })
           }

--- a/client/web/compose/src/views/Public/Pages/Records/Create.vue
+++ b/client/web/compose/src/views/Public/Pages/Records/Create.vue
@@ -30,13 +30,6 @@ export default {
     }
   },
 
-  computed: {
-    title () {
-      const { name, handle } = this.module
-      return this.$t('page:public.record.create.title', { name: name || handle, interpolation: { escapeValue: false } })
-    },
-  },
-
   created () {
     this.record = new compose.Record(this.module, { values: this.values })
 

--- a/client/web/compose/src/views/Public/Pages/Records/Edit.vue
+++ b/client/web/compose/src/views/Public/Pages/Records/Edit.vue
@@ -13,13 +13,6 @@ export default {
     }
   },
 
-  computed: {
-    title () {
-      const { name, handle } = this.module
-      return this.$t('page:public.record.edit.title', { name: name || handle, interpolation: { escapeValue: false } })
-    },
-  },
-
   methods: {
     handleBack () {
       this.$router.push({ name: 'page.record', params: { recordID: this.recordID, pageID: this.page.pageID } })

--- a/client/web/compose/src/views/Public/Pages/View.vue
+++ b/client/web/compose/src/views/Public/Pages/View.vue
@@ -62,6 +62,10 @@
       />
     </div>
 
+    <record-modal
+      :namespace="namespace"
+    />
+
     <attachment-modal />
   </div>
 </template>
@@ -69,6 +73,7 @@
 import { mapActions } from 'vuex'
 import Grid from 'corteza-webapp-compose/src/components/Public/Page/Grid'
 import AttachmentModal from 'corteza-webapp-compose/src/components/Public/Page/Attachment/Modal'
+import RecordModal from 'corteza-webapp-compose/src/components/Public/Record/Modal'
 import PageTranslator from 'corteza-webapp-compose/src/components/Admin/Page/PageTranslator'
 import { compose, NoID } from '@cortezaproject/corteza-js'
 
@@ -80,6 +85,7 @@ export default {
   components: {
     Grid,
     AttachmentModal,
+    RecordModal,
     PageTranslator,
   },
 

--- a/lib/js/src/compose/types/page-block/record-list.ts
+++ b/lib/js/src/compose/types/page-block/record-list.ts
@@ -23,6 +23,7 @@ interface Options {
   hideRecordPermissionsButton: boolean;
   allowExport: boolean;
   perPage: number;
+  recordDisplayOption: string;
 
   fullPageNavigation: boolean;
   showTotalCount: boolean;
@@ -38,6 +39,7 @@ interface Options {
   linkToParent: boolean;
 
   // Should records be opened in a new tab
+  // legacy field that has been removed but we keep it for backwards compatibility
   openInNewTab: boolean;
 
   // Are table rows selectable
@@ -66,6 +68,7 @@ const defaults: Readonly<Options> = Object.freeze({
   hideRecordPermissionsButton: true,
   allowExport: false,
   perPage: 20,
+  recordDisplayOption: 'sameTab',
 
   fullPageNavigation: true,
   showTotalCount: true,
@@ -100,7 +103,7 @@ export class PageBlockRecordList extends PageBlock {
     if (!o) return
 
     Apply(this.options, o, CortezaID, 'moduleID')
-    Apply(this.options, o, String, 'prefilter', 'presort', 'selectMode', 'positionField', 'refField')
+    Apply(this.options, o, String, 'prefilter', 'presort', 'selectMode', 'positionField', 'refField', 'recordDisplayOption')
     Apply(this.options, o, Number, 'perPage')
 
     if (o.fields) {
@@ -109,6 +112,10 @@ export class PageBlockRecordList extends PageBlock {
 
     if (o.editFields) {
       this.options.editFields = o.editFields
+    }
+
+    if (o.openInNewTab) {
+      this.options.recordDisplayOption = 'newTab'
     }
 
     Apply(this.options, o, Boolean,
@@ -129,7 +136,6 @@ export class PageBlockRecordList extends PageBlock {
       'hideRecordPermissionsButton',
       'editable',
       'draggable',
-      'openInNewTab',
       'linkToParent',
     )
 

--- a/locale/en/corteza-webapp-compose/block.yaml
+++ b/locale/en/corteza-webapp-compose/block.yaml
@@ -350,7 +350,9 @@ recordList:
     presortLabel: Presort records
     presortPlaceholder: field1 DESC, field2 ASC
     showTotalCount: Show total record count
+    openInSameTab: Open records in the same tab
     openInNewTab: Open records in a new tab
+    openInModal: Open records in a modal
     linkToParent: Link to parent record
     tooltip:
       clone: Clone record
@@ -358,6 +360,7 @@ recordList:
       undelete: Undelete record
       reminder: Reminder
       view: View record
+    recordDisplayOptions: Record display options
   recordPage: record page
   refField:
     footnote: Field that links records with the parent record


### PR DESCRIPTION
## Screenshots of the implementation

![Screenshot from 2022-11-11 13-52-31](https://user-images.githubusercontent.com/26258032/201339573-ca34dab2-e48a-4365-83a2-50f00f0baa0f.png)

![Screenshot from 2022-11-11 13-48-19](https://user-images.githubusercontent.com/26258032/201339595-92f31f45-f127-42a5-9331-8f8adb94246f.png)

## Changelog

**What was added?**

When adding a "record list" page block in the Compose page builder, a dropdown field has been added with three options:

- open record in the same tab
- open record in a new tab
- open record in a modal

The default option is to open in the same tab.

_Note: The first two options already existed and are handled gracefully, e.g. respected for existing record lists_

The new thing here is the third option - "open record in a modal". When this option is selected and the user goes to a record list page or a page that displays record lists, he can click on a specific record and it will open as a modal. From the modal, the user can do whatever he wants with the existing record (edit, delete, clone) or even add a new record.

The opened modal remains open even after the user refreshes the page for some reason. This also allow users to share links with the modal opened or closed.

**How it was added?**

In the Compose app, a root event was emitted from the RecordList component that emits an event with all the necessary information to a new modal component, which has been called from the public page. The modal is then able to display the record and its information. In order to do this, instead of using routes, the ViewRecord component is added as a child component to the modal and it receives its props from the modal itself. The  modal state (opened or closed) is persisted  after page reload by adding query params with the record data in the url. We will reuse this functionality in future tasks, since it is benefitial for UI.