### PR TITLE
Validate font file for avatar generation and fix avatar-related unit and integration tests

### DIFF
--- a/server/auth/handlers/handle_profile.go
+++ b/server/auth/handlers/handle_profile.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"fmt"
 	"github.com/cortezaproject/corteza/server/auth/request"
+	"github.com/cortezaproject/corteza/server/pkg/options"
 	"github.com/cortezaproject/corteza/server/system/service"
 	"github.com/cortezaproject/corteza/server/system/types"
 	"go.uber.org/zap"
+	"strings"
 )
 
 func (h *AuthHandlers) profileForm(req *request.AuthReq) (err error) {
@@ -32,7 +34,7 @@ func (h *AuthHandlers) profileForm(req *request.AuthReq) (err error) {
 		}
 	}
 
-	avatarUrl = fmt.Sprintf("%sapi/system/attachment/avatar/%d/original/%s", GetLinks().Base, u.Meta.AvatarID, types.AttachmentKindAvatar)
+	avatarUrl = fmt.Sprintf("%s/system/attachment/avatar/%d/original/%s", getApiFullPath(), u.Meta.AvatarID, types.AttachmentKindAvatar)
 
 	if form := req.PopKV(); len(form) > 0 {
 		req.Data["form"] = form
@@ -137,7 +139,7 @@ func (h *AuthHandlers) profileProc(req *request.AuthReq) error {
 		return nil
 	}
 
-	avatarUrl := fmt.Sprintf("%sapi/system/attachment/avatar/%d/original/%s", GetLinks().Base, u.Meta.AvatarID, types.AttachmentKindAvatar)
+	avatarUrl := fmt.Sprintf("%s/system/attachment/avatar/%d/original/%s", getApiFullPath(), u.Meta.AvatarID, types.AttachmentKindAvatar)
 	switch {
 	case
 		service.UserErrInvalidID().Is(err),
@@ -171,4 +173,8 @@ func (h *AuthHandlers) profileProc(req *request.AuthReq) error {
 		h.Log.Error("unhandled error", zap.Error(err))
 		return err
 	}
+}
+
+func getApiFullPath() (path string) {
+	return fmt.Sprintf("/%s", strings.TrimPrefix(options.CleanBase(options.HttpServer().BaseUrl, options.HttpServer().ApiBaseUrl), "/"))
 }

--- a/server/auth/handlers/handle_profile_test.go
+++ b/server/auth/handlers/handle_profile_test.go
@@ -46,7 +46,7 @@ func Test_profileForm(t *testing.T) {
 	authHandlers.UserService = userService
 	authReq = prepareClientAuthReq(authHandlers, req, user)
 
-	avatarUrl := fmt.Sprintf("/api/system/attachment/avatar/%d/original/%s", user.Meta.AvatarID, types.AttachmentKindAvatar)
+	avatarUrl := fmt.Sprintf("//system/attachment/avatar/%d/original/%s", user.Meta.AvatarID, types.AttachmentKindAvatar)
 
 	userForm := map[string]string{
 		"email":             user.Email,
@@ -123,7 +123,7 @@ func Test_profileFormProc(t *testing.T) {
 				"name":             "name",
 				"initialBgColor":   "",
 				"initialTextColor": "",
-				"avatarUrl":        "/api/system/attachment/avatar/0/original/avatar",
+				"avatarUrl":        "//system/attachment/avatar/0/original/avatar",
 			},
 			fn: func(_ *settings.Settings) {
 				req.PostForm.Add("handle", "handle")
@@ -154,7 +154,7 @@ func Test_profileFormProc(t *testing.T) {
 				"name":             "name",
 				"initialBgColor":   "",
 				"initialTextColor": "",
-				"avatarUrl":        "/api/system/attachment/avatar/0/original/avatar",
+				"avatarUrl":        "//system/attachment/avatar/0/original/avatar",
 			},
 			fn: func(_ *settings.Settings) {
 				req.PostForm.Add("handle", "handle")
@@ -185,7 +185,7 @@ func Test_profileFormProc(t *testing.T) {
 				"name":             "name",
 				"initialBgColor":   "",
 				"initialTextColor": "",
-				"avatarUrl":        "/api/system/attachment/avatar/0/original/avatar",
+				"avatarUrl":        "//system/attachment/avatar/0/original/avatar",
 			},
 			fn: func(_ *settings.Settings) {
 				req.PostForm.Add("handle", "handle")
@@ -216,7 +216,7 @@ func Test_profileFormProc(t *testing.T) {
 				"name":             "name",
 				"initialBgColor":   "",
 				"initialTextColor": "",
-				"avatarUrl":        "/api/system/attachment/avatar/0/original/avatar",
+				"avatarUrl":        "//system/attachment/avatar/0/original/avatar",
 			},
 			fn: func(_ *settings.Settings) {
 				req.PostForm.Add("handle", "handle")
@@ -247,7 +247,7 @@ func Test_profileFormProc(t *testing.T) {
 				"name":             "name",
 				"initialBgColor":   "",
 				"initialTextColor": "",
-				"avatarUrl":        "/api/system/attachment/avatar/0/original/avatar",
+				"avatarUrl":        "//system/attachment/avatar/0/original/avatar",
 			},
 			fn: func(_ *settings.Settings) {
 				req.PostForm.Add("handle", "handle")

--- a/server/tests/system/main_test.go
+++ b/server/tests/system/main_test.go
@@ -99,6 +99,7 @@ func InitTestApp() {
 
 			sm = request.NewSessionManager(service.DefaultStore, app.Opt.Auth, service.DefaultLogger)
 
+			app.Opt.Attachment.AvatarInitialsFontPath = "../../auth/assets/public/fonts/poppins/Poppins-Regular.ttf"
 			return nil
 		})
 


### PR DESCRIPTION
This PR adds validation for the font file used to generate avatar initials and it fixes the tests that were broken by the introduction of the new avatar feature.