### PR TITLE
Adjust node styles in FederationSettings when zooming in/out

### DIFF
--- a/client/web/compose/src/components/Admin/Module/FederationSettings.vue
+++ b/client/web/compose/src/components/Admin/Module/FederationSettings.vue
@@ -50,11 +50,19 @@
             :key="f.nodeID"
             href="#"
             :class="{ 'border border-primary': f.nodeID === upstream.active }"
-            class="border text-truncate"
+            class="border d-flex flex-column"
             @click="upstream.active = f.nodeID"
           >
-            {{ f.name }}<br>
-            <small>{{ f.baseURL }}</small>
+            <p
+              class="mb-0 text-truncate"
+            >
+              {{ f.name }}
+            </p>
+            <small
+              class="text-truncate"
+            >
+              {{ f.baseURL }}
+            </small>
           </b-list-group-item>
         </b-list-group>
 
@@ -142,11 +150,19 @@
             :key="f.nodeID"
             href="#"
             :class="{ 'border border-primary': f.nodeID === downstream.active }"
-            class="border text-truncate"
+            class="border d-flex flex-column"
             @click="downstream.active = f.nodeID"
           >
-            {{ f.name }}<br>
-            <small>{{ f.baseURL }}</small>
+            <p
+              class="mb-0 text-truncate"
+            >
+              {{ f.name }}
+            </p>
+            <small
+              class="text-truncate"
+            >
+              {{ f.baseURL }}
+            </small>
           </b-list-group-item>
         </b-list-group>
 


### PR DESCRIPTION
# The following changes are implemented
Adjust node styles in FederationSettings when zooming in/out

# Changes in the user interface:

![1](https://user-images.githubusercontent.com/85161724/209979290-47c6eca8-9d49-4820-8f97-a02a3ae737e5.gif)
