### PR TITLE
Fix error when trying to fetch incorrectly configured workflow trigge…

### DIFF
--- a/client/web/admin/src/components/Workflow/CWorkflowEditorTriggers.vue
+++ b/client/web/admin/src/components/Workflow/CWorkflowEditorTriggers.vue
@@ -18,7 +18,11 @@
           v-for="(c, index) in trigger.item.constraints"
           :key="index"
         >
-          {{ c.name[0].toUpperCase() + c.name.slice(1).toLowerCase() }} {{ c.op }} "{{ c.values.join(' or ') }}"
+          <template
+            v-if="c.name"
+          >
+            {{ c.name[0].toUpperCase() + c.name.slice(1).toLowerCase() }} {{ c.op }} "{{ c.values.join(' or ') }}"
+          </template>
           <code
             v-if="index < trigger.item.constraints.length - 1"
           >

--- a/client/web/workflow/src/components/Configurator/Trigger.vue
+++ b/client/web/workflow/src/components/Configurator/Trigger.vue
@@ -453,7 +453,6 @@ export default {
 
     eventChanged () {
       this.item.triggers.constraints = []
-      this.addConstraint()
       this.$root.$emit('change-detected')
       this.updateDefaultName()
     },


### PR DESCRIPTION
…rs in admin

# The following changes are implemented
Added a template el with an if statement that prevents triggers without a name to be displayed

# Changes in the user interface:

How it looks when a trigger name isn't provided with the given reproduction steps:
<img width="713" alt="Screenshot 2023-03-10 at 12 17 49" src="https://user-images.githubusercontent.com/85161724/224290728-2140f2a1-b5f6-4308-b3d2-065ee5cb71e6.png">

# Checklist when submitting a final (!draft) PR
 - [ ] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [ ] PR is linked to the relevant issue(s)
 - [ ] Rebased with the target branch
