### PR TITLE
Add geolocation capture feature on record geometry field

### DIFF
--- a/client/web/compose/src/components/ModuleFields/Configurator/Geometry.vue
+++ b/client/web/compose/src/components/ModuleFields/Configurator/Geometry.vue
@@ -1,21 +1,44 @@
 <template>
   <div>
+    <b-form-checkbox v-model="f.options.prefillWithCurrentLocation">
+      {{ $t('prefillWithCurrentLocation') }}
+    </b-form-checkbox>
+
+    <b-form-checkbox v-model="f.options.hideCurrentLocationButton">
+      {{ $t('hideCurrentLocationButton') }}
+    </b-form-checkbox>
+
     <b-form-group
-      :label="$t('kind.geometry.initialZoomAndPosition')"
+      :label="$t('initialZoomAndPosition')"
       class="mb-0"
     >
       <l-map
+        ref="map"
         :zoom="zoom"
         :center="center"
         class="w-100"
         style="height: 60vh;"
         @update:zoom="f.options.zoom = $event"
         @update:center="f.options.center = $event"
+        @locationfound="onLocationFound"
       >
         <l-tile-layer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           :attribution="attribution"
         />
+        <l-control class="leaflet-bar">
+          <a
+            :title="$t('tooltip.goToCurrentLocation')"
+            role="button"
+            class="d-flex justify-content-center align-items-center"
+            @click="goToCurrentLocation"
+          >
+            <font-awesome-icon
+              :icon="['fas', 'location-arrow']"
+              class="text-primary"
+            />
+          </a>
+        </l-control>
       </l-map>
     </b-form-group>
   </div>
@@ -23,10 +46,16 @@
 
 <script>
 import base from './base'
+import { LControl } from 'vue2-leaflet'
 
 export default {
   i18nOptions: {
     namespaces: 'field',
+    keyPrefix: 'kind.geometry',
+  },
+
+  components: {
+    LControl,
   },
 
   extends: base,
@@ -44,6 +73,17 @@ export default {
 
     zoom () {
       return this.f.options.zoom || 3
+    },
+  },
+
+  methods: {
+    goToCurrentLocation () {
+      this.$refs.map.mapObject.locate()
+    },
+
+    onLocationFound ({ latitude, longitude }) {
+      const zoom = this.$refs.map.mapObject._zoom >= 13 ? this.$refs.map.mapObject._zoom : 13
+      this.$refs.map.mapObject.flyTo([latitude, longitude], zoom)
     },
   },
 }

--- a/client/web/compose/src/components/ModuleFields/Viewer/Geometry.vue
+++ b/client/web/compose/src/components/ModuleFields/Viewer/Geometry.vue
@@ -30,6 +30,7 @@
         :zoom="map.zoom"
         :center="map.center"
         style="height: 75vh; width: 100%;"
+        @locationfound="onLocationFound"
       >
         <l-tile-layer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -41,6 +42,19 @@
           :lat-lng="marker"
           :opacity="i == localValueIndex ? 1.0 : 0.6"
         />
+        <l-control class="leaflet-bar">
+          <a
+            :title="$t('tooltip.goToCurrentLocation')"
+            role="button"
+            class="d-flex justify-content-center align-items-center"
+            @click="goToCurrentLocation"
+          >
+            <font-awesome-icon
+              :icon="['fas', 'location-arrow']"
+              class="text-primary"
+            />
+          </a>
+        </l-control>
       </l-map>
     </b-modal>
 
@@ -50,14 +64,19 @@
 <script>
 import base from './base'
 import { latLng } from 'leaflet'
