### PR TITLE
Use Magnifying Glass in Page Builder

### DIFF
--- a/client/web/compose/src/components/Public/Page/Block/Modal.vue
+++ b/client/web/compose/src/components/Public/Page/Block/Modal.vue
@@ -99,18 +99,20 @@ export default {
   },
 
   created () {
-    this.$root.$on('magnify-page-block', ({ blockID, block } = {}) => {
-      this.customBlock = block
-      blockID = blockID || (block || {}).blockID
-      this.$router.push({ query: { ...this.$route.query, blockID } })
-    })
+    this.$root.$on('magnify-page-block', this.magnifyPageBlock)
   },
 
-  beforeDestroy () {
-    this.$root.$off('magnify-page-block')
+  destroyed () {
+    this.$root.$off('magnify-page-block', this.magnifyPageBlock)
   },
 
   methods: {
+    magnifyPageBlock ({ blockID, block } = {}) {
+      this.customBlock = block
+      blockID = blockID || (block || {}).blockID
+      this.$router.push({ query: { ...this.$route.query, blockID } })
+    },
+
     loadModal (blockID) {
       // Get data from route
       const { recordID: paramsRecordID, pageID } = this.$route.params

--- a/client/web/compose/src/views/Admin/Pages/Builder.vue
+++ b/client/web/compose/src/views/Admin/Pages/Builder.vue
@@ -262,6 +262,10 @@
         </template>
       </editor-toolbar>
     </portal>
+
+    <magnification-modal
+      :namespace="namespace"
+    />
   </div>
 </template>
 
@@ -276,6 +280,7 @@ import EditorToolbar from 'corteza-webapp-compose/src/components/Admin/EditorToo
 import { compose, NoID } from '@cortezaproject/corteza-js'
 import Configurator from 'corteza-webapp-compose/src/components/PageBlocks/Configurator'
 import { fetchID } from 'corteza-webapp-compose/src/lib/tabs'
+import MagnificationModal from 'corteza-webapp-compose/src/components/Public/Page/Block/Modal'
 
 export default {
   i18nOptions: {
@@ -289,6 +294,7 @@ export default {
     PageBlock,
     EditorToolbar,
     PageTranslator,
+    MagnificationModal,
   },
 
   mixins: [

--- a/client/web/compose/src/views/Public/Pages/View.vue
+++ b/client/web/compose/src/views/Public/Pages/View.vue
@@ -71,7 +71,6 @@
 
     <magnification-modal
       :namespace="namespace"
-      :page="page"
     />
   </div>
 </template>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26258032/224968341-19316f82-7063-4b6c-9f87-62c24b5346a2.png)


## Changelog

### What was improved?
The block magnification icon was not functional in the page builder, only on public pages. It was decided that this should not be the case, the icon should work from everywhere, all the time.

### How was improved?
Inside the compose, the page block modal was appended to the the page builder component.

### Why was improved?
It was impractical to have a magnification icon that does not magnify. Adding it improved the usability of the feature and its adoption throughout Corteza.