### PR TITLE
Close import modal after successfully importing a workflow

### DIFF
--- a/client/web/workflow/src/components/Import.vue
+++ b/client/web/workflow/src/components/Import.vue
@@ -9,6 +9,7 @@
     </b-button>
 
     <b-modal
+      id="import"
       v-model="show"
       size="lg"
       :title="$t('general:import.json')"

--- a/client/web/workflow/src/components/WorkflowEditor.vue
+++ b/client/web/workflow/src/components/WorkflowEditor.vue
@@ -2497,6 +2497,7 @@ export default {
 
         this.importProcessing = false
         this.$root.$emit('change-detected')
+        this.$bvModal.hide('import')
         this.toastSuccess(this.$t('notification:imported-workflow'))
       } catch (e) {
         this.toastErrorHandler(this.$t('notification:import-failed'))(e)

--- a/client/web/workflow/src/views/Workflow/List.vue
+++ b/client/web/workflow/src/views/Workflow/List.vue
@@ -290,6 +290,7 @@ export default {
           } else {
             this.toastSuccess(this.$t('notification:import.imported-workflows'))
           }
+          this.$bvModal.hide('import')
         })
         .catch(this.toastErrorHandler(this.$t('notification:import.failed-import')))
 


### PR DESCRIPTION
# The following changes are implemented
Close import modal after successfully importing a workflow

# Changes in the user interface:

![1](https://user-images.githubusercontent.com/85161724/210235603-5aa18b69-ac95-4553-b949-1b24729ad0af.gif)
