### PR TITLE
Fix Magnify Icon on Record Revisions Block

### DIFF
--- a/client/web/compose/src/components/PageBlocks/RecordListBase.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListBase.vue
@@ -1155,9 +1155,8 @@ export default {
         window.open(this.$router.resolve(route).href)
       } else if (this.options.recordDisplayOption === 'modal') {
         this.$root.$emit('show-record-modal', {
-          moduleID: this.recordListModule.moduleID,
-          recordPageID: this.recordPageID,
           recordID,
+          recordPageID: this.recordPageID,
         })
       } else {
         this.$router.push(route)

--- a/client/web/compose/src/components/PageBlocks/Wrap/base.vue
+++ b/client/web/compose/src/components/PageBlocks/Wrap/base.vue
@@ -1,6 +1,10 @@
 <script>
 import { compose } from '@cortezaproject/corteza-js'
 export default {
+  i18nOptions: {
+    namespaces: 'block',
+  },
+
   props: {
     block: {
       type: compose.PageBlock,
@@ -13,6 +17,7 @@ export default {
       default: () => true,
     },
   },
+
   computed: {
     blockClass () {
       return [


### PR DESCRIPTION
## Changelog

### What was fixed
When you open magnified record page, the magnify option/button did not work for record revisions page block.

### How was fixed
Adding a record prop to the revisions block was able to display the block inside the magnification modal

### Why was fixed
It was a bug that prevented the record revisions block on record page to work properly.
