### PR TITLE
WIP properly translate auth error messages

### DIFF
--- a/locale/en/corteza-server/system/auth.yaml
+++ b/locale/en/corteza-server/system/auth.yaml
@@ -23,3 +23,4 @@ errors:
   passwordResetDisabledByConfig: password reset is disabled
   profileWithoutValidEmail: external authentication provider returned profile without valid email
   unconfiguredTOTP: TOTP not configured
+  passwordResetFailedOldPasswordCheckFailed: failed to change password, old password does not match

--- a/server/auth/handlers/handle_change-password.go
+++ b/server/auth/handlers/handle_change-password.go
@@ -40,10 +40,8 @@ func (h *AuthHandlers) changePasswordProc(req *request.AuthReq) (err error) {
 		service.AuthErrPasswordChangeFailedForUnknownUser().Is(err),
 		service.AuthErrPasswordResetFailedOldPasswordCheckFailed().Is(err),
 		service.AuthErrPasswordSetFailedReusedPasswordCheckFailed().Is(err):
-		req.SetKV(map[string]string{
-			"error": err.Error(),
-		})
 		req.RedirectTo = GetLinks().ChangePassword
+		req.SetError(err)
 
 		h.Log.Warn("handled error", zap.Error(err))
 		return nil


### PR DESCRIPTION
TL;DR

A new util fnc. was added which attaches the error to the auth request. If the error is translatable, it is translated similarly to how we do it elsewhere, else, it's used as is.