### PR TITLE
Fix relative value shown incorrectly for bar and line charts

### DIFF
--- a/lib/js/src/compose/types/chart/chart.ts
+++ b/lib/js/src/compose/types/chart/chart.ts
@@ -21,6 +21,9 @@ export default class Chart extends BaseChart {
   makeDataset (m: Metric, d: Dimension, data: Array<number|TemporalDataPoint>, alias: string) {
     data = this.datasetPostProc(data, m)
 
+    console.log(m.relativeValue)
+    console.log(!!m.relativeValue)
+
     return {
       type: m.type,
       label: m.label || m.field,
@@ -28,7 +31,7 @@ export default class Chart extends BaseChart {
       fill: !!m.fill,
       tooltip: {
         fixed: m.fixTooltips,
-        relative: !!m.relativeValue,
+        relative: !!(m.relativeValue && m.type !== 'bar' && m.type!=='line'),
       },
     }
   }

--- a/lib/js/src/compose/types/chart/chart.ts
+++ b/lib/js/src/compose/types/chart/chart.ts
@@ -21,9 +21,6 @@ export default class Chart extends BaseChart {
   makeDataset (m: Metric, d: Dimension, data: Array<number|TemporalDataPoint>, alias: string) {
     data = this.datasetPostProc(data, m)
 
-    console.log(m.relativeValue)
-    console.log(!!m.relativeValue)
-
     return {
       type: m.type,
       label: m.label || m.field,
@@ -31,7 +28,7 @@ export default class Chart extends BaseChart {
       fill: !!m.fill,
       tooltip: {
         fixed: m.fixTooltips,
-        relative: !!(m.relativeValue && m.type !== 'bar' && m.type!=='line'),
+        relative: m.relativeValue && !['bar', 'line'].includes(m.type as string),
       },
     }
   }


### PR DESCRIPTION
### What was fixed?
The relative value option was removed from bar and line charts, since these charts are not meant to display relative data.