### PR TITLE
Fix reporter page block load elements error

### DIFF
--- a/client/web/reporter/src/components/Report/Blocks/index.vue
+++ b/client/web/reporter/src/components/Report/Blocks/index.vue
@@ -188,10 +188,14 @@ export default {
       this.dataframes = {}
       const frames = []
 
-      this.block.elements.forEach((element) => {
+      this.block.elements.forEach((element, key) => {
         element = reporter.DisplayElementMaker(element)
 
         if (element && element.kind !== 'Text') {
+          if (element.elementID === '0') {
+            element.elementID = `${key}`
+          }
+
           const { dataframes = [] } = element.reportDefinitions(this.getScenarioDefinition(element))
 
           frames.push(...dataframes.filter(({ source }) => source))
@@ -201,7 +205,10 @@ export default {
       if (frames.length) {
         this.$SystemAPI.reportRun({ frames, reportID: this.reportID })
           .then(({ frames = [] }) => {
-            this.block.elements = this.block.elements.map(element => {
+            this.block.elements = this.block.elements.map((element, key) => {
+              if (element.elementID === '0') {
+                element.elementID = `${key}`
+              }
               const dataframes = frames.filter(({ name }) => name === element.elementID)
               return { ...element, dataframes }
             })


### PR DESCRIPTION
# The following changes are implemented

More than one load element can be added to the reporter page block without   getting 
 `expecting at most one definition, got [number of elements]`  error message.


Fixes https://github.com/cortezaproject/corteza/issues/597