### PR TITLE
2022.9.x fix pgsql id columns datatype

### DIFF
--- a/server/store/adapters/rdbms/drivers/postgres/dialect.go
+++ b/server/store/adapters/rdbms/drivers/postgres/dialect.go
@@ -114,10 +114,10 @@ func (postgresDialect) AttributeToColumn(attr *dal.Attribute) (col *ddl.Column, 
 
 	switch t := attr.Type.(type) {
 	case *dal.TypeID:
-		col.Type.Name = "BIGINT"
+		col.Type.Name = "NUMERIC"
 		col.Default = ddl.DefaultID(t.HasDefault, t.DefaultValue)
 	case *dal.TypeRef:
-		col.Type.Name = "BIGINT"
+		col.Type.Name = "NUMERIC"
 		col.Default = ddl.DefaultID(t.HasDefault, t.DefaultValue)
 
 	case *dal.TypeTimestamp:

--- a/server/store/adapters/rdbms/upgrade.go
+++ b/server/store/adapters/rdbms/upgrade.go
@@ -182,3 +182,16 @@ func renameColumn(ctx context.Context, s *Store, table string, from, to string) 
 
 	return nil
 }
+
+// tableNames returns table names that Corteza creates
+func tableNames() (tnames []string) {
+	cortezaModels := append(systemModels.Models(), composeModels.Models()...)
+	cortezaModels = append(cortezaModels, automationModels.Models()...)
+	cortezaModels = append(cortezaModels, federationModels.Models()...)
+
+	for _, m := range cortezaModels {
+		tnames = append(tnames, m.Ident)
+	}
+
+	return tnames
+}


### PR DESCRIPTION
Change PSQL ID column datatype from `int8` to `numeric` to enable support for  Corteza ID ` uint64` data type.

Fixes: https://github.com/cortezaproject/corteza/issues/682
