### PR TITLE
2022.9.x feature undismiss reminder

### DIFF
--- a/client/web/compose/src/components/Namespaces/Reminders/List.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/List.vue
@@ -23,8 +23,7 @@
       <b-form-checkbox
         data-test-id="checkbox-dismiss-reminder"
         :checked="!!r.dismissedAt"
-        :disabled="!!r.dismissedAt"
-        @change="$emit('dismiss', r)"
+        @change="$emit('dismiss', r, $event)"
       >
         <span
           data-test-id="span-reminder-title"

--- a/client/web/compose/src/components/Namespaces/Reminders/index.vue
+++ b/client/web/compose/src/components/Namespaces/Reminders/index.vue
@@ -89,10 +89,16 @@ export default {
       this.edit = null
     },
 
-    onDismiss (r) {
-      this.$SystemAPI.reminderDismiss(r).then(() => {
-        this.fetchReminders()
-      })
+    onDismiss (r, value) {
+      if (value) {
+        this.$SystemAPI.reminderDismiss(r).then(() => {
+          this.fetchReminders()
+        })
+      } else {
+        this.$SystemAPI.reminderUndismiss(r).then(() => {
+          this.fetchReminders()
+        })
+      }
     },
 
     onDelete (r) {

--- a/lib/js/src/api-clients/system.ts
+++ b/lib/js/src/api-clients/system.ts
@@ -2568,11 +2568,37 @@ export default class System {
     return this.api().request(cfg).then(result => stdResolve(result))
   }
 
+  // Undismiss reminder
+  async reminderUndismiss (a: KV, extra: AxiosRequestConfig = {}): Promise<KV> {
+    const {
+      reminderID,
+    } = (a as KV) || {}
+    if (!reminderID) {
+      throw Error('field reminderID is empty')
+    }
+    const cfg: AxiosRequestConfig = {
+      ...extra,
+      method: 'patch',
+      url: this.reminderUndismissEndpoint({
+        reminderID,
+      }),
+    }
+
+    return this.api().request(cfg).then(result => stdResolve(result))
+  }
+
   reminderDismissEndpoint (a: KV): string {
     const {
       reminderID,
     } = a || {}
     return `/reminder/${reminderID}/dismiss`
+  }
+
+  reminderUndismissEndpoint (a: KV): string {
+    const {
+      reminderID,
+    } = a || {}
+    return `/reminder/${reminderID}/undismiss`
   }
 
   // Snooze reminder

--- a/server/system/rest.yaml
+++ b/server/system/rest.yaml
@@ -1353,6 +1353,16 @@ endpoints:
         name: reminderID
         required: true
         title: reminder ID
+  - name: undismiss
+    method: PATCH
+    title: Undismiss reminder
+    path: "/{reminderID}/undismiss"
+    parameters:
+      path:
+      - type: uint64
+        name: reminderID
+        required: true
+        title: reminder ID
   - name: snooze
     method: PATCH
     title: Snooze reminder

--- a/server/system/rest/reminder.go
+++ b/server/system/rest/reminder.go
@@ -98,6 +98,10 @@ func (ctrl *Reminder) Dismiss(ctx context.Context, r *request.ReminderDismiss) (
 	return api.OK(), ctrl.reminder.Dismiss(ctx, r.ReminderID)
 }
 
+func (ctrl *Reminder) Undismiss(ctx context.Context, r *request.ReminderUndismiss) (interface{}, error) {
+	return api.OK(), ctrl.reminder.Undismiss(ctx, r.ReminderID)
+}
+
 func (ctrl *Reminder) Snooze(ctx context.Context, r *request.ReminderSnooze) (interface{}, error) {
 	return api.OK(), ctrl.reminder.Snooze(ctx, r.ReminderID, r.RemindAt)
 }

--- a/server/system/rest/request/reminder.go
+++ b/server/system/rest/request/reminder.go
@@ -162,6 +162,13 @@ type (
 		ReminderID uint64 `json:",string"`
 	}
 
+	ReminderUndismiss struct {
+		// ReminderID PATH parameter
+		//
+		// reminder ID
+		ReminderID uint64 `json:",string"`
+	}
+
 	ReminderSnooze struct {
 		// ReminderID PATH parameter
 		//
@@ -692,6 +699,41 @@ func (r ReminderDismiss) GetReminderID() uint64 {
 
 // Fill processes request and fills internal variables
 func (r *ReminderDismiss) Fill(req *http.Request) (err error) {
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "reminderID")
+		r.ReminderID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewReminderUndismiss request
+func NewReminderUndismiss() *ReminderUndismiss {
+	return &ReminderUndismiss{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ReminderUndismiss) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"reminderID": r.ReminderID,
+	}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r ReminderUndismiss) GetReminderID() uint64 {
+	return r.ReminderID
+}
+
+// Fill processes request and fills internal variables
+func (r *ReminderUndismiss) Fill(req *http.Request) (err error) {
 
 	{
 		var val string

--- a/server/system/service/reminder_actions.gen.go
+++ b/server/system/service/reminder_actions.gen.go
@@ -54,10 +54,9 @@ var (
 // Props methods
 // setReminder updates reminderActionProps's reminder
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setReminder(reminder *types.Reminder) *reminderActionProps {
 	p.reminder = reminder
 	return p
@@ -65,10 +64,9 @@ func (p *reminderActionProps) setReminder(reminder *types.Reminder) *reminderAct
 
 // setNew updates reminderActionProps's new
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setNew(new *types.Reminder) *reminderActionProps {
 	p.new = new
 	return p
@@ -76,10 +74,9 @@ func (p *reminderActionProps) setNew(new *types.Reminder) *reminderActionProps {
 
 // setUpdated updates reminderActionProps's updated
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setUpdated(updated *types.Reminder) *reminderActionProps {
 	p.updated = updated
 	return p
@@ -87,10 +84,9 @@ func (p *reminderActionProps) setUpdated(updated *types.Reminder) *reminderActio
 
 // setFilter updates reminderActionProps's filter
 //
-// Allows method chaining
+// # Allows method chaining
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setFilter(filter *types.ReminderFilter) *reminderActionProps {
 	p.filter = filter
 	return p
@@ -99,7 +95,6 @@ func (p *reminderActionProps) setFilter(filter *types.ReminderFilter) *reminderA
 // Serialize converts reminderActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p reminderActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -143,7 +138,6 @@ func (p reminderActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p reminderActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -260,7 +254,6 @@ func (p reminderActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *reminderAction) String() string {
 	var props = &reminderActionProps{}
 
@@ -288,7 +281,6 @@ func (e *reminderAction) ToAction() *actionlog.Action {
 // ReminderActionSearch returns "system:reminder.search" action
 //
 // This function is auto-generated.
-//
 func ReminderActionSearch(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -308,7 +300,6 @@ func ReminderActionSearch(props ...*reminderActionProps) *reminderAction {
 // ReminderActionLookup returns "system:reminder.lookup" action
 //
 // This function is auto-generated.
-//
 func ReminderActionLookup(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -328,7 +319,6 @@ func ReminderActionLookup(props ...*reminderActionProps) *reminderAction {
 // ReminderActionCreate returns "system:reminder.create" action
 //
 // This function is auto-generated.
-//
 func ReminderActionCreate(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -348,7 +338,6 @@ func ReminderActionCreate(props ...*reminderActionProps) *reminderAction {
 // ReminderActionUpdate returns "system:reminder.update" action
 //
 // This function is auto-generated.
-//
 func ReminderActionUpdate(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -368,7 +357,6 @@ func ReminderActionUpdate(props ...*reminderActionProps) *reminderAction {
 // ReminderActionDelete returns "system:reminder.delete" action
 //
 // This function is auto-generated.
-//
 func ReminderActionDelete(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -388,13 +376,31 @@ func ReminderActionDelete(props ...*reminderActionProps) *reminderAction {
 // ReminderActionDismiss returns "system:reminder.dismiss" action
 //
 // This function is auto-generated.
-//
 func ReminderActionDismiss(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
 		resource:  "system:reminder",
 		action:    "dismiss",
-		log:       "deleted {{reminder}}",
+		log:       "dismissed {{reminder}}",
+		severity:  actionlog.Notice,
+	}
+
+	if len(props) > 0 {
+		a.props = props[0]
+	}
+
+	return a
+}
+
+// ReminderActionUndismiss returns "system:reminder.undismiss" action
+//
+// This function is auto-generated.
+func ReminderActionUndismiss(props ...*reminderActionProps) *reminderAction {
+	a := &reminderAction{
+		timestamp: time.Now(),
+		resource:  "system:reminder",
+		action:    "undismiss",
+		log:       "undismissed {{reminder}}",
 		severity:  actionlog.Notice,
 	}
 
@@ -408,13 +414,12 @@ func ReminderActionDismiss(props ...*reminderActionProps) *reminderAction {
 // ReminderActionSnooze returns "system:reminder.snooze" action
 //
 // This function is auto-generated.
-//
 func ReminderActionSnooze(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
 		resource:  "system:reminder",
 		action:    "snooze",
-		log:       "deleted {{reminder}}",
+		log:       "snoozed {{reminder}}",
 		severity:  actionlog.Notice,
 	}
 
@@ -431,9 +436,7 @@ func ReminderActionSnooze(props ...*reminderActionProps) *reminderAction {
 
 // ReminderErrGeneric returns "system:reminder.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrGeneric(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -467,9 +470,7 @@ func ReminderErrGeneric(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotFound returns "system:reminder.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotFound(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -501,9 +502,7 @@ func ReminderErrNotFound(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrInvalidID returns "system:reminder.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrInvalidID(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -535,9 +534,7 @@ func ReminderErrInvalidID(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToAssign returns "system:reminder.notAllowedToAssign" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToAssign(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -569,9 +566,7 @@ func ReminderErrNotAllowedToAssign(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToDismiss returns "system:reminder.notAllowedToDismiss" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToDismiss(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -601,11 +596,41 @@ func ReminderErrNotAllowedToDismiss(mm ...*reminderActionProps) *errors.Error {
 	return e
 }
 
-// ReminderErrNotAllowedToRead returns "system:reminder.notAllowedToRead" as *errors.Error
-//
+// ReminderErrNotAllowedToUndismiss returns "system:reminder.notAllowedToUndismiss" as *errors.Error
 //
 // This function is auto-generated.
+func ReminderErrNotAllowedToUndismiss(mm ...*reminderActionProps) *errors.Error {
+	var p = &reminderActionProps{}
+	if len(mm) > 0 {
+		p = mm[0]
+	}
+
+	var e = errors.New(
+		errors.KindInternal,
+
+		p.Format("not allowed to undo dismissed reminders of other users", nil),
+
+		errors.Meta("type", "notAllowedToUndismiss"),
+		errors.Meta("resource", "system:reminder"),
+
+		errors.Meta(reminderPropsMetaKey{}, p),
+
+		// translation namespace & key
+		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
+		errors.Meta(locale.ErrorMetaKey{}, "reminder.errors.notAllowedToUndismiss"),
+
+		errors.StackSkip(1),
+	)
+
+	if len(mm) > 0 {
+	}
+
+	return e
+}
+
+// ReminderErrNotAllowedToRead returns "system:reminder.notAllowedToRead" as *errors.Error
 //
+// This function is auto-generated.
 func ReminderErrNotAllowedToRead(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -643,7 +668,6 @@ func ReminderErrNotAllowedToRead(mm ...*reminderActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc reminder) recordAction(ctx context.Context, props *reminderActionProps, actionFn func(...*reminderActionProps) *reminderAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/reminder_actions.yaml
+++ b/server/system/service/reminder_actions.yaml
@@ -45,10 +45,13 @@ actions:
     log: "deleted {{reminder}}"
 
   - action: dismiss
-    log: "deleted {{reminder}}"
+    log: "dismissed {{reminder}}"
+
+  - action: undismiss
+    log: "undismissed {{reminder}}"
 
   - action: snooze
-    log: "deleted {{reminder}}"
+    log: "snoozed {{reminder}}"
 
 errors:
   - error: notFound
@@ -64,6 +67,9 @@ errors:
 
   - error: notAllowedToDismiss
     message: "not allowed to dismiss reminders of other users"
+
+  - error: notAllowedToUndismiss
+    message: "not allowed to undo dismissed reminders of other users"
 
   - error: notAllowedToRead
     message: "not allowed to read reminders of other users"


### PR DESCRIPTION
https://user-images.githubusercontent.com/26258032/221588363-1a32bce8-0624-4384-b262-75e151de8a3d.mp4

Summary: When the reminder is dismissed by the user or expires, there is currently no option to undismiss it. This pr adresses this problem

## Changelog

### What was added?
A checkbox to undismiss a reminder has been enabled

### How was added?
The checkbox that disimisses a reminder at `src/components/namespaces/reminders/list` has been adjusted so that it can be toggled. For this, on the backend an endpoint to undismiss the reminder has been added, which was then consumed on the frontend

### Why was added?
It was requested at corteza forum that there should be an option to reuse a reminder once it expires.