### PR TITLE
Improve text when copying a page

### DIFF
--- a/client/web/compose/src/mixins/pages.js
+++ b/client/web/compose/src/mixins/pages.js
@@ -1,0 +1,66 @@
+import { NoID } from '@cortezaproject/corteza-js'
+
+export default {
+  methods: {
+    countDuplicateTitles (pages, pattern) {
+      let substrTitle = this.page.title
+
+      // if the old page begins with 'copy of' and it does not end with a number in brackets, remove copy of prefix
+      if (this.page.title.includes(this.$t('copyOf')) && !pattern.test(this.page.title)) {
+        substrTitle = this.page.title.substring(this.$t('copyOf').length, this.page.title.length)
+      // if the old page begins with 'copy of' and it ends with a number in brackets, remove them
+      } else if (this.page.title.includes(this.$t('copyOf')) && pattern.test(this.page.title)) {
+        substrTitle = this.page.title.substring(this.$t('copyOf').length, this.page.title.lastIndexOf('(') - 1)
+      }
+
+      return pages.filter(p => p.title.includes(substrTitle)).length
+    },
+
+    handleClone () {
+      const { namespaceID = NoID } = this.namespace
+      const pattern = /\([0-9]+\)/
+
+      let page = this.page.clone()
+
+      this.loadPages({ namespaceID, force: true })
+        .then(pages => {
+          let newPageTitle = this.$t('copyOf', { title: this.page.title })
+          const countDuplicates = this.countDuplicateTitles(pages, pattern)
+
+          // if page with the same name already exists two times, add a number (2) sufix
+          if (countDuplicates === 2) {
+            newPageTitle = this.page.title.includes(this.$t('copyOf'))
+              ? `${this.page.title} (${countDuplicates})`
+              : `${this.$t('copyOf')} ${this.page.title} (${countDuplicates})`
+          } else if (countDuplicates > 2 && this.page.title.includes(this.$t('copyOf'))) {
+            /**
+            * if page with the same name exists more than two times and it has "copy of" prefix, check old page's sufix
+            * If page ends with a number inside parenthesis, replace it with the new number
+            * If page does not have a number, add it
+            */
+            newPageTitle = pattern.test(page.title)
+              ? `${this.page.title.substr(0, this.page.title.lastIndexOf('('))}(${countDuplicates})`
+              : `${this.page.title} (${countDuplicates})`
+          } else if (countDuplicates > 2 && !this.page.title.includes(this.$t('copyOf'))) {
+            // if page with the same name exists more than two times and it does not have "copy of" prefix, append the prefix and the new number
+            newPageTitle = `${this.$t('copyOf')}${this.page.title} (${countDuplicates})`
+          }
+
+          page = {
+            ...page,
+            pageID: NoID,
+            title: newPageTitle,
+            handle: '',
+          }
+
+          return this.createPage({ namespaceID, ...page })
+        })
+        .then(({ pageID }) => {
+          this.$router.push({ name: this.$route.name, params: { pageID } })
+        })
+        .catch(this.toastErrorHandler(this.$t('notification:page.cloneFailed')))
+    },
+
+  },
+
+}

--- a/client/web/compose/src/views/Admin/Pages/Builder.vue
+++ b/client/web/compose/src/views/Admin/Pages/Builder.vue
@@ -223,6 +223,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import pages from 'corteza-webapp-compose/src/mixins/pages'
 import NewBlockSelector from 'corteza-webapp-compose/src/components/Admin/Page/Builder/Selector'
 import PageTranslator from 'corteza-webapp-compose/src/components/Admin/Page/PageTranslator'
 import Grid from 'corteza-webapp-compose/src/components/Common/Grid'
@@ -245,6 +246,10 @@ export default {
     PageTranslator,
   },
 
+  mixins: [
+    pages,
+  ],
+
   props: {
     namespace: {
       type: compose.Namespace,
@@ -261,7 +266,6 @@ export default {
     return {
       editor: undefined,
       page: undefined,
-
       blocks: [],
       board: null,
     }
@@ -360,7 +364,7 @@ export default {
 
         if (pageID) {
           const { namespaceID, name } = this.namespace
-          this.findPageByID({ namespaceID, pageID: this.pageID, force: true })
+          this.findPageByID({ namespaceID, pageID, force: true })
             .then(page => {
               document.title = [page.title, name, this.$t('general:label.app-name.private')].filter(v => v).join(' | ')
 
@@ -386,6 +390,7 @@ export default {
       deletePage: 'page/delete',
       updatePageSet: 'page/updateSet',
       createPage: 'page/create',
+      loadPages: 'page/load',
     }),
 
     addBlock (block, index = undefined) {
@@ -558,23 +563,6 @@ export default {
       } else {
         this.toastErrorHandler(this.$t('notification:page.duplicateFailed'))
       }
-    },
-
-    handleClone () {
-      let page = this.page.clone()
-      page = {
-        ...page,
-        pageID: NoID,
-        title: this.$t('copyOf', { title: this.page.title }),
-        handle: '',
-      }
-
-      const { namespaceID = NoID } = this.namespace
-      this.createPage({ namespaceID, ...page })
-        .then(({ pageID }) => {
-          this.$router.push({ name: 'admin.pages.builder', params: { pageID } })
-        })
-        .catch(this.toastErrorHandler(this.$t('notification:page.cloneFailed')))
     },
   },
 }


### PR DESCRIPTION
# Screenshots
![image](https://user-images.githubusercontent.com/26258032/207543361-81788666-dc84-465d-95a1-2aebd89c0d0a.png)
Image 1 - Copied pages list in the page admin

![image](https://user-images.githubusercontent.com/26258032/207543578-999c95b8-ace3-453d-8978-55fac78f67e7.png)
Image 2 - Save as Copy functionality

# The following changes are implemented
When copying a page in the page builder or the page admin, new naming structure has been implemented. To illustrate this, if you copy a page, called "Test", the new page will become "Copy of Test". If you copy "Copy of Test", it will become "Copy of Test (2)" and so on:  
Test
Copy of Test
Copy of Test (2)
Copy of Test (3)

## Changlelog

### What was changed

When you go to admin => pages and edit a specific page, you have an option to clone existing page by clicking on "Save as Copy" button. (Another way to clone the page by going to the page builder of the specific page). When you click on "Save as Copy" button, a new page is generated and its title recomputed. If no other copies of the old page exist, the title of the new page is constructed by adding a prefix "copy of" to the page title. If other copies exist, a number is added as a sufix to the page's name. To give an example, if you copy a page, called "Test", the new page will become "Copy of Test". If you copy "Copy of Test", it will become "Copy of Test (2)" and so on:  

Test
Copy of Test
Copy of Test (2)
Copy of Test (3)

In previous versions of Corteza, the copied page was always prefixed with 'copy of'. If we continue with the same example as above, the page dublication process  used to look like that:

Test
Copy of Test
Copy of Copy of Test
Copy of Copy of Test
Copy of Copy of Copy of Test

### How was changed

In Compose, two files have been adjusted, `views/Admin/Pages/Edit.vue` and `views/Admin/Pages/Builder.vue`. The namespace's pages have been programatically filtered to find how many times a certain page with same name already exists by excluding 'copy of' prefix and number sufix. Depending on the number of pages that match the same name, a counter is adjusted. 

### Why was changed

If we copy a page 3-4 or more times, the naming gets confusing and too long. Reshaping this aims to improve user interaction across Corteza.