### PR TITLE
Align text message in inc_toasts.html

### DIFF
--- a/server/auth/assets/templates/inc_toasts.html.tpl
+++ b/server/auth/assets/templates/inc_toasts.html.tpl
@@ -1,7 +1,7 @@
 <div class="position-fixed bottom-0 right-0 p-3 mb-2" style="z-index: 5; right: 0; bottom: 0;">
 {{ range . }}
 	<div class="toast align-items-center bg-dark text-white" role="alert" aria-live="polite" aria-atomic="true" data-delay="5000" style="min-width:200px;">
-	  <div class="d-flex toast-body border-top border-{{ .Type }}">
+	  <div class="d-flex align-items-center toast-body border-top border-{{ .Type }}">
 		{{ .Text | html }}
 		<button type="button" class="ml-auto text-white btn p-0" data-dismiss="toast" aria-label="Close">
 		<i class="bi bi-x"></i>


### PR DESCRIPTION
# The following changes are implemented
The text of the toast message was centered according to the y axis

# Changes in the user interface:
<img width="724" alt="Screenshot 2022-12-30 at 12 56 28" src="https://user-images.githubusercontent.com/85161724/210064138-d45fc78f-db5c-4c3a-8bf4-531048518966.png">