### PR TITLE
Integration gateway response support

### DIFF
--- a/server/pkg/apigw/filter/postfilter.go
+++ b/server/pkg/apigw/filter/postfilter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 
 	atypes "github.com/cortezaproject/corteza/server/automation/types"
 	agctx "github.com/cortezaproject/corteza/server/pkg/apigw/ctx"
@@ -31,22 +32,16 @@ type (
 		}
 	}
 
-	// support for arbitrary response
-	// obfuscation
-	customResponse struct {
-		types.FilterMeta
-		params struct {
-			Source string `json:"source"`
-		}
-	}
-
-	jsonResponse struct {
+	response struct {
 		types.FilterMeta
 
 		reg typesRegistry
 
 		params struct {
-			Exp       *atypes.Expr
+			Header http.Header `json:"header"`
+
+			Exp *atypes.Expr `json:"input"`
+
 			Evaluable expr.Evaluable
 		}
 	}
@@ -181,10 +176,10 @@ func checkStatus(typ string, status int) bool {
 	}
 }
 
-func NewJsonResponse(opts options.ApigwOpt, reg typesRegistry) (e *jsonResponse) {
-	e = &jsonResponse{}
+func NewResponse(opts options.ApigwOpt, reg typesRegistry) (e *response) {
+	e = &response{}
 
-	e.Name = "jsonResponse"
+	e.Name = "response"
 	e.Label = "JSON response"
 	e.Kind = types.PostFilter
 
@@ -194,6 +189,11 @@ func NewJsonResponse(opts options.ApigwOpt, reg typesRegistry) (e *jsonResponse)
 			Label:   "input",
 			Options: map[string]interface{}{},
 		},
+		{
+			Type:    "header",
+			Label:   "header",
+			Options: map[string]interface{}{},
+		},
 	}
 
 	e.reg = reg
@@ -201,28 +201,28 @@ func NewJsonResponse(opts options.ApigwOpt, reg typesRegistry) (e *jsonResponse)
 	return
 }
 
