### PR TITLE
update de-duplication UI on module and fields configuration pages #467

### DIFF
--- a/client/web/compose/src/components/Admin/Module/UniqueValues.vue
+++ b/client/web/compose/src/components/Admin/Module/UniqueValues.vue
@@ -1,0 +1,215 @@
+<template>
+  <div>
+    <div
+      v-for="(rule, index) in rules"
+      :key="index"
+    >
+      <hr v-if="index">
+      <div>
+        <div class="d-flex justify-content-between align-items-center">
+          <h5 v-html="$t('uniqueValueConstraint', { index: index + 1, interpolation: { escapeValue: false } })" />
+
+          <div class="px-4">
+            <c-input-confirm
+              @confirmed="rules.splice(index, 1)"
+            />
+          </div>
+        </div>
+        <b-form-checkbox
+          v-model="rule.strict"
+          switch
+          class="mt-3"
+        >
+          {{ $t("preventRecordsSave") }}
+        </b-form-checkbox>
+      </div>
+      <div class="mt-3">
+        <b-table-simple
+          v-if="rule.constraints.length > 0"
+          borderless
+        >
+          <thead>
+            <tr>
+              <th>
+                {{ $t("field") }}
+              </th>
+              <th>
+                {{ $t("type") }}
+              </th>
+              <th style="width: 250px">
+                {{ $t("valueModifiers") }}
+              </th>
+              <th style="width: 250px">
+                {{ $t("multiValues") }}
+              </th>
+            </tr>
+          </thead>
+          <tbody v-if="rule.constraints">
+            <tr
+              v-for="(constraint, consIndex) in rule.constraints"
+              :key="`constraint-${consIndex}`"
+            >
+              <td>{{ getOptionLabel(getField(constraint.attribute)) }}</td>
+              <td>{{ getField(constraint.attribute).kind }}</td>
+              <td>
+                <b-form-select
+                  v-model="constraint.modifier"
+                  :options="modifierOptions"
+                  size="sm"
+                />
+              </td>
+              <td>
+                <b-form-select
+                  v-model="constraint.multiValue"
+                  :options="multiValueOptions"
+                  :disabled="!getField(constraint.attribute).isMulti"
+                  size="sm"
+                />
+              </td>
+              <td class="text-right p-0 px-4 align-middle">
+                <c-input-confirm
+                  button-class="text-right"
+                  @confirmed="rule.constraints.splice(consIndex, 1)"
+                />
+              </td>
+            </tr>
+          </tbody>
+        </b-table-simple>
+
+        <b-form-group>
+          <b-input-group>
+            <vue-select
+              v-model="rule.currentField"
+              :placeholder="$t('searchFields')"
+              :get-option-label="getOptionLabel"
+              :options="filterFieldOptions(rule)"
+              class="bg-white"
+            />
+
+            <b-input-group-append>
+              <b-button
+                variant="primary"
+                class="px-4"
+                @click="updateRuleConstraint(rule)"
+              >
+                {{ $t("add") }}
+              </b-button>
+            </b-input-group-append>
+          </b-input-group>
+        </b-form-group>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="d-flex justify-content-end">
+      <b-button
+        size="lg"
+        variant="link"
+        class="d-flex align-items-center text-decoration-none p-0 mt-3"
+        @click="addNewConstraint"
+      >
+        <font-awesome-icon
+          :icon="['fas', 'plus']"
+          class="mr-2"
+        />
+        {{ $t("addNewConstraint") }}
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { compose } from '@cortezaproject/corteza-js'
+import { VueSelect } from 'vue-select'
+
+export default {
+  i18nOptions: {
+    namespaces: 'module',
+    keyPrefix: 'edit.config.uniqueValues',
+  },
+
+  components: {
+    VueSelect,
+  },
+
+  props: {
+    module: {
+      type: compose.Module,
+      required: true,
+    },
+  },
+
+  computed: {
+    rules: {
+      get () {
+        this.module.config.recordDeDup.rules.forEach(rule => {
+          if (rule.constraints === null) {
+            rule.constraints = []
+          }
+        })
+
+        return this.module.config.recordDeDup.rules
+      },
+      set (value) {
+        this.module.config.recordDeDup.rules = value
+      },
+    },
+
+    modifierOptions () {
+      return [
+        { value: 'ignore-case', text: this.$t('ignoreCase') },
+        { value: 'fuzzy-match', text: this.$t('fuzzyMatch') },
+        { value: 'sounds-like', text: this.$t('soundsLike') },
+        { value: 'case-sensitive', text: this.$t('caseSensitive') },
+      ]
+    },
+
+    multiValueOptions () {
+      return [
+        { value: 'one-of', text: this.$t('oneOf') },
+        { value: 'equal', text: this.$t('equal') },
+      ]
+    },
+  },
+
+  methods: {
+    addNewConstraint () {
+      this.rules.push({
+        name: '',
+        strict: true,
+        constraints: [],
+      })
+    },
+
+    updateRuleConstraint (rule) {
+      rule.constraints.push({
+        attribute: rule.currentField.name,
+        modifier: 'case-sensitive',
+        multiValue: 'equal',
+        type: rule.currentField.kind,
+        isMulti: rule.currentField.isMulti,
+      })
+
+      rule.currentField = undefined
+    },
+
+    filterFieldOptions (rule) {
+      const selectedFields = rule.constraints.map(({ attribute }) => attribute)
+      return this.module.fields.filter(({ name }) => !selectedFields.includes(name))
+    },
+
+    getField (attribute) {
+      const field = this.module.fields.find(
+        ({ name }) => name === attribute,
+      )
+
+      return field || {}
+    },
+
+    getOptionLabel ({ kind, label, name }) {
+      return label || name || kind
+    },
+  },
+}
+</script>

