### PR TITLE
Fix geometry map overlapping page block toolbox

### DIFF
--- a/client/web/compose/src/views/Admin/Pages/Builder.vue
+++ b/client/web/compose/src/views/Admin/Pages/Builder.vue
@@ -582,7 +582,7 @@ div.toolbox {
   background-color: $dark;
   bottom: 0;
   left: 0;
-  z-index: 100;
+  z-index: 401;
   border-top-right-radius: 10px;
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
# The following changes are implemented
z-index of toolbox was increased to 401. Before it was 100

# Changes in the user interface:

<img width="771" alt="Screenshot 2023-01-11 at 17 23 24" src="https://user-images.githubusercontent.com/85161724/211845342-1ba1d2a1-8fa2-4608-bede-3d57cd3f7b25.png">

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [x] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
