### PR TITLE
Add option to close the workflow modal

### DIFF
--- a/client/web/workflow/src/components/WorkflowEditor.vue
+++ b/client/web/workflow/src/components/WorkflowEditor.vue
@@ -375,6 +375,14 @@
           </c-input-confirm>
 
           <b-button
+            v-if="workflow.workflowID === '0'"
+            variant="light"
+            @click="$router.back()"
+          >
+            {{ $t('editor:back') }}
+          </b-button>
+
+          <b-button
             variant="primary"
             data-test-id="button-save-workflow"
             class="ml-auto"


### PR DESCRIPTION
# The following changes are implemented
Added an option to close a modal that creates a workflow without  actually creating it.

# Changes in the user interface:
A back button was added that lets you escape the "Create Workflow" modal. In this way, the user can cancel the modal creation.

# Screenshots of the implementation

![image](https://user-images.githubusercontent.com/26258032/205120244-df339e7b-d7e1-4a87-a565-ec2145fb0483.png)

## Changlelog

### What was fixed
When creating a workflow, the user opens a modal with a form that he needs to submit in order to create a workflow. However, once the modal opens, there is no other way out of it except for pressing the back button on the browser.

### How was fixed
A back button was added that simulates the back button behaviour of the browser.
