### PR TITLE
Hide unnecessary configurations for pie and dougnut charts

### DIFF
--- a/client/web/compose/src/components/Chart/Report/GenericChart.vue
+++ b/client/web/compose/src/components/Chart/Report/GenericChart.vue
@@ -115,6 +115,7 @@
 
     <template #metric-options="{ metric }">
       <b-form-group
+        v-if="!['pie', 'doughnut'].includes(metric.type)"
         horizontal
         :label-cols="3"
         class="mt-1"

--- a/client/web/compose/src/components/Chart/Report/ReportEdit.vue
+++ b/client/web/compose/src/components/Chart/Report/ReportEdit.vue
@@ -150,6 +150,7 @@
               <b-input
                 v-model="d.rotateLabel"
                 type="number"
+                number
               />
             </b-form-group>
           </template>

--- a/lib/js/src/compose/types/chart/base.ts
+++ b/lib/js/src/compose/types/chart/base.ts
@@ -313,7 +313,7 @@ export class BaseChart {
     return Object.assign({}, {
       conditions: {},
       meta: {},
-      rotateLabel: '0',
+      rotateLabel: 0,
     })
   }
 
@@ -331,7 +331,7 @@ export class BaseChart {
         axisType: 'linear',
         axisPosition: 'left',
         labelPosition: 'end',
-        rotateLabel: '0',
+        rotateLabel: 0,
       },
       tooltip: {},
       legend: {

--- a/lib/js/src/compose/types/chart/chart.ts
+++ b/lib/js/src/compose/types/chart/chart.ts
@@ -121,15 +121,19 @@ export default class Chart extends BaseChart {
 
         options.tooltip.trigger = 'item'
 
-        let lbl =  {}
+        let lbl:any =  {
+          rotate: dimension.rotateLabel ? +dimension.rotateLabel: 0
+        }
 
         if (t?.labelsNextToPartition) {
           lbl = {
+            ...lbl,
             show: true,
             overflow: 'truncate',
           }
         } else {
           lbl = {
+            ...lbl,
             show: fixed,
             position: 'inside',
             align: 'center',

--- a/lib/js/src/compose/types/chart/util.ts
+++ b/lib/js/src/compose/types/chart/util.ts
@@ -30,7 +30,7 @@ export interface Dimension {
   default?: string;
   skipMissing?: boolean;
   autoSkip?: boolean;
-  rotateLabel?: string;
+  rotateLabel?: number;
 }
 
 export interface Metric {
@@ -56,7 +56,7 @@ export interface YAxis {
   labelPosition?: string;
   min?: string;
   max?: string;
-  rotateLabel?: string;
+  rotateLabel?: number;
 }
 
 export interface ChartOffset {

--- a/locale/en/corteza-webapp-compose/chart.yaml
+++ b/locale/en/corteza-webapp-compose/chart.yaml
@@ -42,7 +42,7 @@ edit:
       noItemsFound: No options found
     rotate:
       label: Rotate label
-      description: Labels can be rotated from -90 to 90 degrees. Applied to bar and line charts
+      description: Labels can be rotated from -90 to 90 degrees.
   filter:
     customize: Customize filter
     label: Filters


### PR DESCRIPTION
## Changelog

### What was improved?
Rotate label field was not working for pie and doughnut charts. At the same time rotate field was included, which was misleading for users. This pr allowed the chart values for the above chart types to rotate. At the same time, metric label field was included in pie and doughnut charts ,which is not displayed at these charts. This field was removed

### How was improved?
Chart.ts file is corteza-js was updated to adjust existing rotate logic for the above-mentioned charts.

### Why was improved?
Rotate field was not working for pie and doughnut charts and metric label was not needed.