+import { LControl } from 'vue2-leaflet'
 
 export default {
-  extends: base,
-
   i18nOptions: {
     namespaces: 'field',
     keyPrefix: 'kind.geometry',
   },
+
+  components: {
+    LControl,
+  },
+
+  extends: base,
 
   data () {
     return {
@@ -102,6 +121,15 @@ export default {
       if (lat && lng) {
         return latLng(lat, lng)
       }
+    },
+
+    goToCurrentLocation () {
+      this.$refs.map.mapObject.locate()
+    },
+
+    onLocationFound ({ latitude, longitude }) {
+      const zoom = this.$refs.map.mapObject._zoom >= 13 ? this.$refs.map.mapObject._zoom : 13
+      this.$refs.map.mapObject.flyTo([latitude, longitude], zoom)
     },
   },
 }

--- a/client/web/compose/src/components/PageBlocks/GeometryBase.vue
+++ b/client/web/compose/src/components/PageBlocks/GeometryBase.vue
@@ -25,6 +25,7 @@
           :bounds="map.bounds"
           :max-bounds="map.bounds"
           class="w-100 h-100"
+          @locationfound="onLocationFound"
         >
           <l-tile-layer
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -43,6 +44,19 @@
             :lat-lng="marker.value"
             :icon="getIcon(marker)"
           />
+          <l-control class="leaflet-bar">
+            <a
+              :title="$t('tooltip.goToCurrentLocation')"
+              role="button"
+              class="d-flex justify-content-center align-items-center"
+              @click="goToCurrentLocation"
+            >
+              <font-awesome-icon
+                :icon="['fas', 'location-arrow']"
+                class="text-primary"
+              />
+            </a>
+          </l-control>
         </l-map>
       </div>
     </template>
@@ -51,16 +65,17 @@
 
 <script>
 import { divIcon, latLng, latLngBounds } from 'leaflet'
-import {
-  LPolygon,
-} from 'vue2-leaflet'
+import { LPolygon, LControl } from 'vue2-leaflet'
 import { compose, NoID } from '@cortezaproject/corteza-js'
 import { mapGetters, mapActions } from 'vuex'
 import { evaluatePrefilter } from 'corteza-webapp-compose/src/lib/record-filter'
 import base from './base'
 
 export default {
-  components: { LPolygon },
+  components: {
+    LPolygon,
+    LControl,
+  },
 
   extends: base,
 
@@ -227,6 +242,15 @@ export default {
     },
     enableMap () {
       if (this.editable) this.$refs.map.mapObject._handlers.forEach(handler => handler.enable())
+    },
+
+    goToCurrentLocation () {
+      this.$refs.map.mapObject.locate()
+    },
+
+    onLocationFound ({ latitude, longitude }) {
+      const zoom = this.$refs.map.mapObject._zoom >= 13 ? this.$refs.map.mapObject._zoom : 13
+      this.$refs.map.mapObject.flyTo([latitude, longitude], zoom)
     },
   },
 }

--- a/client/web/compose/src/components/PageBlocks/GeometryConfigurator/Configurator.vue
+++ b/client/web/compose/src/components/PageBlocks/GeometryConfigurator/Configurator.vue
@@ -14,11 +14,25 @@
         @update:zoom="zoomUpdated"
         @update:center="updateCenter"
         @update:bounds="boundsUpdated"
+        @locationfound="onLocationFound"
       >
         <l-tile-layer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           :attribution="map.attribution"
         />
+        <l-control class="leaflet-bar">
+          <a
+            :title="$t('tooltip.goToCurrentLocation')"
+            role="button"
+            class="d-flex justify-content-center align-items-center"
+            @click="goToCurrentLocation"
+          >
+            <font-awesome-icon
+              :icon="['fas', 'location-arrow']"
+              class="text-primary"
+            />
+          </a>
+        </l-control>
       </l-map>
       <b-form-text id="password-help-block">
         {{ $t('geometry.mapHelpText') }}
@@ -130,14 +144,17 @@
 </template>
 
 <script>
-import { latLng } from 'leaflet'
 import base from '../base'
+import { latLng } from 'leaflet'
+import { LControl } from 'vue2-leaflet'
 
 export default {
-  components: {},
-
   i18nOptions: {
     namespaces: 'block',
+  },
+
+  components: {
+    LControl,
   },
 
   extends: base,
@@ -166,6 +183,7 @@ export default {
         return latLng(lat, lng)
       }
     },
+
     updateCenter (coordinates) {
       let { lat = 0, lng = 0 } = coordinates || {}
 
@@ -174,14 +192,17 @@ export default {
 
       this.options.center = [lat, lng]
     },
+
     boundsUpdated (coordinates) {
       this.bounds = coordinates
 
       this.updateBounds(this.options.lockBounds)
     },
+
     zoomUpdated (zoom) {
       this.options.zoomStarting = zoom
     },
+
     updateBounds (value) {
       if (value) {
         const bounds = this.bounds || this.$refs.map.mapObject.getBounds()
@@ -191,6 +212,15 @@ export default {
       } else {
         this.options.bounds = null
       }
+    },
+
+    goToCurrentLocation () {
+      this.$refs.map.mapObject.locate()
+    },
+
+    onLocationFound ({ latitude, longitude }) {
+      const zoom = this.$refs.map.mapObject._zoom >= 13 ? this.$refs.map.mapObject._zoom : 13
+      this.$refs.map.mapObject.flyTo([latitude, longitude], zoom)
     },
   },
 }

