### PR TITLE
Fix Post-processing function not working for gauge chart

### DIFF
--- a/lib/js/src/compose/types/chart/base.ts
+++ b/lib/js/src/compose/types/chart/base.ts
@@ -6,6 +6,7 @@ import {
   Report,
   dimensionFunctions,
   makeAlias,
+  TemporalDataPoint,
 } from './util'
 
 import {
@@ -16,6 +17,10 @@ import {
 } from '../../../cast'
 
 export type PartialChart = Partial<BaseChart>
+
+// The default dataset post processing function to use.
+// This one simply returns the current value.
+const defaultFx = 'n'
 
 /**
  * BaseChart represents a structure that stores any configuration data.
@@ -39,6 +44,59 @@ export class BaseChart {
 
   constructor (def: PartialChart = {}) {
     this.merge(def)
+  }
+
+  /**
+   * The method performs post processing for each value in the given dataset.
+   * It works with a simple equation written in javascript (example: n + m).
+   * Available variables to use:
+   * * n - current value
+   * * m - previous value (undefined in case of the first element)
+   * * r - entire data array.
+   *
+   * @param data Array of values in the given data set
+   * @param m Metric for the given dataset
+   */
+  datasetPostProc (data: Array<number|TemporalDataPoint>, m: Metric): Array<number|TemporalDataPoint> {
+    // Define a valid function to evaluate
+    let fxRaw = (m.fx || defaultFx).trim()
+    if (!fxRaw.startsWith('return')) {
+      fxRaw = 'return ' + fxRaw
+    }
+    const fx = new Function('n', 'm', 'r', fxRaw)
+
+    // Define a new array, so we don't alter the original one.
+    const r = [...data]
+
+    // Run postprocessing for all data in the given data set
+    // There is a slight difference between temporal data points and categorical data points.
+    if (data[0] instanceof Object) {
+      // Temporal
+      for (let i = 0; i < data.length; i++) {
+        const a = data[i] as TemporalDataPoint
+        const b = data[i - 1] as TemporalDataPoint|undefined
+
+        const n = a.y
+        let m: number|undefined
+        if (i > 0) {
+          m = b?.y
+        }
+
+        a.y = fx(n, m, r)
+      }
+    } else {
+      // Categorical
+      for (let i = 0; i < data.length; i++) {
+        const n = data[i] as number
+        let m: number|undefined
+        if (i > 0) {
+          m = data[i - 1] as number
+        }
+        data[i] = fx(n, m, r)
+      }
+    }
+
+    return data
   }
 
   merge (c: PartialChart) {

--- a/lib/js/src/compose/types/chart/gauge.ts
+++ b/lib/js/src/compose/types/chart/gauge.ts
@@ -4,6 +4,7 @@ import {
   Report,
   Dimension,
   ChartType,
+  TemporalDataPoint,
 } from './util'
 import { getColorschemeColors } from '../../../shared'
 
@@ -36,10 +37,12 @@ export default class GaugeChart extends BaseChart {
     return (d.meta?.steps || []).map(({ label }: any) => label)
   }
 
-  makeDataset (m: Metric, d: Dimension, data: Array<number|any>, alias: string) {
+  makeDataset (m: Metric, d: Dimension, data: Array<number|TemporalDataPoint>, alias: string) {
     const steps = (d.meta?.steps || [])
 
-    const value = data.reduce((acc, cur) => {
+     data = this.datasetPostProc(data, m)
+
+     const value = data.reduce((acc: any, cur: any) => {
       return !isNaN(cur) ? acc + parseFloat(cur) : acc
     }, 0)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26258032/218103145-ecf09886-ddea-4751-a872-8bea2ffd00b8.png)

### Changelog

### What was fixed?
Post processing function in Gauge chart in Compose did not work as expected. The end result of the Gauge chart was not updated based on the post processing function field. In contrast. this works for standard charts.

### How was fixed?
Post processing method was added to Gauge Chart compose type in `lib/corteza-js`. 

### Why was fixed?
Users should be able to do basic computations and write expressions based on the result of the chart, in the same way as in standard charts.