### PR TITLE
Fix Geometry Multi Value Map Inconsistency

### DIFF
--- a/client/web/compose/src/components/ModuleFields/Viewer/Geometry.vue
+++ b/client/web/compose/src/components/ModuleFields/Viewer/Geometry.vue
@@ -7,7 +7,7 @@
     >
       <a
         class="text-primary pointer"
-        @click.stop="openMap"
+        @click.stop="openMap(index)"
       >
         {{ c.lat }}, {{ c.lng }}
         <font-awesome-icon
@@ -39,6 +39,7 @@
           v-for="(marker, i) in localValue"
           :key="i"
           :lat-lng="marker"
+          :opacity="i == localValueIndex ? 1.0 : 0.6"
         />
       </l-map>
     </b-modal>
@@ -62,11 +63,12 @@ export default {
     return {
       map: {
         show: false,
-        zoom: 3,
+        zoom: 14,
         center: [30, 30],
         rotation: 0,
         attribution: '&copy; <a target="_blank" rel="noopener noreferrer" href="http://osm.org/copyright">OpenStreetMap</a>',
       },
+      localValueIndex: undefined,
     }
   },
 
@@ -83,10 +85,10 @@ export default {
   },
 
   methods: {
-    openMap () {
-      const firstCoordinates = this.localValue[0]
-      this.map.center = firstCoordinates && firstCoordinates.length ? firstCoordinates : this.field.options.center
-      this.map.zoom = this.field.options.zoom
+    openMap (i) {
+      this.localValueIndex = i
+      this.map.center = this.localValue[i] || this.field.options.center
+      this.map.zoom = this.localValue[i] ? this.map.zoom : this.field.options.zoom
       this.map.show = true
 
       setTimeout(() => {


### PR DESCRIPTION
https://user-images.githubusercontent.com/26258032/225582227-c1eab341-a2f3-4445-beed-4014a1062211.mp4
### Changelog

### What was fixed?
- The corresponding marker is shown when opening a specific geometry location, including on geometry multivalue fields. Before, the map was opening on the same location as specified in the module field, not taking into account the marker location.
- Obscure other map markers (if present) with some opacity to make the current marker stand out in a multivalue field.
- Zoom in to a more appropriate level. Before, the map markers were too far off and users had to zoom in all the time to see the exact coordinates.

### How was fixed?
Leaflet map  instance in compose was updated. Params, e.g. zoom level was updated. The correct marker indexes were used to make a connection with the localValue index

### Why was fixed?
Different markers in multivalue fields when the map is opened were causing confusion and bad ui. This pr aims to improve ux and usability of the geometry field.