--- a/client/web/compose/src/components/faIcons.js
+++ b/client/web/compose/src/components/faIcons.js
@@ -62,6 +62,7 @@ import {
   faSync,
   faExclamationTriangle,
   faEllipsisV,
+  faLocationArrow,
 } from '@fortawesome/free-solid-svg-icons'
 
 import {
@@ -172,4 +173,5 @@ library.add(
   faExclamationTriangle,
   faSync,
   faEllipsisV,
+  faLocationArrow,
 )

--- a/lib/js/src/compose/types/module-field/geometry.ts
+++ b/lib/js/src/compose/types/module-field/geometry.ts
@@ -7,6 +7,8 @@ interface GeometryOptions extends Options {
   center: number[];
   zoom: number;
   multiDelimiter: string;
+  prefillWithCurrentLocation: boolean;
+  hideCurrentLocationButton: boolean;
 }
 
 const defaults = (): Readonly<GeometryOptions> => Object.freeze({
@@ -14,6 +16,8 @@ const defaults = (): Readonly<GeometryOptions> => Object.freeze({
   center: [30, 30],
   zoom: 3,
   multiDelimiter: '\n',
+  prefillWithCurrentLocation: false,
+  hideCurrentLocationButton: false,
 })
 
 export class ModuleFieldGeometry extends ModuleField {
@@ -32,6 +36,8 @@ export class ModuleFieldGeometry extends ModuleField {
 
     Apply(this.options, o, String, 'multiDelimiter')
     Apply(this.options, o, Number, 'zoom')
+    Apply(this.options, o, Boolean, 'prefillWithCurrentLocation')
+    Apply(this.options, o, Boolean, 'hideCurrentLocationButton')
 
     if (o.center) {
       this.options.center = o.center

--- a/locale/en/corteza-webapp-compose/field.yaml
+++ b/locale/en/corteza-webapp-compose/field.yaml
@@ -143,8 +143,14 @@ kind:
     label: Geometry
     latitude: Latitude
     longitude: Longitude
-    clickToPlaceMarker: Click to place a marker or click on a marker to remove it
+    clickToPlaceMarker: Click to place/remove a marker
     initialZoomAndPosition: Set initial map zoom and position
+    prefillWithCurrentLocation: Prefill with current location
+    hideCurrentLocationButton: Hide current location button
+    tooltip:
+      goToCurrentLocation: Go to current location
+      useCurrentLocation: Use current location
+      openMap: Open map
 noPermission: No permission to read field value
 no-items-found: No items found
 options:

--- a/locale/en/corteza-webapp-compose/notification.yaml
+++ b/locale/en/corteza-webapp-compose/notification.yaml
@@ -28,6 +28,14 @@ field:
 field-datetime:
   valueNotFuture: Past value on future only field
   valueNotPast: Future value on past only field
+field-geometry:
+  geolocationErrors:
+    permissionDenied: User denied the request for geolocation
+    positionUnavailable: Location information is unavailable
+    timeout: The request to get user location timed out
+    unknownError: An unknown error occurred
+    notSupported: Geolocation is not supported by this browser
+    errorOccurred: An error occurred while getting user location
 general:
   composeAccessNotAllowed: Not allowed to access Compose
   error: Error


### PR DESCRIPTION
ref: https://github.com/cortezaproject/corteza/issues/875

This PR adds a geolocation capture feature on the record geometry field while using the [geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API) provided by the browser.

### Features added
- Show the current location button with a `location-arrow` icon.

   ![Screenshot 2023-03-23 at 11 11 09](https://user-images.githubusercontent.com/32476094/227141882-6b13c4e1-ccdd-4f0b-8810-d363f5451fb0.png)

   
   ![Screenshot 2023-03-23 at 11 22 59](https://user-images.githubusercontent.com/32476094/227144402-1e4f382d-86e4-421f-9e5b-e2644bf89fac.png)

- An option to prefill the current location and to hide the `current location` button.
   
   <img width="328" alt="Screenshot 2023-03-22 at 10 39 06" src="https://user-images.githubusercontent.com/32476094/226833004-d48c79c0-d74d-4212-9ad2-17f0625d822d.png">

- Ability to fly to current location while on the map.

When the `Show Current Location` button is clicked or when the `Prefill With Current Location`  option is enabled, both the latitude and longitude input fields are prefilled with the user's current coordinates obtained from the [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API).

### Errors captured
1.  [Geolocation API permission denied error](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code)
2. [Geolocation API position unavailable error](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code)
3. [Geolocation API timeout error](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code)
4. Geolocation API unknown error
5. Geolocation API not supported error
6. An error occurred while getting user's location