### PR TITLE
Make name property required for templates, dal connections and workfl…

### DIFF
--- a/client/web/admin/src/components/Authclient/CAuthclientEditorInfo.vue
+++ b/client/web/admin/src/components/Authclient/CAuthclientEditorInfo.vue
@@ -17,6 +17,7 @@
           v-model="authClient.meta.name"
           data-test-id="input-name"
           required
+          :state="nameState"
         />
       </b-form-group>
 
@@ -634,6 +635,10 @@ export default {
       return this.secret.length > 0
     },
 
+    nameState () {
+      return this.authClient.meta.name ? null : false
+    },
+
     handleState () {
       return handle.handleState(this.authClient.handle)
     },
@@ -647,7 +652,7 @@ export default {
     },
 
     saveDisabled () {
-      return !this.editable || [this.handleState].includes(false)
+      return !this.editable || [this.nameState, this.handleState].includes(false)
     },
   },
 

--- a/client/web/admin/src/components/Connection/CConnectionEditorInfo.vue
+++ b/client/web/admin/src/components/Connection/CConnectionEditorInfo.vue
@@ -15,8 +15,10 @@
         >
           <b-form-input
             v-model="connection.meta.name"
+            required
             :disabled="disabled"
             :placeholder="$t('form.name.placeholder')"
+            :state="nameState"
           />
         </b-form-group>
       </b-col>
