### PR TITLE
Show loading spinner before displaying the page tree content

### DIFF
--- a/client/web/compose/src/views/Admin/Pages/List.vue
+++ b/client/web/compose/src/views/Admin/Pages/List.vue
@@ -74,7 +74,20 @@
               </b-col>
             </b-row>
 
+            <div
+              v-if="processing"
+              class="text-center text-muted m-5"
+            >
+              <div>
+                <b-spinner
+                  class="align-middle m-2"
+                />
+              </div>
+              {{ $t('loading') }}
+            </div>
+
             <page-tree
+              v-else
               v-model="tree"
               :namespace="namespace"
               class="pb-2"
@@ -115,6 +128,7 @@ export default {
     return {
       tree: [],
       page: new compose.Page({ visible: true }),
+      processing: false,
     }
   },
 
@@ -128,10 +142,14 @@ export default {
     }),
 
     loadTree () {
+      this.processing = true
       const { namespaceID } = this.namespace
       this.$ComposeAPI.pageTree({ namespaceID }).then((tree) => {
         this.tree = tree.map(p => new compose.Page(p))
       }).catch(this.toastErrorHandler(this.$t('notification:page.loadFailed')))
+        .finally(() => {
+          this.processing = false
+        })
     },
 
     handleAddPageFormSubmit () {

--- a/locale/en/corteza-webapp-compose/page.yaml
+++ b/locale/en/corteza-webapp-compose/page.yaml
@@ -31,6 +31,7 @@ label:
   pageBuilder: Page builder
   permissions: Permissions
   saveAndClose: Save and close
+loading: Loading
 moduleEdit: Edit module
 navigation:
   page: Pages


### PR DESCRIPTION
# The following changes are implemented
Added loading spinner before displaying the Page/Tree content

# Changes in the user interface:
**With pages**
![with-pages](https://user-images.githubusercontent.com/85161724/207916175-11c6afb3-d450-4e2f-8d9a-3ae6dcfa5445.gif)

**Without pages**
![without-pages](https://user-images.githubusercontent.com/85161724/207916195-ee12c067-0feb-4c12-88c9-46585581b367.gif)