### PR TITLE
Add notification message on successful namespace delete

### DIFF
--- a/client/web/compose/src/views/Namespace/Edit.vue
+++ b/client/web/compose/src/views/Namespace/Edit.vue
@@ -595,9 +595,12 @@ export default {
             return this.$SystemAPI.applicationDelete({ applicationID })
           }
         })
+        .then(() => {
+          this.$router.push({ name: 'namespace.manage' })
+          this.toastSuccess(this.$t('notification:namespace.deleted'))
+        })
         .finally(() => {
           this.processing = false
-          this.$router.push({ name: 'namespace.manage' })
         })
     },
 

--- a/locale/en/corteza-webapp-compose/notification.yaml
+++ b/locale/en/corteza-webapp-compose/notification.yaml
@@ -60,6 +60,7 @@ namespace:
     saveFailed: Could not save namespace application
   assetUploadFailed: Could not upload attached assets
   createFailed: Could not create namespace
+  deleted: Namespace deleted
   deleteFailed: Could not delete this namespace
   disabled: Namespace disabled - redirecting
   saveFailed: Could not save this namespace


### PR DESCRIPTION
# Screenshots
![image](https://user-images.githubusercontent.com/26258032/209119403-0c0375c2-1cd2-45b1-908b-70aa7ad4f44c.png)


# The following changes are implemented
Upon successful namespace deletion, a notification pops up that the namespace has been successfully deleted.