@@ -165,6 +167,10 @@ export default {
   },
 
   computed: {
+    nameState () {
+      return this.connection.meta.name ? null : false
+    },
+
     handleState () {
       return handle.handleState(this.connection.handle)
     },

--- a/client/web/admin/src/components/SensitivityLevel/CSensitivityLevelEditorInfo.vue
+++ b/client/web/admin/src/components/SensitivityLevel/CSensitivityLevelEditorInfo.vue
@@ -17,6 +17,8 @@
           >
             <b-form-input
               v-model="sensitivityLevel.meta.name"
+              required
+              :state="nameState"
             />
           </b-form-group>
         </b-col>
@@ -183,12 +185,16 @@ export default {
       return this.fresh ? this.canCreate : true
     },
 
+    nameState () {
+      return this.sensitivityLevel.meta.name ? null : false
+    },
+
     handleState () {
       return handle.handleState(this.sensitivityLevel.handle)
     },
 
     saveDisabled () {
-      return !this.editable || [this.handleState].includes(false)
+      return !this.editable || [this.nameState, this.handleState].includes(false)
     },
 
     getDeleteStatus () {

--- a/client/web/admin/src/components/Template/CTemplateEditorInfo.vue
+++ b/client/web/admin/src/components/Template/CTemplateEditorInfo.vue
@@ -15,6 +15,8 @@
         <b-form-input
           v-model="template.meta.short"
           data-test-id="input-short-name"
+          required
+          :state="shortState"
         />
       </b-form-group>
 
@@ -200,12 +202,16 @@ export default {
       return this.fresh ? this.canCreate : true // this.template.canUpdateRole
     },
 
+    shortState () {
+      return this.template.meta.short ? null : false
+    },
+
     handleState () {
       return handle.handleState(this.template.handle)
     },
 
     saveDisabled () {
-      return !this.editable || [this.handleState].includes(false)
+      return !this.editable || [this.shortState, this.handleState].includes(false)
     },
 
     getDeleteStatus () {

--- a/client/web/admin/src/components/Workflow/CWorkflowEditorInfo.vue
+++ b/client/web/admin/src/components/Workflow/CWorkflowEditorInfo.vue
@@ -27,6 +27,7 @@
         <b-form-input
           v-model="workflow.meta.name"
           required
+          :state="nameState"
         />
       </b-form-group>
 
@@ -185,6 +186,10 @@ export default {
   computed: {
     editable () {
       return (!this.workflow.workflowID || this.workflow.workflowID === NoID) || this.workflow.canUpdateWorkflow
+    },
+
+    nameState () {
+      return this.workflow.meta.name ? null : false
     },
 
     handleState () {

--- a/client/web/admin/src/views/System/Connection/Editor.vue
+++ b/client/web/admin/src/views/System/Connection/Editor.vue
@@ -132,12 +132,16 @@ export default {
       return this.fresh ? this.canCreate : true // this.user.canUpdateUser
     },
 
+    nameState () {
+      return this.connection.meta.name ? null : false
+    },
+
     handleState () {
       return handle.handleState(this.connection.handle)
     },
 
     saveDisabled () {
-      return !this.editable || [this.handleState].includes(false)
+      return !this.editable || [this.nameState, this.handleState].includes(false)
     },
 
   },

--- a/lib/js/src/api-clients/system.ts
+++ b/lib/js/src/api-clients/system.ts
@@ -1559,9 +1559,6 @@ export default class System {
       level,
       meta,
     } = (a as KV) || {}
-    if (!handle) {
-      throw Error('field handle is empty')
-    }
     if (!level) {
       throw Error('field level is empty')
     }
@@ -1595,9 +1592,6 @@ export default class System {
     } = (a as KV) || {}
     if (!sensitivityLevelID) {
       throw Error('field sensitivityLevelID is empty')
-    }
-    if (!handle) {
-      throw Error('field handle is empty')
     }
     if (!level) {
       throw Error('field level is empty')

--- a/locale/en/corteza-webapp-admin/automation.workflows.yaml
+++ b/locale/en/corteza-webapp-admin/automation.workflows.yaml
@@ -7,7 +7,7 @@ editor:
     handle: Handle
     invalid-handle-characters: Should be at least 2 characters long and start with a letter. Can contain only letters, numbers, dashes, underscores and dots
     id: ID
-    name: Name
+    name: Name *
     openBuilder: Open builder
     title: Basic information
     undelete: Undelete

--- a/locale/en/corteza-webapp-admin/system.authclients.yaml
+++ b/locale/en/corteza-webapp-admin/system.authclients.yaml
@@ -20,7 +20,7 @@ editor:
       label: Handle
       placeholder-handle: handle (a - z, 0 - 9, underscore, dash)
       invalid-handle-characters: Should be at least 2 characters long and start with a letter. Can contain only letters, numbers, dashes, underscores and dots
-    name: Name
+    name: Name *
     no-time: No time selected
     profile: Allow client access to user's profile
     redirectURI: Redirect URI's

--- a/locale/en/corteza-webapp-admin/system.connections.yaml
+++ b/locale/en/corteza-webapp-admin/system.connections.yaml
@@ -33,7 +33,7 @@ editor:
     title: Basic settings
     form:
       name:
-        label: Name
+        label: Name *
         placeholder: Data lake
         description: ''
       handle:

--- a/locale/en/corteza-webapp-admin/system.sensitivityLevel.yaml
+++ b/locale/en/corteza-webapp-admin/system.sensitivityLevel.yaml
@@ -9,7 +9,7 @@ editor:
       label: Handle
       placeholder: handle (a - z, 0 - 9, underscore, dash)
       invalid-characters: Should be at least 2 characters long and start with a letter. Can contain only letters, numbers, dashes, underscores and dots
-    name: Name
+    name: Name *
     description: Description
     level: Level {{level}}
     createdAt: Created at

--- a/locale/en/corteza-webapp-admin/system.templates.yaml
+++ b/locale/en/corteza-webapp-admin/system.templates.yaml
@@ -31,7 +31,7 @@ editor:
     invalid-handle-characters: Should be at least 2 characters long and start with a letter. Can contain only letters, numbers, dashes, underscores and dots
     meta:
       description: Description
-      short: Short name
+      short: Short name *
     partial: Partial template
     partialDescription: Partial templates may be used inside other templates such as headers and footers. Partial templates may not be used on their own.
     title: Basic information


### PR DESCRIPTION
…ows on FE

# The following changes are implemented
Made name property required for templates, dal connections and workflows in admin by: 
- adding * to required fields (short name/name)
- applied validation for entered short name/name: if a value isn't provided, the field will be outlined in red, else no outline will be added
- disabled submit button unless required values are provided

# Changes in the user interface:
No data
<img width="1035" alt="Screenshot 2023-01-26 at 17 48 27" src="https://user-images.githubusercontent.com/85161724/214883133-ee2dfa5b-43ba-456d-ba93-37ac3b2f9dd8.png">

With data
<img width="1035" alt="Screenshot 2023-01-26 at 17 48 54" src="https://user-images.githubusercontent.com/85161724/214883129-998022fb-c7f9-402b-91f1-622b1a2fce05.png">


# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [x] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