--- a/client/web/compose/src/views/Admin/Modules/Edit.vue
+++ b/client/web/compose/src/views/Admin/Modules/Edit.vue
@@ -340,10 +340,9 @@
               </b-tab>
 
               <b-tab
-                v-if="module.config.recordDeDup.enabled"
-                :title="$t('edit.config.validation.title')"
+                :title="$t('edit.config.uniqueValues.title')"
               >
-                <validation
+                <unique-values
                   :module="module"
                 />
               </b-tab>
@@ -458,7 +457,7 @@ import DalSettings from 'corteza-webapp-compose/src/components/Admin/Module/DalS
 import RecordRevisionsSettings from 'corteza-webapp-compose/src/components/Admin/Module/RecordRevisionsSettings'
 import DataPrivacySettings from 'corteza-webapp-compose/src/components/Admin/Module/DataPrivacySettings'
 import ModuleTranslator from 'corteza-webapp-compose/src/components/Admin/Module/ModuleTranslator'
-import Validation from 'corteza-webapp-compose/src/components/Admin/Module/Validation'
+import UniqueValues from 'corteza-webapp-compose/src/components/Admin/Module/UniqueValues'
 import RelatedPages from 'corteza-webapp-compose/src/components/Admin/Module/RelatedPages'
 import { compose, NoID } from '@cortezaproject/corteza-js'
 import EditorToolbar from 'corteza-webapp-compose/src/components/Admin/EditorToolbar'
@@ -485,8 +484,8 @@ export default {
     ModuleTranslator,
     RelatedPages,
     EditorToolbar,
-    Validation,
     Export,
+    UniqueValues,
   },
 
   props: {

--- a/lib/js/src/compose/types/module.ts
+++ b/lib/js/src/compose/types/module.ts
@@ -58,8 +58,6 @@ interface Config {
   };
 
   recordDeDup: {
-    enabled: boolean;
-    strict: boolean;
     rules: RecordDeDupRule[];
   };
 }
@@ -71,10 +69,17 @@ interface ConfigDiscoveryAccess {
   };
 }
 
