### PR TITLE
fix authorized clients empty-list text view

### DIFF
--- a/server/auth/assets/templates/authorized-clients.html.tpl
+++ b/server/auth/assets/templates/authorized-clients.html.tpl
@@ -31,13 +31,16 @@
                 {{ tr "authorized-clients.template.list.buttons.revoke" }}
             </button>
         </div>
-		<div
-            data-test-id="text-empty-list"
-            class="text-center m-3 mb-3"
-        >
-			<i>{{ tr "authorized-clients.template.list.empty" }}</i>
-		</div>
-	{{ end }}
-	</form>
+        {{ end }}
+    </form>
+
+    {{ if not .authorizedClients}}
+    <div
+        data-test-id="text-empty-list"
+        class="text-center m-3 mb-3"
+    >
+        <i>{{ tr "authorized-clients.template.list.empty" }}</i>
+    </div>
+    {{ end }}
 </div>
 {{ template "inc_footer.html.tpl" . }}


### PR DESCRIPTION
Fix : show  **_no authorized clients found_**  text on an empty authorized clients list instead of a full one.
