### PR TITLE
Fix multi value date time record list filter for PSQL

### DIFF
--- a/server/store/adapters/rdbms/dal/iterator.go
+++ b/server/store/adapters/rdbms/dal/iterator.go
@@ -287,7 +287,7 @@ func (i *iterator) collectCursorValues(r dal.ValueGetter) (_ *filter.PagingCurso
 	}
 
 	if len(pKeys) == 0 {
-		//return nil, fmt.Errorf("can not construct cursor without primary key attributes")
+		// return nil, fmt.Errorf("can not construct cursor without primary key attributes")
 	}
 
 	for _, c := range i.sorting {

--- a/server/store/adapters/rdbms/drivers/mysql/dialect.go
+++ b/server/store/adapters/rdbms/drivers/mysql/dialect.go
@@ -82,7 +82,7 @@ func (d mysqlDialect) JsonExtractUnquote(jsonDoc exp.Expression, pp ...any) (_ e
 // JSON_CONTAINS(v, '"needle"', '$.f2')
 //
 // This approach is not optimal, but it is the only way to make it work
-func (d mysqlDialect) JsonArrayContains(needle, haystack exp.Expression) (_ exp.Expression, err error) {
+func (d mysqlDialect) JsonArrayContains(needle, haystack exp.Expression, _ string) (_ exp.Expression, err error) {
 	return exp.NewSQLFunctionExpression("JSON_CONTAINS", haystack, needle), nil
 }
 

--- a/server/store/adapters/rdbms/drivers/sqlite/dialect.go
+++ b/server/store/adapters/rdbms/drivers/sqlite/dialect.go
@@ -79,7 +79,7 @@ func (sqliteDialect) JsonExtractUnquote(ident exp.Expression, pp ...any) (exp.Ex
 //
 // Unfortunately SQLite converts boolean values into 0 and 1 when decoding from
 // JSON and we need a special handler for that.
-func (sqliteDialect) JsonArrayContains(needle, haystack exp.Expression) (exp.Expression, error) {
+func (sqliteDialect) JsonArrayContains(needle, haystack exp.Expression, _ string) (exp.Expression, error) {
 	// @todo should be implemented using native SQLite capabilties and
 	//       not through custom JSON_ARRAY_CONTAINS function
 	return exp.NewLiteralExpression("JSON_ARRAY_CONTAINS(?, ?)", needle, haystack), nil

--- a/server/store/adapters/rdbms/drivers/tests/dialect_test.go
+++ b/server/store/adapters/rdbms/drivers/tests/dialect_test.go
@@ -69,6 +69,7 @@ func TestJSONOp(t *testing.T) {
 			contains, err := conn.dialect.JsonArrayContains(
 				exp.NewLiteralExpression("?", val),
 				a2e(attr),
+				"",
 			)
 			req.NoError(err)
 


### PR DESCRIPTION
Explicit type casting was needed for timezone to cast into jsonb.
- Fixes the validation check inside `in` operation handler to prevent error(Could not load record list: unsupported IN operator on a single value field) thrown for the date time field.
- Updates the JsonArrayContains argument list to have attribute type so it can be process acc. for driver, In case we need to handle values from json fields differently.

Fixes #857

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [x] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