+interface Constraint {
+    attribute: string;
+    modifier: string;
+    multiValue: string;
+    type: string;
+}
+
 interface RecordDeDupRule {
-  name: string;
+  name?: string;
   strict: boolean;
-  attributes: string[];
+  constraints: Constraint[];
 }
 
 /**
@@ -163,10 +168,12 @@ export class Module {
     },
 
     recordDeDup: {
-      // Always true for now since empty array of rules is the same as disabling it
-      enabled: true,
-      strict: false,
-      rules: [],
+      rules: [
+        {
+          strict: true,
+          constraints: []
+        }
+      ],
     },
   }
 
@@ -224,9 +231,6 @@ export class Module {
       this.config = merge({}, this.config, m.config)
 
       // Remove when we improve duplicate detection, for now its always enabled
-      if (this.config.recordDeDup) {
-        this.config.recordDeDup.enabled = true
-      }
     }
 
     if (IsOf(m, 'labels')) {

--- a/locale/en/corteza-webapp-compose/field.yaml
+++ b/locale/en/corteza-webapp-compose/field.yaml
@@ -222,3 +222,16 @@ valueExpr:
 label:
   required: Required
   multi: Multi value
+constraints:
+  label: Unique value constraint
+  description: Use unique value constraints for this field
+  ignoreCase: Ignore case
+  fuzzyMatch: Fuzzy match
+  soundsLike: Sounds like
+  caseSensitive: Case sensitive
+  oneOf: One of
+  none: None
+  equal: Equal
+  valueModifiers: Value modifiers
+  multiValues: Multi-field values
+  totalFieldConstraintCount: The field is used in {{total}} other unique value constraint. See "unique values" tab on module editor.

--- a/locale/en/corteza-webapp-compose/module.yaml
+++ b/locale/en/corteza-webapp-compose/module.yaml
@@ -165,6 +165,26 @@ edit:
           label: Soft duplicate value validation
           description: Record will be saved and user will be presented with a warning when a duplicate value is detected in the selected fields in any existing record of this module
 
+    uniqueValues:
+      title: Unique values
+      preventRecordsSave: Prevent record saving if duplicate values are found
+      warningLabel: Warning or error message toast when constraint matches
+      valueModifiers: Value modifiers
+      multiValues: Multi-field values
+      add: Add
+      searchFields: Search fields
+      ignoreCase: Ignore case
+      fuzzyMatch: Fuzzy match
+      soundsLike: Sounds like
+      caseSensitive: Case sensitive
+      oneOf: One of
+      equal: Equal
+      warningMessage: Warning or error message toast when constraint matches
+      field: Field
+      type: Type
+      none: None
+      addNewConstraint: Add new constraint
+      uniqueValueConstraint: Unique value constraint &#x23;{{index}}
 
 federated: Federated
 forModule:
@@ -210,4 +230,3 @@ searchPlaceholder: Type here to search all modules in this namespace
 title: List of Modules
 tooltip:
   permissions: Module permissions
-

--- a/server/compose/service/record.go
+++ b/server/compose/service/record.go
@@ -571,6 +571,12 @@ func (svc record) Bulk(ctx context.Context, oo ...*types.RecordBulkOperation) (r
 			//       before we start storing any changes
 			rves = &types.RecordValueErrorSet{}
 
+			// duplication errors
+			ddes = &types.RecordValueErrorSet{}
+
+			// merge of record value errors and duplication errors
+			ee = &types.RecordValueErrorSet{}
+
 			action func(props ...*recordActionProps) *recordAction
 			r      *types.Record
 
@@ -599,11 +605,11 @@ func (svc record) Bulk(ctx context.Context, oo ...*types.RecordBulkOperation) (r
 			switch p.Operation {
 			case types.OperationTypeCreate:
 				action = RecordActionCreate
-				r, dd, err = svc.create(ctx, r)
+				r, ddes, err = svc.create(ctx, r)
 
 			case types.OperationTypeUpdate:
 				action = RecordActionUpdate
-				r, dd, err = svc.update(ctx, r)
+				r, ddes, err = svc.update(ctx, r)
 
 			case types.OperationTypeDelete:
 				action = RecordActionDelete
@@ -613,8 +619,13 @@ func (svc record) Bulk(ctx context.Context, oo ...*types.RecordBulkOperation) (r
 			aProp.setChanged(r)
 
 			// Attach meta ID to each value error for FE identification
-			if !dd.HasStrictErrors() && r != nil {
-				dd.SetMetaID(r.ID)
+			if !ddes.HasStrictErrors() && r != nil {
+				ddes.SetMetaID(r.ID)
+			}
+			if !ddes.IsValid() && dd == nil {
+				dd = ddes
+			} else {
+				dd.Merge(ddes)
 			}
 
 			if rve := types.IsRecordValueErrorSet(err); rve != nil {
@@ -644,9 +655,14 @@ func (svc record) Bulk(ctx context.Context, oo ...*types.RecordBulkOperation) (r
 			}
 		}
 
-		if !rves.IsValid() {
+		// merge record value errors and strict duplication errors
+		if dd.HasStrictErrors() {
+			ee.Merge(rves, dd)
+		}
+
+		if !ee.IsValid() {
 			// Any errors gathered?
-			return RecordErrValueInput().Wrap(rves)
+			return RecordErrValueInput().Wrap(ee)
 		}
 
 		return nil
@@ -701,8 +717,17 @@ func (svc record) create(ctx context.Context, new *types.Record) (rec *types.Rec
 	new.SetModule(m)
 
 	{
+		// handle deDup error/warnings
+		dd, err = svc.DupDetection(ctx, m, new)
+
+		// handle input payload errors
 		if rve = svc.procCreate(ctx, invokerID, m, new); !rve.IsValid() {
 			return nil, dd, RecordErrValueInput().Wrap(rve)
+		}
+
+		// record value errors from dup detection
+		if err != nil {
+			return
 		}
 
 		if err = svc.eventbus.WaitFor(ctx, event.RecordBeforeCreate(new, nil, m, ns, rve, nil)); err != nil {
@@ -713,11 +738,6 @@ func (svc record) create(ctx context.Context, new *types.Record) (rec *types.Rec
 	}
 
 	new.Values = RecordValueDefaults(m, new.Values)
-
-	dd, err = svc.DupDetection(ctx, m, new)
-	if err != nil {
-		return
-	}
 
 	// Handle payload from automation scripts
 	if rve = svc.procCreate(ctx, invokerID, m, new); !rve.IsValid() {
@@ -996,15 +1016,18 @@ func (svc record) update(ctx context.Context, upd *types.Record) (rec *types.Rec
 	upd.SetModule(m)
 	old.SetModule(m)
 
-	dd, err = svc.DupDetection(ctx, m, upd)
-	if err != nil {
-		return
-	}
-
 	{
-		// Handle input payload
+		// handle deDup error/warnings
+		dd, err = svc.DupDetection(ctx, m, upd)
+
+		// handle input payload errors
 		if rve = svc.procUpdate(ctx, invokerID, m, upd, old); !rve.IsValid() {
 			return nil, dd, RecordErrValueInput().Wrap(rve)
+		}
+
+		// record value errors from dup detection
+		if err != nil {
+			return
 		}
 
 		// Scripts can (besides simple error value) return complex record value error set
@@ -1833,7 +1856,6 @@ func (svc record) DupDetection(ctx context.Context, m *types.Module, rec *types.
 			return
 		}
 
-		// @todo: improve error string with details
 		rProps.setValueErrors(out)
 
 		// Error out if duplicate record exist
@@ -2036,7 +2058,7 @@ fields:
 				val.Value = pickRandomID(recRefs[refModID])
 
 			case "select":
-				//val.Value = src.Select(f.Options)
+				// val.Value = src.Select(f.Options)
 				continue fields
 
 			case "url":

--- a/server/compose/types/module.go
+++ b/server/compose/types/module.go
@@ -93,12 +93,9 @@ type (
 	}
 
 	ModuleConfigRecordDeDup struct {
-		// enable or disable duplicate detection
-		Enabled bool `json:"enabled"`
-
 		// strictly restrict record saving
 		// 		otherwise show a warning with list of duplicated records
-		Strict bool `json:"strict"`
+		Strict bool `json:"-"`
 
 		// list of duplicate detection rules applied to module's fields
 		Rules DeDupRuleSet `json:"rules,omitempty"`

--- a/server/compose/types/record_detect_duplicates_test.go
+++ b/server/compose/types/record_detect_duplicates_test.go
@@ -1,0 +1,126 @@
+package types
+
+import (
+	"context"
+	"github.com/cortezaproject/corteza/server/pkg/locale"
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDeDupRule_checkCaseSensitiveDuplication(t *testing.T) {
+	var (
+		req = require.New(t)
+		ctx = context.Background()
+		ls  = locale.Global()
+
+		rule1 = DeDupRule{
+			Name:   "",
+			Strict: true,
+			ConstraintSet: []*DeDupRuleConstraint{
+				{
+					Attribute: "name",
+					Modifier:  ignoreCase,
+				},
+			},
+		}
+
+		tests = []struct {
+			name    string
+			rule    DeDupRule
+			rec     Record
+			vv      RecordValueSet
+			wantOut *RecordValueErrorSet
+		}{
+			{
+				name: "no duplication",
+				rule: rule1,
+				rec: Record{
+					ID: 1,
+					Values: RecordValueSet{
+						&RecordValue{
+							RecordID: 1,
+							Name:     "name",
+							Value:    "test",
+						},
+					},
+				},
+				vv: RecordValueSet{
+					&RecordValue{
+						RecordID: 2,
+						Name:     "name",
+						Value:    "test",
+					},
+				},
+				wantOut: &RecordValueErrorSet{
+					Set: []RecordValueError{
+						{
+							Kind:    deDupError.String(),
+							Message: rule1.IssueMessage(),
+							Meta: map[string]interface{}{
+								"field":         "name",
+								"value":         "test",
+								"dupValueField": "name",
+								"recordID":      cast.ToString(2),
+								"rule":          rule1.String(),
+							},
+						},
+					},
+				},
+			},
+		}
+	)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOut := tt.rule.checkCaseSensitiveDuplication(ctx, ls, tt.rec, tt.vv)
+			req.Equal(tt.wantOut, gotOut, "checkCaseSensitiveDuplication() = %v, want %v", gotOut, tt.wantOut)
+		})
+	}
+}
+
+func Test_matchValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		target   string
+		modifier DeDupValueModifier
+		want     bool
+	}{
+		{
+			name:     "ignoreCase match value",
+			input:    "test",
+			target:   "tEst",
+			modifier: ignoreCase,
+			want:     true,
+		},
+		{
+			name:     "caseSensitive match value",
+			input:    "tEst",
+			target:   "tEst",
+			modifier: caseSensitive,
+			want:     true,
+		},
+		{
+			name:     "fuzzyMatch match value",
+			input:    "kitten",
+			target:   "sitting",
+			modifier: fuzzyMatch,
+			want:     true,
+		},
+		{
+			name:     "soundsLike match value",
+			input:    "Robert",
+			target:   "Rupert",
+			modifier: soundsLike,
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchValue(tt.modifier, tt.input, tt.target); got != tt.want {
+				t.Errorf("matchValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/compose/types/validated.go
+++ b/server/compose/types/validated.go
@@ -29,6 +29,13 @@ func (v *RecordValueErrorSet) IsValid() bool {
 	return v == nil || len(v.Set) == 0
 }
 
+func (v *RecordValueErrorSet) Len() int {
+	if v == nil {
+		return 0
+	}
+	return len(v.Set)
+}
+
 func (v *RecordValueErrorSet) Error() string {
 	var no = 0
 	if v != nil {
@@ -60,6 +67,20 @@ func (v *RecordValueErrorSet) HasKind(kind string) bool {
 	}
 
 	return false
+}
+
+func (v *RecordValueErrorSet) Merge(errs ...*RecordValueErrorSet) {
+	if v == nil {
+		return
+	}
+
+	for _, e := range errs {
+		if e == nil || e.IsValid() {
+			continue
+		}
+
+		v.Push(e.Set...)
+	}
 }
 
 // IsRecordValueErrorSet tests if given error is RecordValueErrorSet (or it wraps it) and it has errors

--- a/server/pkg/str/levenshtein.go
+++ b/server/pkg/str/levenshtein.go
@@ -1,0 +1,52 @@
+package str
+
+// write Levenshtein Distance search algorithm for strings
+// https://en.wikipedia.org/wiki/Levenshtein_distance
+func ToLevenshteinDistance(a, b string) int {
+	var (
+		// length of a
+		la = len(a)
+		// length of b
+		lb = len(b)
+		// distance matrix
+		d = make([][]int, la+1)
+	)
+
+	// initialize distance matrix
+	for i := 0; i <= la; i++ {
+		d[i] = make([]int, lb+1)
+		d[i][0] = i
+	}
+
+	for j := 0; j <= lb; j++ {
+		d[0][j] = j
+	}
+
+	// calculate distance matrix
+	for i := 1; i <= la; i++ {
+		for j := 1; j <= lb; j++ {
+			if a[i-1] == b[j-1] {
+				d[i][j] = d[i-1][j-1]
+			} else {
+				// fix this min function
+				d[i][j] = min(d[i-1][j]+1, d[i][j-1]+1, d[i-1][j-1]+1)
+			}
+		}
+	}
+
+	return d[la][lb]
+}
+
+func min(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+	}
+
+	if b < c {
+		return b
+	}
+
+	return c
+}

--- a/server/pkg/str/levenshtein_test.go
+++ b/server/pkg/str/levenshtein_test.go
@@ -1,0 +1,39 @@
+package str
+
+import (
+	"testing"
+)
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a    string
+		b    string
+		want int
+	}{
+		{"", "hello", 5},
+		{"hello", "", 5},
+		{"hello", "hello", 0},
+		{"ab", "aa", 1},
+		{"ab", "ba", 2},
+		{"ab", "aaa", 2},
+		{"bbb", "a", 3},
+		{"kitten", "sitting", 3},
+		{"distance", "difference", 5},
+		{"levenshtein", "frankenstein", 6},
+		{"resume and cafe", "resumes and cafes", 2},
+		{"a very long string that is meant to exceed", "another very long string that is meant to exceed", 6},
+		// Testing acutes and umlauts
+		{"resumé and café", "resumés and cafés", 2},
+		{"resume and cafe", "resumé and café", 4},
+		{"Hafþór Júlíus Björnsson", "Hafþor Julius Bjornsson", 8},
+		// Only 2 characters are less in the 2nd string
+		{"།་གམ་འས་པ་་མ།", "།་གམའས་པ་་མ", 6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a, func(t *testing.T) {
+			if got := ToLevenshteinDistance(tt.a, tt.b); got != tt.want {
+				t.Errorf("LevenshteinDistance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/pkg/str/soundex.go
+++ b/server/pkg/str/soundex.go
@@ -1,0 +1,104 @@
+package str
+
+import (
+	"strings"
+)
+
+// ToSoundex takes a word and returns the soundex code for it.
+// https://en.wikipedia.org/wiki/Soundex
+//
+// 1. Retain the first letter of the name and drop all other occurrences of a, e, i, o, u, y, h, w.
+// 2. Replace consonants with digits as follows (after the first letter):
+//		b, f, p, v → 1
+//		c, g, j, k, q, s, x, z → 2
+//		d, t → 3
+//		l → 4
+//		m, n → 5
+//		r → 6
+// 3. If two or more letters with the same number are adjacent in the original name (before step 1),
+//		only retain the first letter; also two letters with the same number separated
+//		by 'h' or 'w' are coded as a single number, whereas such letters separated by a vowel are coded twice.
+//		This rule also applies to the first letter.
+// 4. Iterate the previous step until you have one letter and three numbers.
+//		If you have too few letters in your word that you can't assign three numbers, append with zeros
+//		until there are three numbers. If you have more than 3 letters, just retain the first 3 numbers.
+func ToSoundex(s string) string {
+	var (
+		// soundex code
+		code string
+		// last code
+		lastCode string
+		// last rune
+		lastRune rune
+		// last rune is vowel
+		lastRuneIsVowel bool
+	)
+
+	// retain the first letter of the name and drop all other occurrences of a, e, i, o, u, y, h, w
+	for _, r := range s {
+		if r == 'a' || r == 'e' || r == 'i' || r == 'o' || r == 'u' || r == 'y' || r == 'h' || r == 'w' {
+			continue
+		}
+
+		code = string(r)
+		break
+	}
+
+	// replace consonants with digits as follows (after the first letter)
+	for _, r := range s {
+		if r == 'a' || r == 'e' || r == 'i' || r == 'o' || r == 'u' || r == 'y' || r == 'h' || r == 'w' {
+			lastRuneIsVowel = true
+			continue
+		}
+
+		if lastRuneIsVowel {
+			lastRuneIsVowel = false
+			lastCode = ""
+		}
+
+		switch r {
+		case 'b', 'f', 'p', 'v':
+			lastCode = "1"
+		case 'c', 'g', 'j', 'k', 'q', 's', 'x', 'z':
+			lastCode = "2"
+		case 'd', 't':
+			lastCode = "3"
+		case 'l':
+			lastCode = "4"
+		case 'm', 'n':
+			lastCode = "5"
+		case 'r':
+			lastCode = "6"
+		}
+
+		if lastCode != "" && lastCode != string(lastRune) {
+			code += lastCode
+		}
+
+		lastRune = r
+	}
+
+	// if two or more letters with the same number are adjacent in the original name (before step 1),
+	// only retain the first letter
+	// also two letters with the same number separated by 'h' or 'w' are coded as a single number,
+	// whereas such letters separated by a vowel are coded twice
+	// this rule also applies to the first letter
+	code = strings.ReplaceAll(code, "11", "1")
+	code = strings.ReplaceAll(code, "22", "2")
+	code = strings.ReplaceAll(code, "33", "3")
+	code = strings.ReplaceAll(code, "44", "4")
+	code = strings.ReplaceAll(code, "55", "5")
+	code = strings.ReplaceAll(code, "66", "6")
+
+	// iterate the previous step until you have one letter and three numbers
+	// if you have too few letters in your word that you can't assign three numbers,
+	// append with zeros until there are three numbers
+	// if you have more than 3 letters, just retain the first 3 numbers
+	if len(code) < 4 {
+		code += strings.Repeat("0", 4-len(code))
+	} else {
+		code = code[:4]
+	}
+
+	return code
+}

--- a/server/pkg/str/soundex_test.go
+++ b/server/pkg/str/soundex_test.go
@@ -1,0 +1,64 @@
+package str
+
+import (
+	"testing"
+)
+
+func Test_soundex(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			"Robert",
+			"R163",
+		},
+		{
+			"Rupert",
+			"R163",
+		},
+		{
+			"Rubin",
+			"R150",
+		},
+		{
+			"Ashcraft",
+			"A261",
+		},
+		{
+			"Ashcroft",
+			"A261",
+		},
+		{
+			"Tymczak",
+			"T522",
+		},
+		{
+			"Pfister",
+			"P123",
+		},
+		{
+			"AH KEY",
+			"A000",
+		},
+		{
+			"The quick brown fox",
+			"T221",
+		},
+		{
+			"h3110 w021d",
+			"3000",
+		},
+		{
+			"1337",
+			"1000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToSoundex(tt.name); got != tt.want {
+				t.Errorf("soundex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/pkg/str/str.go
+++ b/server/pkg/str/str.go
@@ -1,0 +1,31 @@
+package str
+
+import (
+	"strings"
+)
+
+const (
+	// DefaultLevenshteinDistance is the default levenshtein distance
+	DefaultLevenshteinDistance = 3
+
+	CaseInSensitiveMatch = iota
+	CaseSensitiveMatch
+	LevenshteinDistance
+	Soundex
+)
+
+// Match will match string as per given algorithm
+func Match(str1, str2 string, algorithm int) bool {
+	switch algorithm {
+	case LevenshteinDistance:
+		return ToLevenshteinDistance(str1, str2) <= DefaultLevenshteinDistance
+	case Soundex:
+		return ToSoundex(str1) == ToSoundex(str2)
+	case CaseSensitiveMatch:
+		return strings.Compare(str1, str2) == 0
+	case CaseInSensitiveMatch:
+		return strings.EqualFold(str1, str2)
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
# The following changes are implemented
update de-duplication UI on module and fields configuration pages

ISSSUE: #467 

# Changes in the user interface:
![image](https://user-images.githubusercontent.com/23015247/206469541-cc016903-0d6c-49a9-8cdf-b7c39690664e.png)
![image](https://user-images.githubusercontent.com/23015247/206469507-502c603e-3655-42f1-b32a-8fccbfd91c2b.png)

# Checklist when submitting a final (!draft) PR
 - [ ] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
