### PR TITLE
Preview page attachments in public pages

### DIFF
--- a/client/web/compose/src/views/Namespace/View.vue
+++ b/client/web/compose/src/views/Namespace/View.vue
@@ -45,11 +45,14 @@
         </div>
       </div>
     </div>
+
+    <attachment-modal />
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
+import AttachmentModal from 'corteza-webapp-compose/src/components/Public/Page/Attachment/Modal'
 
 export default {
   i18nOptions: {
@@ -57,6 +60,10 @@ export default {
   },
 
   name: 'Namespace',
+
+  components: {
+    AttachmentModal,
+  },
 
   props: {
     slug: {

--- a/client/web/compose/src/views/Public/Pages/View.vue
+++ b/client/web/compose/src/views/Public/Pages/View.vue
@@ -64,14 +64,11 @@
         :page="page"
       />
     </div>
-
-    <attachment-modal />
   </div>
 </template>
 <script>
 import { mapActions } from 'vuex'
 import Grid from 'corteza-webapp-compose/src/components/Public/Page/Grid'
-import AttachmentModal from 'corteza-webapp-compose/src/components/Public/Page/Attachment/Modal'
 import PageTranslator from 'corteza-webapp-compose/src/components/Admin/Page/PageTranslator'
 import { compose, NoID } from '@cortezaproject/corteza-js'
 
@@ -82,7 +79,6 @@ export default {
 
   components: {
     Grid,
-    AttachmentModal,
     PageTranslator,
   },
 


### PR DESCRIPTION
# The following changes are implemented
Moved attachment modal from Public/Pages/View to Namespace/View so attachments can be previewed in the admin area of compose

# Changes in the user interface:

![1](https://user-images.githubusercontent.com/85161724/210213489-2512ec93-2a4c-4433-8849-55387e520e52.gif)
