### PR TITLE
Fix Magnifying glass in page builder

### DIFF
--- a/client/web/compose/src/components/PageBlocks/Wrap/Card.vue
+++ b/client/web/compose/src/components/PageBlocks/Wrap/Card.vue
@@ -44,6 +44,7 @@
                 :title="isBlockOpened ? '' : $t('general.label.magnify')"
                 variant="outline-light"
                 class="d-flex align-items-center text-secondary d-print-none border-0"
+                :style="isAdmin ? { 'cursor': 'default', 'background' : 'transparent', 'box-shadow' : 'none' } : {}"
                 @click="$root.$emit('magnify-page-block', isBlockOpened ? undefined : { blockID: block.blockID })"
               >
                 <font-awesome-icon :icon="['fas', isBlockOpened ? 'times' : 'search-plus']" />

--- a/client/web/compose/src/components/PageBlocks/Wrap/Plain.vue
+++ b/client/web/compose/src/components/PageBlocks/Wrap/Plain.vue
@@ -42,6 +42,7 @@
                 :title="isBlockOpened ? '' : $t('general.label.magnify')"
                 variant="outline-light"
                 class="d-flex align-items-center text-primary d-print-none border-0"
+                :style="isAdmin ? { 'cursor': 'default', 'background' : 'transparent', 'box-shadow' : 'none' } : {}"
                 @click="$root.$emit('magnify-page-block', isBlockOpened ? undefined : { blockID: block.blockID })"
               >
                 <font-awesome-icon :icon="['fas', isBlockOpened ? 'times' : 'search-plus']" />

--- a/client/web/compose/src/components/PageBlocks/Wrap/base.vue
+++ b/client/web/compose/src/components/PageBlocks/Wrap/base.vue
@@ -27,6 +27,10 @@ export default {
       ]
     },
 
+    isAdmin () {
+      return this.$route.name.startsWith('admin')
+    },
+
     isBlockOpened () {
       return this.block.blockID === this.$route.query.blockID
     },


### PR DESCRIPTION
## Changelog

**Summary of the issue:** The magnify icon in the page builder has styles that make it look like a link, when you hover over the icon. Since it is just an icon, these styles has to be removed for better ui.

**What was changed:** Link styles are stripped off from the magnify icon in compose page builder.
