### PR TITLE
Add Record Page Links to Reminders

### DIFF
--- a/client/web/compose/src/components/Namespaces/Reminders/Edit.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/Edit.vue
@@ -50,10 +50,24 @@
           v-if="reminder.payload.link"
           :label="$t('reminder.routesTo')"
         >
-          <b-form-input
-            v-model="reminder.payload.link.label"
-            data-test-id="input-link"
-          />
+          <b-input-group>
+            <b-form-input
+              v-model="reminder.payload.link.label"
+              data-test-id="input-link"
+            />
+
+            <b-input-group-append>
+              <b-button
+                :disabled="!recordViewer"
+                :to="recordViewer(reminder.payload.link.params)"
+                :title="$t('label.recordPageLink')"
+                variant="light"
+                class="d-flex align-items-center"
+              >
+                <font-awesome-icon :icon="['fas', 'external-link-alt']" />
+              </b-button>
+            </b-input-group-append>
+          </b-input-group>
         </b-form-group>
       </b-form>
     </b-list-group-item>
@@ -177,6 +191,10 @@ export default {
   },
 
   methods: {
+    recordViewer (params) {
+      return params ? { name: 'page.record', params } : undefined
+    },
+
     save () {
       // @todo support for updating times
       let r = {}

--- a/client/web/compose/src/components/Namespaces/Reminders/List.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/List.vue
@@ -23,8 +23,7 @@
       <b-form-checkbox
         data-test-id="checkbox-dismiss-reminder"
         :checked="!!r.dismissedAt"
-        :disabled="!!r.dismissedAt"
-        @change="$emit('dismiss', r)"
+        @change="$emit('dismiss', r, $event)"
       >
         <span
           data-test-id="span-reminder-title"

--- a/client/web/compose/src/components/Namespaces/Reminders/List.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/List.vue
@@ -55,6 +55,17 @@
         />
 
         <b-button
+          v-if="r.payload.link"
+          :disabled="!recordViewer()"
+          :to="recordViewer(r.payload.link.params)"
+          :title="$t('label.recordPageLink')"
+          variant="link"
+          class="p-0 ml-2"
+        >
+          <font-awesome-icon :icon="['fas', 'external-link-alt']" />
+        </b-button>
+
+        <b-button
           data-test-id="button-edit-reminder"
           variant="link"
           class="p-1 ml-2"
@@ -126,6 +137,9 @@ export default {
 
     makeTooltip ({ remindAt }) {
       return fmt.fullDateTime(remindAt)
+    },
+    recordViewer (params) {
+      return { name: 'page.record', params }
     },
   },
 }

--- a/client/web/compose/src/components/Namespaces/Reminders/List.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="h-100 pl-1"
+    class="h-100"
   >
     <div
       class="text-center bg-white py-2 sticky-top"
@@ -16,76 +16,88 @@
     </div>
 
     <div
-      v-for="r in sortedReminders"
+      v-for="(r, i) in sortedReminders"
       :key="r.reminderID"
-      class="d-flex align-items-center mb-1 overflow-auto"
     >
-      <b-form-checkbox
-        data-test-id="checkbox-dismiss-reminder"
-        :checked="!!r.dismissedAt"
-        @change="$emit('dismiss', r, $event)"
+      <hr v-if="r.dismissedAt && sortedReminders[i - 1] ? !sortedReminders[i - 1].dismissedAt : false ">
+
+      <div
+        class="d-flex flex-row flex-nowrap align-items-center mb-2 overflow-auto border card"
       >
-        <span
+        <b-form-checkbox
+          v-b-tooltip.hover.left.350
+          data-test-id="checkbox-dismiss-reminder"
+          :checked="!!r.dismissedAt"
+          switch
+          :title="$t(`reminder.${!!r.dismissedAt ? 'undismiss' : 'dismiss'}`)"
+          class="my-2 ml-2"
+          @change="$emit('dismiss', r, $event)"
+        />
+
+        <div
           data-test-id="span-reminder-title"
           class="text-break"
           :style="`${!!r.dismissedAt ? 'text-decoration: line-through;' : ''}`"
         >
           {{ r.payload.title || r.link || rlLabel(r) || r.linkLabel }}
-        </span>
-      </b-form-checkbox>
+        </div>
 
-      <div
-        class="ml-auto"
-      >
-        <font-awesome-icon
-          v-if="r.snoozeCount"
-          data-test-id="icon-snoozed-reminder"
-          :icon="['far', 'clock']"
-          class="ml-1"
-        />
-
-        <font-awesome-icon
-          v-else-if="r.remindAt"
-          v-b-tooltip.hover
-          data-test-id="icon-remind-at"
-          :title="makeTooltip(r)"
-          :icon="['far', 'bell']"
-          class="ml-1"
-        />
-
-        <b-button
-          v-if="r.payload.link"
-          :disabled="!recordViewer()"
-          :to="recordViewer(r.payload.link.params)"
-          :title="$t('label.recordPageLink')"
-          variant="link"
-          class="p-0 ml-2"
-        >
-          <font-awesome-icon :icon="['fas', 'external-link-alt']" />
-        </b-button>
-
-        <b-button
-          data-test-id="button-edit-reminder"
-          variant="link"
-          class="p-1 ml-2"
-          @click="$emit('edit', r)"
+        <div
+          class="d-flex align-items-center text-primary ml-auto px-2"
         >
           <font-awesome-icon
-            :icon="['far', 'edit']"
-            class="text-primary"
+            v-if="r.snoozeCount"
+            data-test-id="icon-snoozed-reminder"
+            :title="makeTooltip(r)"
+            :icon="['far', 'clock']"
+            class="m-2"
           />
-        </b-button>
 
-        <b-button
-          data-test-id="button-delete-reminder"
-          variant="link"
-          class="text-dark p-1"
-          @click.prevent="$emit('delete', r)"
-        >
           <font-awesome-icon
-            :icon="['far', 'trash-alt']"
+            v-if="r.remindAt"
+            data-test-id="icon-remind-at"
+            :title="makeTooltip(r)"
+            :icon="['far', 'bell']"
+            class="m-2"
           />
-        </b-button>
+
+          <b-button-group
+            size="sm"
+          >
+            <b-button
+              v-if="r.payload.link"
+              :disabled="!recordViewer()"
+              :to="recordViewer(r.payload.link.params)"
+              :title="$t('reminder.recordPageLink')"
+              variant="outline-light"
+              class="d-flex align-items-center py-2 text-primary border-0"
+            >
+              <font-awesome-icon :icon="['far', 'file-alt']" />
+            </b-button>
+
+            <b-button
+              data-test-id="button-edit-reminder"
+              variant="outline-light"
+              :title="$t('reminder.edit.label')"
+              class="d-flex align-items-center py-2 text-primary border-0"
+              @click="$emit('edit', r)"
+            >
+              <font-awesome-icon :icon="['far', 'edit']" />
+            </b-button>
+
+            <b-button
+              data-test-id="button-delete-reminder"
+              variant="outline-light"
+              :title="$t('reminder.delete')"
+              class="d-flex align-items-center py-2 text-danger border-0"
+              @click.prevent="$emit('delete', r)"
+            >
+              <font-awesome-icon
+                :icon="['far', 'trash-alt']"
+              />
+            </b-button>
+          </b-button-group>
+        </div>
       </div>
     </div>
   </div>
@@ -124,19 +136,20 @@ export default {
     },
 
     stdSort (a, b) {
-      if (!a.remindAt) {
+      if (!a.dismissedAt) {
         return -1
       }
-      if (!b.remindAt) {
+      if (!b.dismissedAt) {
         return 0
       }
 
-      return a.remindAt - b.remindAt
+      return a.dismissedAt - b.dismissedAt
     },
 
     makeTooltip ({ remindAt }) {
       return fmt.fullDateTime(remindAt)
     },
+
     recordViewer (params) {
       return { name: 'page.record', params }
     },

--- a/client/web/compose/src/components/Namespaces/Reminders/index.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/index.vue
@@ -1,8 +1,9 @@
 <template>
-  <div>
+  <div class="d-flex flex-column h-100">
     <list
       v-if="!edit"
       :reminders="reminders"
+      class="flex-fill"
       @edit="onEdit"
       @dismiss="onDismiss"
       @delete="onDelete"
@@ -13,6 +14,9 @@
       :edit="edit"
       :my-i-d="$auth.user.userID"
       :users="users"
+      class="flex-fill"
+      @dismiss="onDismiss"
+      @back="edit = undefined"
       @save="onSave"
     />
   </div>
@@ -73,11 +77,9 @@ export default {
     },
 
     onSave (r) {
-      let h = 'reminderCreate'
-      if (r.reminderID && r.reminderID !== NoID) {
-        h = 'reminderUpdate'
-      }
-      this.$SystemAPI[h](r).then(r => {
+      const endpoint = r.reminderID && r.reminderID !== NoID ? 'reminderUpdate' : 'reminderCreate'
+      this.$SystemAPI[endpoint](r).then(r => {
+        this.edit = undefined
         this.fetchReminders()
         this.$Reminder.prefetch()
       })
@@ -86,23 +88,18 @@ export default {
     },
 
     onCancel () {
-      this.edit = null
+      this.edit = undefined
     },
 
-    onDismiss (r, value) {
-      if (value) {
-        this.$SystemAPI.reminderDismiss(r).then(() => {
-          this.fetchReminders()
-        })
-      } else {
-        this.$SystemAPI.reminderUndismiss(r).then(() => {
-          this.fetchReminders()
-        })
-      }
+    onDismiss ({ reminderID }, value) {
+      const endpoint = value ? 'reminderDismiss' : 'reminderUndismiss'
+      this.$SystemAPI[endpoint]({ reminderID }).then(() => {
+        this.fetchReminders()
+      })
     },
 
-    onDelete (r) {
-      this.$SystemAPI.reminderDelete(r).then(() => {
+    onDelete ({ reminderID }) {
+      this.$SystemAPI.reminderDelete({ reminderID }).then(() => {
         this.fetchReminders()
       })
     },

--- a/client/web/compose/src/components/Namespaces/Reminders/index.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/index.vue
@@ -89,10 +89,16 @@ export default {
       this.edit = null
     },
 
-    onDismiss (r) {
-      this.$SystemAPI.reminderDismiss(r).then(() => {
-        this.fetchReminders()
-      })
+    onDismiss (r, value) {
+      if (value) {
+        this.$SystemAPI.reminderDismiss(r).then(() => {
+          this.fetchReminders()
+        })
+      } else {
+        this.$SystemAPI.reminderUndismiss(r).then(() => {
+          this.fetchReminders()
+        })
+      }
     },
 
     onDelete (r) {

--- a/client/web/compose/src/components/PageBlocks/RecordListBase.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListBase.vue
@@ -1098,8 +1098,8 @@ export default {
     createReminder (record) {
       // Determine initial reminder title
       const { recordID, values = {} } = record
-      const tField = ((this.options.fields || []).find(({ name }) => !!values[name]) || {}).name
-      const title = values[tField]
+      const { name, isMulti } = (this.options.fields || []).find(({ name }) => !!values[name]) || {}
+      const title = isMulti ? values[name].join(', ') : values[name]
 
       const resource = `compose:record:${recordID}`
       const payload = {

--- a/lib/js/src/api-clients/system.ts
+++ b/lib/js/src/api-clients/system.ts
@@ -2568,11 +2568,37 @@ export default class System {
     return this.api().request(cfg).then(result => stdResolve(result))
   }
 
+  // Undismiss reminder
+  async reminderUndismiss (a: KV, extra: AxiosRequestConfig = {}): Promise<KV> {
+    const {
+      reminderID,
+    } = (a as KV) || {}
+    if (!reminderID) {
+      throw Error('field reminderID is empty')
+    }
+    const cfg: AxiosRequestConfig = {
+      ...extra,
+      method: 'patch',
+      url: this.reminderUndismissEndpoint({
+        reminderID,
+      }),
+    }
+
+    return this.api().request(cfg).then(result => stdResolve(result))
+  }
+
   reminderDismissEndpoint (a: KV): string {
     const {
       reminderID,
     } = a || {}
     return `/reminder/${reminderID}/dismiss`
+  }
+
+  reminderUndismissEndpoint (a: KV): string {
+    const {
+      reminderID,
+    } = a || {}
+    return `/reminder/${reminderID}/undismiss`
   }
 
   // Snooze reminder

--- a/lib/vue/src/components/reminders/CReminderSidebar.vue
+++ b/lib/vue/src/components/reminders/CReminderSidebar.vue
@@ -2,7 +2,7 @@
   <b-sidebar
     v-model="isVisible"
     header-class="d-flex align-items-center justify-content-between reminder-sidebar-header px-2 py-3 border-bottom"
-    body-class="bg-white px-2"
+    body-class="bg-white px-2 pb-2"
     :title="title"
     :backdrop="isMobile"
     no-footer

--- a/locale/en/corteza-webapp-compose/general.yaml
+++ b/locale/en/corteza-webapp-compose/general.yaml
@@ -55,6 +55,7 @@ label:
   processing: Processing...
   record: Record
   recordPage: Record page
+  recordPageLink: View record
   field: Field
   remove: Remove
   removeDefault: Remove default

--- a/locale/en/corteza-webapp-compose/general.yaml
+++ b/locale/en/corteza-webapp-compose/general.yaml
@@ -55,7 +55,6 @@ label:
   processing: Processing...
   record: Record
   recordPage: Record page
-  recordPageLink: View record
   field: Field
   remove: Remove
   removeDefault: Remove default
@@ -88,17 +87,22 @@ placeholder:
 reminder:
   add: Add a new reminder
   dismiss: Dismiss
+  dismissed: Dismissed
+  undismiss: Undismiss
+  delete: Delete reminder
+  recordPageLink: View record
   edit:
+    label: Edit reminder
     assigneeLabel: Assignee
     assigneePlaceholder: Myself (default)
     notesLabel: Notes
     notesPlaceholder: Notes
-    remindAtLabel: Notify me
+    remindAtLabel: Remind me at
     remindAtNone: Never
     titleLabel: Title
     titlePlaceholder: Title
   listLabel: Reminders
-  routesTo: 'Includes link to:'
+  routesTo: Label for page link
   snooze: Snooze
 tooltip:
   dragAndDrop: Drag and drop to change order

--- a/server/system/rest.yaml
+++ b/server/system/rest.yaml
@@ -1353,6 +1353,16 @@ endpoints:
         name: reminderID
         required: true
         title: reminder ID
+  - name: undismiss
+    method: PATCH
+    title: Undismiss reminder
+    path: "/{reminderID}/undismiss"
+    parameters:
+      path:
+      - type: uint64
+        name: reminderID
+        required: true
+        title: reminder ID
   - name: snooze
     method: PATCH
     title: Snooze reminder

--- a/server/system/rest/reminder.go
+++ b/server/system/rest/reminder.go
@@ -98,6 +98,10 @@ func (ctrl *Reminder) Dismiss(ctx context.Context, r *request.ReminderDismiss) (
 	return api.OK(), ctrl.reminder.Dismiss(ctx, r.ReminderID)
 }
 
+func (ctrl *Reminder) Undismiss(ctx context.Context, r *request.ReminderUndismiss) (interface{}, error) {
+	return api.OK(), ctrl.reminder.Undismiss(ctx, r.ReminderID)
+}
+
 func (ctrl *Reminder) Snooze(ctx context.Context, r *request.ReminderSnooze) (interface{}, error) {
 	return api.OK(), ctrl.reminder.Snooze(ctx, r.ReminderID, r.RemindAt)
 }

--- a/server/system/rest/request/reminder.go
+++ b/server/system/rest/request/reminder.go
@@ -162,6 +162,13 @@ type (
 		ReminderID uint64 `json:",string"`
 	}
 
+	ReminderUndismiss struct {
+		// ReminderID PATH parameter
+		//
+		// reminder ID
+		ReminderID uint64 `json:",string"`
+	}
+
 	ReminderSnooze struct {
 		// ReminderID PATH parameter
 		//
@@ -692,6 +699,41 @@ func (r ReminderDismiss) GetReminderID() uint64 {
 
 // Fill processes request and fills internal variables
 func (r *ReminderDismiss) Fill(req *http.Request) (err error) {
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "reminderID")
+		r.ReminderID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewReminderUndismiss request
+func NewReminderUndismiss() *ReminderUndismiss {
+	return &ReminderUndismiss{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ReminderUndismiss) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"reminderID": r.ReminderID,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ReminderUndismiss) GetReminderID() uint64 {
+	return r.ReminderID
+}
+
+// Fill processes request and fills internal variables
+func (r *ReminderUndismiss) Fill(req *http.Request) (err error) {
 
 	{
 		var val string

--- a/server/system/service/reminder_actions.gen.go
+++ b/server/system/service/reminder_actions.gen.go
@@ -54,10 +54,9 @@ var (
 // Props methods
 // setReminder updates reminderActionProps's reminder
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setReminder(reminder *types.Reminder) *reminderActionProps {
 	p.reminder = reminder
 	return p
@@ -65,10 +64,9 @@ func (p *reminderActionProps) setReminder(reminder *types.Reminder) *reminderAct
 
 // setNew updates reminderActionProps's new
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setNew(new *types.Reminder) *reminderActionProps {
 	p.new = new
 	return p
@@ -76,10 +74,9 @@ func (p *reminderActionProps) setNew(new *types.Reminder) *reminderActionProps {
 
 // setUpdated updates reminderActionProps's updated
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setUpdated(updated *types.Reminder) *reminderActionProps {
 	p.updated = updated
 	return p
@@ -87,10 +84,9 @@ func (p *reminderActionProps) setUpdated(updated *types.Reminder) *reminderActio
 
 // setFilter updates reminderActionProps's filter
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setFilter(filter *types.ReminderFilter) *reminderActionProps {
 	p.filter = filter
 	return p
@@ -99,7 +95,6 @@ func (p *reminderActionProps) setFilter(filter *types.ReminderFilter) *reminderA
 // Serialize converts reminderActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p reminderActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -143,7 +138,6 @@ func (p reminderActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p reminderActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -260,7 +254,6 @@ func (p reminderActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *reminderAction) String() string {
 	var props = &reminderActionProps{}
 
@@ -288,7 +281,6 @@ func (e *reminderAction) ToAction() *actionlog.Action {
 // ReminderActionSearch returns "system:reminder.search" action
 //
 // This function is auto-generated.
-//
 func ReminderActionSearch(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -308,7 +300,6 @@ func ReminderActionSearch(props ...*reminderActionProps) *reminderAction {
 // ReminderActionLookup returns "system:reminder.lookup" action
 //
 // This function is auto-generated.
-//
 func ReminderActionLookup(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -328,7 +319,6 @@ func ReminderActionLookup(props ...*reminderActionProps) *reminderAction {
 // ReminderActionCreate returns "system:reminder.create" action
 //
 // This function is auto-generated.
-//
 func ReminderActionCreate(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -348,7 +338,6 @@ func ReminderActionCreate(props ...*reminderActionProps) *reminderAction {
 // ReminderActionUpdate returns "system:reminder.update" action
 //
 // This function is auto-generated.
-//
 func ReminderActionUpdate(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -368,7 +357,6 @@ func ReminderActionUpdate(props ...*reminderActionProps) *reminderAction {
 // ReminderActionDelete returns "system:reminder.delete" action
 //
 // This function is auto-generated.
-//
 func ReminderActionDelete(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -388,13 +376,31 @@ func ReminderActionDelete(props ...*reminderActionProps) *reminderAction {
 // ReminderActionDismiss returns "system:reminder.dismiss" action
 //
 // This function is auto-generated.
-//
 func ReminderActionDismiss(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
 		resource:  "system:reminder",
 		action:    "dismiss",
-		log:       "deleted {{reminder}}",
+		log:       "dismissed {{reminder}}",
+		severity:  actionlog.Notice,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// ReminderActionUndismiss returns "system:reminder.undismiss" action
+//
+// This function is auto-generated.
+func ReminderActionUndismiss(props ...*reminderActionProps) *reminderAction {
+	a := &reminderAction{
+		timestamp: time.Now(),
+		resource:  "system:reminder",
+		action:    "undismiss",
+		log:       "undismissed {{reminder}}",
 		severity:  actionlog.Notice,
 	}
 
@@ -408,13 +414,12 @@ func ReminderActionDismiss(props ...*reminderActionProps) *reminderAction {
 // ReminderActionSnooze returns "system:reminder.snooze" action
 //
 // This function is auto-generated.
-//
 func ReminderActionSnooze(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
 		resource:  "system:reminder",
 		action:    "snooze",
-		log:       "deleted {{reminder}}",
+		log:       "snoozed {{reminder}}",
 		severity:  actionlog.Notice,
 	}
 
@@ -431,9 +436,7 @@ func ReminderActionSnooze(props ...*reminderActionProps) *reminderAction {
 
 // ReminderErrGeneric returns "system:reminder.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrGeneric(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -467,9 +470,7 @@ func ReminderErrGeneric(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotFound returns "system:reminder.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotFound(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -501,9 +502,7 @@ func ReminderErrNotFound(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrInvalidID returns "system:reminder.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrInvalidID(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -535,9 +534,7 @@ func ReminderErrInvalidID(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToAssign returns "system:reminder.notAllowedToAssign" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToAssign(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -569,9 +566,7 @@ func ReminderErrNotAllowedToAssign(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToDismiss returns "system:reminder.notAllowedToDismiss" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToDismiss(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -601,11 +596,41 @@ func ReminderErrNotAllowedToDismiss(mm ...*reminderActionProps) *errors.Error {
 	return e
 }
 
-// ReminderErrNotAllowedToRead returns "system:reminder.notAllowedToRead" as *errors.Error
-//
+// ReminderErrNotAllowedToUndismiss returns "system:reminder.notAllowedToUndismiss" as *errors.Error
 //
 // This function is auto-generated.
+func ReminderErrNotAllowedToUndismiss(mm ...*reminderActionProps) *errors.Error {
+	var p = &reminderActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("not allowed to undo dismissed reminders of other users", nil),
+
+		errors.Meta("type", "notAllowedToUndismiss"),
+		errors.Meta("resource", "system:reminder"),
+
+		errors.Meta(reminderPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "reminder.errors.notAllowedToUndismiss"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// ReminderErrNotAllowedToRead returns "system:reminder.notAllowedToRead" as *errors.Error
 //
+// This function is auto-generated.
 func ReminderErrNotAllowedToRead(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -643,7 +668,6 @@ func ReminderErrNotAllowedToRead(mm ...*reminderActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc reminder) recordAction(ctx context.Context, props *reminderActionProps, actionFn func(...*reminderActionProps) *reminderAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/reminder_actions.yaml
+++ b/server/system/service/reminder_actions.yaml
@@ -45,10 +45,13 @@ actions:
     log: "deleted {{reminder}}"
 
   - action: dismiss
-    log: "deleted {{reminder}}"
+    log: "dismissed {{reminder}}"
+
+  - action: undismiss
+    log: "undismissed {{reminder}}"
 
   - action: snooze
-    log: "deleted {{reminder}}"
+    log: "snoozed {{reminder}}"
 
 errors:
   - error: notFound
@@ -64,6 +67,9 @@ errors:
 
   - error: notAllowedToDismiss
     message: "not allowed to dismiss reminders of other users"
+
+  - error: notAllowedToUndismiss
+    message: "not allowed to undo dismissed reminders of other users"
 
   - error: notAllowedToRead
     message: "not allowed to read reminders of other users"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26258032/221810859-2d906df2-57eb-43a9-ad10-66a738097966.png)

Summary: This PR improves the way how linked reminders function in Corteza. When there is a linked reminder to a specific record, you can now go to the Record Page from the reminder directly. Before that, there was a link on the record page to the linked reminder but not vice vicera.

## Changelog

### What was added?
When there is a linked reminder, a link to the linked Record is added in the reminder. 

### How was added?
In Compose, the edit reminder tempate was updated at `src/components/namespaces/reminders/edit` to add button input group as well the list template at `src/components/namespaces/reminders/edit`.

### Why was added?
Before this feature, when the users link a record page to a reminder, the link was shown in the record page but when you visit the reminder, there was no way to navigate quickly to the record. This functionality improves UX, since users can now easily navigate from the linked reminder to the linked record page directly.