-func (j jsonResponse) New(opts options.ApigwOpt) types.Handler {
-	return NewJsonResponse(opts, j.reg)
+func (j response) New(opts options.ApigwOpt) types.Handler {
+	return NewResponse(opts, j.reg)
 }
 
-func (j jsonResponse) Enabled() bool {
+func (j response) Enabled() bool {
 	return true
 }
 
-func (j jsonResponse) String() string {
+func (j response) String() string {
 	return fmt.Sprintf("apigw filter %s (%s)", j.Name, j.Label)
 }
 
-func (j jsonResponse) Meta() types.FilterMeta {
+func (j response) Meta() types.FilterMeta {
 	return j.FilterMeta
 }
 
-func (j *jsonResponse) Merge(params []byte) (h types.Handler, err error) {
+func (j *response) Merge(params []byte) (h types.Handler, err error) {
 	var (
 		parser = expr.NewParser()
 	)
 
-	err = json.NewDecoder(bytes.NewBuffer(params)).Decode(&j.params.Exp)
+	err = json.NewDecoder(bytes.NewBuffer(params)).Decode(&j.params)
 
 	if err != nil {
 		return j, err
@@ -239,11 +239,12 @@ func (j *jsonResponse) Merge(params []byte) (h types.Handler, err error) {
 	return j, err
 }
 
-func (j jsonResponse) Handler() types.HandlerFunc {
+func (j response) Handler() types.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) (err error) {
 		var (
-			ctx   = r.Context()
-			scope = agctx.ScopeFromContext(ctx)
+			ctx           = r.Context()
+			scope         = agctx.ScopeFromContext(ctx)
+			hasJsonHeader = false
 
 			evald interface{}
 		)
@@ -274,15 +275,22 @@ func (j jsonResponse) Handler() types.HandlerFunc {
 			return
 		}
 
-		rw.Header().Add("Content-Type", "application/json")
+		for h, v := range j.params.Header {
+			for _, vv := range v {
+				rw.Header().Add(h, vv)
 
-		switch v := evald.(type) {
-		case string:
-			rw.Write([]byte(v))
-		default:
-			e := json.NewEncoder(rw)
-			err = e.Encode(v)
+				if h == "Content-Type" || h == "content-type" {
+					hasJsonHeader = vv == "application/json"
+				}
+			}
 		}
+
+		if reflect.ValueOf(evald).Kind() != reflect.String && hasJsonHeader {
+			err = (json.NewEncoder(rw)).Encode(expr.UntypedValue(evald))
+			return
+		}
+
+		fmt.Fprintf(rw, "%v", evald)
 
 		return
 	}

--- a/server/pkg/apigw/filter/postfilter_test.go
+++ b/server/pkg/apigw/filter/postfilter_test.go
@@ -114,22 +114,52 @@ func Test_jsonResponse(t *testing.T) {
 	var (
 		tcc = []tf{
 			{
-				name:  "Any response as JSON",
-				expr:  `{"expr": "records", "type": "KV"}`,
+				name:  "String response as JSON",
+				expr:  `{"header":{"content-type":["application/json"]},"input":{"expr": "records", "type": "String"}}`,
+				scope: expr.Must(expr.Any{}.Cast("foobar")),
+				exp:   `foobar`,
+			},
+			{
+				name:  "Array response as JSON",
+				expr:  `{"header":{"content-type":["application/json"]},"input":{"expr": "records", "type": "Array"}}`,
 				scope: expr.Must(expr.Any{}.Cast([]float64{3.14, 42.690})),
 				exp:   `[3.14,42.69]`,
 			},
 			{
-				name:  "KV response as JSON",
-				expr:  `{"expr": "records", "type": "KV"}`,
+				name:  "Array response as text",
+				expr:  `{"input":{"expr": "records", "type": "Array"}}`,
+				scope: expr.Must(expr.Any{}.Cast([]float64{3.14, 42.690})),
+				exp:   `[3.14 42.69]`,
+			},
+			{
+				name:  "Any response as JSON",
+				expr:  `{"header":{"content-type":["application/json"]},"input": {"expr": "records", "type": "Any"}}`,
 				scope: expr.Must(expr.Any{}.Cast(map[string]string{"foo": "bar", "baz": "bzz"})),
 				exp:   `{"baz":"bzz","foo":"bar"}`,
 			},
 			{
+				name:  "Any response as text",
+				expr:  `{"input": {"expr": "records", "type": "Any"}}`,
+				scope: expr.Must(expr.Any{}.Cast(map[string]string{"foo": "bar", "baz": "bzz"})),
+				exp:   `map[baz:bzz foo:bar]`,
+			},
+			{
 				name:  "struct array response as JSON",
-				expr:  `{"expr": "toJSON(records)", "type": "String"}`,
+				expr:  `{"input":{"expr": "toJSON(records)", "type": "String"}}`,
 				scope: []aux{{"First", "Last"}, {"Foo", "bar"}},
 				exp:   `[{"name":"First","surname":"Last"},{"name":"Foo","surname":"bar"}]`,
+			},
+			{
+				name:  "struct array response as text",
+				expr:  `{"input":{"expr": "records", "type": "String"}}`,
+				scope: []aux{{"First", "Last"}, {"Foo", "bar"}},
+				exp:   `[{First Last} {Foo bar}]`,
+			},
+			{
+				name:  "string csv response as text",
+				expr:  `{"header":{"content-type":["application/octet-stream"],"Content-Disposition":["attachment; filename=foo.txt"],"Content-Transfer-Encoding":["binary"]},"input":{"expr": "records", "type": "String"}}`,
+				scope: "\"header 1\",\"header 2\"\nvalue 1,value 2\nvalue 3, value 4",
+				exp:   "\"header 1\",\"header 2\"\nvalue 1,value 2\nvalue 3, value 4",
 			},
 		}
 	)

--- a/server/pkg/apigw/filter/postfilter_test.go
+++ b/server/pkg/apigw/filter/postfilter_test.go
@@ -175,7 +175,7 @@ func Test_jsonResponse(t *testing.T) {
 
 			r = r.WithContext(agctx.ScopeToContext(context.Background(), scope))
 
-			h := getHandler(NewJsonResponse(options.ApigwOpt{}, &mockHandlerRegistry{}))
+			h := getHandler(NewResponse(options.ApigwOpt{}, &mockHandlerRegistry{}))
 			h, err := h.Merge([]byte(tc.expr))
 
 			req.NoError(err)

--- a/server/pkg/apigw/filter/processer.go
+++ b/server/pkg/apigw/filter/processer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/cortezaproject/corteza/server/automation/automation"
 	atypes "github.com/cortezaproject/corteza/server/automation/types"
@@ -32,6 +33,7 @@ type (
 	WfExecer interface {
 		Load(ctx context.Context) error
 		Exec(ctx context.Context, workflowID uint64, p atypes.WorkflowExecParams) (*expr.Vars, uint64, atypes.Stacktrace, error)
+		Search(ctx context.Context, filter atypes.WorkflowFilter) (atypes.WorkflowSet, atypes.WorkflowFilter, error)
 	}
 
 	processerPayload struct {
@@ -85,10 +87,28 @@ func (h workflow) Meta() types.FilterMeta {
 }
 
 func (h *workflow) Merge(params []byte) (types.Handler, error) {
-	err := json.NewDecoder(bytes.NewBuffer(params)).Decode(&h.params)
+	var (
+		t = struct {
+			Workflow string `json:"workflow"`
+		}{}
+	)
 
+	err := json.NewDecoder(bytes.NewBuffer(params)).Decode(&t)
 	if err != nil {
 		return h, err
+	}
+
+	i, err := strconv.Atoi(t.Workflow)
+
+	if err == nil {
+		h.params.Workflow = uint64(i)
+		return h, h.d.Load(context.Background())
+	}
+
+	if wf, _, err := h.d.Search(context.Background(), atypes.WorkflowFilter{Query: fmt.Sprintf("handle='%s'", t.Workflow)}); err != nil {
+		return h, err
+	} else {
+		h.params.Workflow = wf[0].ID
 	}
 
 	// preload workflow cache
@@ -146,7 +166,7 @@ func (h workflow) Handler() types.HandlerFunc {
 		scope = filterScope(scope, "eventType", "resourceType", "invoker")
 
 		// update scope for next items in pipeline
-		r.WithContext(agctx.ScopeToContext(ctx, scope))
+		_ = r.WithContext(agctx.ScopeToContext(ctx, scope))
 
 		return nil
 	}

--- a/server/pkg/apigw/filter/processer.go
+++ b/server/pkg/apigw/filter/processer.go
@@ -13,6 +13,7 @@ import (
 	atypes "github.com/cortezaproject/corteza/server/automation/types"
 	agctx "github.com/cortezaproject/corteza/server/pkg/apigw/ctx"
 	"github.com/cortezaproject/corteza/server/pkg/apigw/types"
+	"github.com/cortezaproject/corteza/server/pkg/auth"
 	pe "github.com/cortezaproject/corteza/server/pkg/errors"
 	"github.com/cortezaproject/corteza/server/pkg/expr"
 	"github.com/cortezaproject/corteza/server/pkg/jsenv"
@@ -91,6 +92,9 @@ func (h *workflow) Merge(params []byte) (types.Handler, error) {
 		t = struct {
 			Workflow string `json:"workflow"`
 		}{}
+
+		// ctx = context.Background()
+		ctx = auth.SetIdentityToContext(context.Background(), auth.ServiceUser())
 	)
 
 	err := json.NewDecoder(bytes.NewBuffer(params)).Decode(&t)
@@ -102,17 +106,17 @@ func (h *workflow) Merge(params []byte) (types.Handler, error) {
 
 	if err == nil {
 		h.params.Workflow = uint64(i)
-		return h, h.d.Load(context.Background())
+		return h, h.d.Load(ctx)
 	}
 
-	if wf, _, err := h.d.Search(context.Background(), atypes.WorkflowFilter{Query: fmt.Sprintf("handle='%s'", t.Workflow)}); err != nil {
+	if wf, _, err := h.d.Search(ctx, atypes.WorkflowFilter{Query: t.Workflow}); err != nil {
 		return h, err
 	} else {
 		h.params.Workflow = wf[0].ID
 	}
 
 	// preload workflow cache
-	return h, h.d.Load(context.Background())
+	return h, h.d.Load(ctx)
 }
 
 func (h workflow) Handler() types.HandlerFunc {

--- a/server/pkg/apigw/filter/processer_test.go
+++ b/server/pkg/apigw/filter/processer_test.go
@@ -23,8 +23,9 @@ import (
 
 type (
 	wfServicer struct {
-		load func(ctx context.Context) error
-		exec func(ctx context.Context, workflowID uint64, p atypes.WorkflowExecParams) (*expr.Vars, uint64, atypes.Stacktrace, error)
+		load   func(ctx context.Context) error
+		exec   func(ctx context.Context, workflowID uint64, p atypes.WorkflowExecParams) (*expr.Vars, uint64, atypes.Stacktrace, error)
+		search func(ctx context.Context, filter atypes.WorkflowFilter) (atypes.WorkflowSet, atypes.WorkflowFilter, error)
 	}
 )
 
@@ -226,6 +227,10 @@ func (f wfServicer) Load(ctx context.Context) error {
 
 func (f wfServicer) Exec(ctx context.Context, workflowID uint64, p atypes.WorkflowExecParams) (*expr.Vars, uint64, atypes.Stacktrace, error) {
 	return f.exec(ctx, workflowID, p)
+}
+
+func (f wfServicer) Search(ctx context.Context, filter atypes.WorkflowFilter) (atypes.WorkflowSet, atypes.WorkflowFilter, error) {
+	return f.search(ctx, filter)
 }
 
 func must(v *expr.Vars, err error) *expr.Vars {

--- a/server/pkg/apigw/filter/processer_test.go
+++ b/server/pkg/apigw/filter/processer_test.go
@@ -3,7 +3,7 @@ package filter
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"

--- a/server/pkg/apigw/registry/registry.go
+++ b/server/pkg/apigw/registry/registry.go
@@ -75,7 +75,7 @@ func (r *Registry) Preload() {
 
 	// postfilters
 	r.Add("redirection", filter.NewRedirection(r.opts))
-	r.Add("jsonResponse", filter.NewJsonResponse(r.opts, service.Registry()))
+	r.Add("response", filter.NewResponse(r.opts, service.Registry()))
 	r.Add("defaultJsonResponse", filter.NewDefaultJsonResponse(r.opts))
 }
 

--- a/server/pkg/provision/apigw.go
+++ b/server/pkg/provision/apigw.go
@@ -1,0 +1,39 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	atypes "github.com/cortezaproject/corteza/server/automation/types"
+	"github.com/cortezaproject/corteza/server/store"
+	"github.com/cortezaproject/corteza/server/system/types"
+	"go.uber.org/zap"
+)
+
+func apigwFilters(ctx context.Context, log *zap.Logger, s store.Storer) (err error) {
+	var (
+		filters types.ApigwFilterSet
+	)
+
+	if filters, _, err = store.SearchApigwFilters(ctx, s, types.ApigwFilterFilter{Ref: "jsonResponse"}); err != nil {
+		return
+	}
+
+	for _, f := range filters {
+		h := http.Header{}
+		h.Add("Content-Type", "application/json")
+
+		f.Ref = "response"
+		f.Params = map[string]interface{}{
+			"header": h,
+			"input":  &atypes.Expr{Expr: f.Params["input"].(string), Type: "String"},
+		}
+
+		if err = store.UpdateApigwFilter(ctx, s, f); err != nil {
+			log.Warn(fmt.Sprintf("could not migrate jsonResponse to response: %s", err))
+		}
+	}
+
+	return
+}

--- a/server/pkg/provision/auth.go
+++ b/server/pkg/provision/auth.go
@@ -5,13 +5,15 @@ import (
 	"os"
 
 	"github.com/cortezaproject/corteza/server/pkg/errors"
+	"github.com/cortezaproject/corteza/server/pkg/id"
+	"github.com/cortezaproject/corteza/server/pkg/options"
+	"github.com/cortezaproject/corteza/server/pkg/rand"
 	"github.com/cortezaproject/corteza/server/store"
 	"github.com/cortezaproject/corteza/server/system/types"
+	"go.uber.org/zap"
 )
 
 // Sets email-related settings (if not set) under "auth.internal..."
-//
-//
 func emailSettings(ctx context.Context, s store.Storer) error {
 	var (
 		val, has      = os.LookupEnv("SMTP_HOST")
@@ -42,4 +44,57 @@ func emailSettings(ctx context.Context, s store.Storer) error {
 			return err
 		})
 	})
+}
+
+// defaultAuthClient checks if default client exists (handle = AUTH_DEFAULT_CLIENT) and adds it
+func defaultAuthClient(ctx context.Context, log *zap.Logger, s store.AuthClients, authOpt options.AuthOpt) error {
+	if authOpt.DefaultClient == "" {
+		// Default client not set
+		return nil
+	}
+
+	c := &types.AuthClient{
+		ID:     id.Next(),
+		Handle: authOpt.DefaultClient,
+		Meta: &types.AuthClientMeta{
+			Name: "Corteza Web Applications",
+		},
+		ValidGrant: "authorization_code",
+		RedirectURI: func() string {
+			// Disabling protection by redirection URL for now, it caused too much confusion on simple setups
+			//baseURL, _ := url.Parse(authOpt.BaseURL)
+			//return fmt.Sprintf("%s://%s", baseURL.Scheme, baseURL.Hostname())
+			return ""
+		}(),
+
+		Secret:    string(rand.Bytes(64)),
+		Scope:     "profile api",
+		Enabled:   true,
+		Trusted:   true,
+		Security:  &types.AuthClientSecurity{},
+		Labels:    nil,
+		CreatedAt: *now(),
+	}
+
+	_, err := store.LookupAuthClientByHandle(ctx, s, c.Handle)
+	if err == nil {
+		return nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err = store.CreateAuthClient(ctx, s, c); err != nil {
+		return err
+	}
+
+	log.Info(
+		"Added OAuth2 client",
+		zap.String("name", c.Meta.Name),
+		zap.String("redirectURI", c.RedirectURI),
+		zap.Uint64("clientId", c.ID),
+	)
+
+	return nil
 }

--- a/server/pkg/provision/provision.go
+++ b/server/pkg/provision/provision.go
@@ -4,12 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/cortezaproject/corteza/server/pkg/errors"
-	"github.com/cortezaproject/corteza/server/pkg/id"
 	"github.com/cortezaproject/corteza/server/pkg/options"
-	"github.com/cortezaproject/corteza/server/pkg/rand"
 	"github.com/cortezaproject/corteza/server/store"
-	"github.com/cortezaproject/corteza/server/system/types"
 	"go.uber.org/zap"
 )
 
@@ -39,6 +35,7 @@ func Run(ctx context.Context, log *zap.Logger, s store.Storer, provisionOpt opti
 
 		// Auto-discoveries and other parts that cannot be imported from static files
 		func() error { return emailSettings(ctx, s) },
+		func() error { return apigwFilters(ctx, log.Named("apigw.filters"), s) },
 		func() error { return authAddExternals(ctx, log.Named("auth.externals"), s) },
 		func() error { return oidcAutoDiscovery(ctx, log.Named("auth.oidc-auto-discovery"), s, authOpt) },
 		func() error { return defaultAuthClient(ctx, log.Named("auth.clients"), s, authOpt) },
@@ -49,59 +46,6 @@ func Run(ctx context.Context, log *zap.Logger, s store.Storer, provisionOpt opti
 			return err
 		}
 	}
-
-	return nil
-}
-
-// defaultAuthClient checks if default client exists (handle = AUTH_DEFAULT_CLIENT) and adds it
-func defaultAuthClient(ctx context.Context, log *zap.Logger, s store.AuthClients, authOpt options.AuthOpt) error {
-	if authOpt.DefaultClient == "" {
-		// Default client not set
-		return nil
-	}
-
-	c := &types.AuthClient{
-		ID:     id.Next(),
-		Handle: authOpt.DefaultClient,
-		Meta: &types.AuthClientMeta{
-			Name: "Corteza Web Applications",
-		},
-		ValidGrant: "authorization_code",
-		RedirectURI: func() string {
-			// Disabling protection by redirection URL for now, it caused too much confusion on simple setups
-			//baseURL, _ := url.Parse(authOpt.BaseURL)
-			//return fmt.Sprintf("%s://%s", baseURL.Scheme, baseURL.Hostname())
-			return ""
-		}(),
-
-		Secret:    string(rand.Bytes(64)),
-		Scope:     "profile api",
-		Enabled:   true,
-		Trusted:   true,
-		Security:  &types.AuthClientSecurity{},
-		Labels:    nil,
-		CreatedAt: *now(),
-	}
-
-	_, err := store.LookupAuthClientByHandle(ctx, s, c.Handle)
-	if err == nil {
-		return nil
-	}
-
-	if !errors.IsNotFound(err) {
-		return err
-	}
-
-	if err = store.CreateAuthClient(ctx, s, c); err != nil {
-		return err
-	}
-
-	log.Info(
-		"Added OAuth2 client",
-		zap.String("name", c.Meta.Name),
-		zap.String("redirectURI", c.RedirectURI),
-		zap.Uint64("clientId", c.ID),
-	)
 
 	return nil
 }

--- a/server/pkg/rbac/session.go
+++ b/server/pkg/rbac/session.go
@@ -50,6 +50,7 @@ func ParamsToSession(ctx context.Context, user uint64, roles ...uint64) *session
 }
 
 func NewSession(ctx context.Context, i auth.Identifiable) *session {
+	// spew.Dump("IDENTIFIABLE", i.Identity(), i.Roles())
 	return &session{
 		id:  i.Identity(),
 		rr:  i.Roles(),

--- a/server/pkg/rbac/session.go
+++ b/server/pkg/rbac/session.go
@@ -50,7 +50,6 @@ func ParamsToSession(ctx context.Context, user uint64, roles ...uint64) *session
 }
 
 func NewSession(ctx context.Context, i auth.Identifiable) *session {
-	// spew.Dump("IDENTIFIABLE", i.Identity(), i.Roles())
 	return &session{
 		id:  i.Identity(),
 		rr:  i.Roles(),

--- a/server/store/adapters/rdbms/filter.go
+++ b/server/store/adapters/rdbms/filter.go
@@ -342,6 +342,22 @@ func DefaultFilters() (f *extendedFilters) {
 		return ee, f, nil
 	}
 
+	f.ApigwFilter = func(s *Store, f systemType.ApigwFilterFilter) (ee []goqu.Expression, _ systemType.ApigwFilterFilter, err error) {
+		if ee, f, err = ApigwFilterFilter(f); err != nil {
+			return
+		}
+
+		if len(f.Ref) > 0 {
+			ee = append(ee, goqu.C("ref").Eq(f.Ref))
+		}
+
+		if len(f.Kind) > 0 {
+			ee = append(ee, goqu.C("kind").Eq(f.Kind))
+		}
+
+		return ee, f, nil
+	}
+
 	return
 }
 
@@ -402,7 +418,9 @@ func stateFalseComparison(lit string, fs filter.State) goqu.Expression {
 }
 
 // @todo: Currently we have for support for MsSQL, MySql, PSQL, SQLite drivers,
-//  		this changes is supported by all DB but we need to move to store.driver
+//
+//	this changes is supported by all DB but we need to move to store.driver
+//
 // generateSorting verify and converts given sorting to literal if required
 func generateSorting(sortables map[string]string, s *filter.SortExpr) (out goqu.Expression, err error) {
 	const COALESCE string = "coalesce"

--- a/server/system/service/apigw_filter_actions.yaml
+++ b/server/system/service/apigw_filter_actions.yaml
@@ -18,7 +18,7 @@ props:
     fields: [ ID, ref ]
   - name: search
     type: "*types.ApigwFilterFilter"
-    fields: []
+    fields: [ kind ]
 
 actions:
   - action: search

--- a/server/system/types/apigw_filter.go
+++ b/server/system/types/apigw_filter.go
@@ -3,8 +3,9 @@ package types
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"github.com/cortezaproject/corteza/server/pkg/sql"
 	"time"
+
+	"github.com/cortezaproject/corteza/server/pkg/sql"
 
 	"github.com/cortezaproject/corteza/server/pkg/filter"
 )
@@ -34,6 +35,9 @@ type (
 
 		Deleted  filter.State `json:"deleted"`
 		Disabled filter.State `json:"disabled"`
+
+		Kind string `json:"kind"`
+		Ref  string `json:"ref"`
 
 		// Check fn is called by store backend for each resource found function can
 		// modify the resource and return false if store should not return it

--- a/server/tests/apigw/postfilter_string_json_test.go
+++ b/server/tests/apigw/postfilter_string_json_test.go
@@ -1,0 +1,20 @@
+package apigw
+
+import (
+	"net/http"
+	"testing"
+)
+
+func Test_postfilter_string_json(t *testing.T) {
+	var (
+		_, h, _ = setupScenario(t)
+	)
+
+	h.apiInit().
+		Get("/json/string").
+		Header("Accept", "application/json").
+		Expect(t).
+		Status(http.StatusOK).
+		Body("{\"baz\":{\"@value\":{\"1\":{\"@value\":1,\"@type\":\"Float\"},\"2\":{\"@value\":2,\"@type\":\"Float\"}},\"@type\":\"Vars\"},\"foo\":{\"@value\":\"bar\",\"@type\":\"String\"}}").
+		End()
+}

--- a/server/tests/apigw/postfilter_string_kv_test.go
+++ b/server/tests/apigw/postfilter_string_kv_test.go
@@ -1,0 +1,20 @@
+package apigw
+
+import (
+	"net/http"
+	"testing"
+)
+
+func Test_postfilter_string_kv(t *testing.T) {
+	var (
+		_, h, _ = setupScenario(t)
+	)
+
+	h.apiInit().
+		Get("/json/kv").
+		Header("Accept", "application/json").
+		Expect(t).
+		Status(http.StatusOK).
+		Body("{\"baz\":\"123\",\"foo\":\"bar\"}").
+		End()
+}

--- a/server/tests/apigw/testdata/postfilter_string_json/def.yaml
+++ b/server/tests/apigw/testdata/postfilter_string_json/def.yaml
@@ -1,0 +1,38 @@
+apigateway:
+  - endpoint: /json/string
+    method: GET
+    enabled: true
+    filters:
+      - ref: response
+        kind: postfilter
+        enabled: true
+        params:
+          input:
+            expr: toJSON(test)
+            type: String
+          header:
+            Content-Type: [ application/json ]
+      - ref: workflow
+        kind: processer
+        enabled: true
+        params:
+          workflow: 'test_variable_json'
+
+workflows:
+  - id: 1
+    enabled: true
+    trace: false
+    handle: test_variable_json
+    meta:
+      name: Test variable
+    triggers:
+      - enabled: true
+        stepID: 1
+    steps:
+      - stepID: 1
+        kind: expressions
+        arguments:
+          - target: test
+            type: Any
+            expr: |
+              {"foo":"bar","baz":{"1":1, "2":2}}

--- a/server/tests/apigw/testdata/postfilter_string_kv/def.yaml
+++ b/server/tests/apigw/testdata/postfilter_string_kv/def.yaml
@@ -1,0 +1,38 @@
+apigateway:
+  - endpoint: /json/kv
+    method: GET
+    enabled: true
+    filters:
+      - ref: response
+        kind: postfilter
+        enabled: true
+        params:
+          input:
+            expr: test
+            type: KV
+          header:
+            Content-Type: [ application/json ]
+      - ref: workflow
+        kind: processer
+        enabled: true
+        params:
+          workflow: 'test_variable_kv'
+
+workflows:
+  - id: 1
+    enabled: true
+    trace: false
+    handle: test_variable_kv
+    meta:
+      name: Test variable
+    triggers:
+      - enabled: true
+        stepID: 1
+    steps:
+      - stepID: 1
+        kind: expressions
+        arguments:
+          - target: test
+            type: KV
+            expr: |
+              {"foo":"bar","baz":123}

--- a/server/tests/helpers/assert.go
+++ b/server/tests/helpers/assert.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"

--- a/server/tests/helpers/rbac.go
+++ b/server/tests/helpers/rbac.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 
+	automationTypes "github.com/cortezaproject/corteza/server/automation/types"
 	composeTypes "github.com/cortezaproject/corteza/server/compose/types"
 	"github.com/cortezaproject/corteza/server/pkg/auth"
 	"github.com/cortezaproject/corteza/server/pkg/cli"
@@ -69,6 +70,11 @@ func Grant(rr ...*rbac.Rule) {
 
 func AllowMeModuleCreate(mrg myRoleGetter) {
 	AllowMe(mrg, composeTypes.NamespaceRbacResource(0), "module.create")
+}
+
+func AllowMeWorkflowSearch(mrg myRoleGetter) {
+	AllowMe(mrg, automationTypes.WorkflowRbacResource(0), "workflows.search")
+	AllowMe(mrg, automationTypes.WorkflowRbacResource(0), "triggers.search")
 }
 
 func AllowMeModuleSearch(mrg myRoleGetter) {


### PR DESCRIPTION
# The following changes are implemented
Ability to return a meaningful response via integration gateway's `Response` postfilter.
This is the backend implementation that might change a bit, depending on the frontend work.

Ref: https://github.com/cortezaproject/corteza/issues/517
