### PR TITLE
Add a nicer error when trying to delete in use sens. levels

### DIFF
--- a/locale/en/corteza-server/system/dal-sensitivity-level.yaml
+++ b/locale/en/corteza-server/system/dal-sensitivity-level.yaml
@@ -6,3 +6,4 @@ errors:
   invalidID: invalid ID
   notAllowedToManage: not allowed to manage sensitivity level
   notFound: sensitivity level not found
+  deleteInUse: cannot delete in use sensitivity levels

--- a/server/pkg/dal/sensitivity_level.go
+++ b/server/pkg/dal/sensitivity_level.go
@@ -16,6 +16,12 @@ type (
 		byHandle map[string]int
 		byID     map[uint64]int
 	}
+
+	SensitivityLevelUsage struct {
+		connections []map[string]any
+		modules     []map[string]any
+		fields      []map[string]any
+	}
 )
 
 func SensitivityLevelIndex(levels ...SensitivityLevel) *sensitivityLevelIndex {
@@ -97,3 +103,7 @@ func (sli sensitivityLevelIndex) isSubset(a, b uint64) (ok bool) {
 func (a SensitivityLevelSet) Len() int           { return len(a) }
 func (a SensitivityLevelSet) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a SensitivityLevelSet) Less(i, j int) bool { return a[i].Level < a[j].Level }
+
+func (u SensitivityLevelUsage) Empty() bool {
+	return len(u.connections)+len(u.fields)+len(u.modules) == 0
+}

--- a/server/pkg/dal/service.go
+++ b/server/pkg/dal/service.go
@@ -227,6 +227,44 @@ func (svc *service) RemoveSensitivityLevel(levelIDs ...uint64) (err error) {
 	return
 }
 
+// InUseSensitivityLevel checks if and where the sensitivity level is being used
+func (svc *service) InUseSensitivityLevel(levelID uint64) (usage SensitivityLevelUsage) {
+	usage = SensitivityLevelUsage{}
+
+	// - connections
+	for _, c := range svc.connections {
+		if levelID == c.Config.SensitivityLevelID {
+			usage.connections = append(usage.connections, map[string]any{
+				// @todo add when needed
+				"ident": c.Config.Label,
+			})
+		}
+	}
+
+	// - models
+	for _, mm := range svc.models {
+		for _, m := range mm {
+			if levelID == m.SensitivityLevelID {
+				usage.modules = append(usage.modules, map[string]any{
+					// @todo add when needed
+					"ident": m.Ident,
+				})
+			}
+
+			for _, attr := range m.Attributes {
+				if levelID == attr.SensitivityLevelID {
+					usage.fields = append(usage.fields, map[string]any{
+						// @todo add when needed
+						"ident": attr.Ident,
+					})
+				}
+			}
+		}
+	}
+
+	return
+}
+
 // // // // // // // // // // // // // // // // // // // // // // // // //
 
 // // // // // // // // // // // // // // // // // // // // // // // // //

--- a/server/system/service/dal_sensitivity_level.go
+++ b/server/system/service/dal_sensitivity_level.go
@@ -28,6 +28,7 @@ type (
 	dalSensitivityLevelManager interface {
 		ReplaceSensitivityLevel(levels ...dal.SensitivityLevel) (err error)
 		RemoveSensitivityLevel(levels ...uint64) (err error)
+		InUseSensitivityLevel(levelID uint64) (usage dal.SensitivityLevelUsage)
 	}
 )
 
@@ -152,6 +153,10 @@ func (svc *dalSensitivityLevel) DeleteByID(ctx context.Context, ID uint64) (err 
 
 		if !svc.ac.CanManageDalSensitivityLevel(ctx) {
 			return DalSensitivityLevelErrNotAllowedToManage(qProps)
+		}
+
+		if !svc.dal.InUseSensitivityLevel(ID).Empty() {
+			return DalSensitivityLevelErrDeleteInUse()
 		}
 
 		qProps.setSensitivityLevel(q)

--- a/server/system/service/dal_sensitivity_level_actions.gen.go
+++ b/server/system/service/dal_sensitivity_level_actions.gen.go
@@ -563,6 +563,40 @@ func DalSensitivityLevelErrAlreadyExists(mm ...*dalSensitivityLevelActionProps) 
 	return e
 }
 
+// DalSensitivityLevelErrDeleteInUse returns "system:dal-sensitivity-level.deleteInUse" as *errors.Error
+//
+//
+// This function is auto-generated.
+//
+func DalSensitivityLevelErrDeleteInUse(mm ...*dalSensitivityLevelActionProps) *errors.Error {
+	var p = &dalSensitivityLevelActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("failed to delete sensitivity level {{sensitivityLevel}} because it is in use by other resources", nil),
+
+		errors.Meta("type", "deleteInUse"),
+		errors.Meta("resource", "system:dal-sensitivity-level"),
+
+		errors.Meta(dalSensitivityLevelPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "dal-sensitivity-level.errors.deleteInUse"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
 // DalSensitivityLevelErrNotAllowedToManage returns "system:dal-sensitivity-level.notAllowedToManage" as *errors.Error
 //
 //

--- a/server/system/service/dal_sensitivity_level_actions.yaml
+++ b/server/system/service/dal_sensitivity_level_actions.yaml
@@ -68,6 +68,9 @@ errors:
     message: "sensitivityLevel by that DSN already exists"
     severity: warning
 
+  - error: deleteInUse
+    message: "failed to delete sensitivity level {{sensitivityLevel}} because it is in use by other resources"
+
   - error: notAllowedToManage
     message: "not allowed to Manage a sensitivityLevel"
     log: "failed to Manage a sensitivityLevel; insufficient permissions"


### PR DESCRIPTION
This code adds some analysis to find out if a sensitivity level is being in use before trying to delete it.
Before, the user would get a _scary_ looking error but now it's clearer.