### PR TITLE
Fix dedicated record revisions table

### DIFF
--- a/server/pkg/revisions/model.go
+++ b/server/pkg/revisions/model.go
@@ -23,9 +23,9 @@ func Model() *dal.Model {
 		Attributes: dal.AttributeSet{
 			&dal.Attribute{Ident: "id", PrimaryKey: true, Store: &dal.CodecPlain{}, Type: &dal.TypeID{}},
 			&dal.Attribute{Ident: "ts", Store: &dal.CodecPlain{}, Type: &dal.TypeTimestamp{}},
-			&dal.Attribute{Ident: "revision", Store: &dal.CodecPlain{}, Type: &dal.TypeNumber{}},
-			&dal.Attribute{Ident: "operation", Store: &dal.CodecPlain{}, Type: &dal.TypeNumber{}},
 			&dal.Attribute{Ident: "rel_resource", Store: &dal.CodecPlain{}, Type: &dal.TypeID{}},
+			&dal.Attribute{Ident: "revision", Store: &dal.CodecPlain{}, Type: &dal.TypeNumber{}},
+			&dal.Attribute{Ident: "operation", Store: &dal.CodecPlain{}, Type: &dal.TypeText{}},
 			&dal.Attribute{Ident: "rel_user", Store: &dal.CodecPlain{}, Type: &dal.TypeID{}},
 			&dal.Attribute{Ident: "delta", Store: &dal.CodecPlain{}, Type: &dal.TypeJSON{}},
 			&dal.Attribute{Ident: "comment", Store: &dal.CodecPlain{}, Type: &dal.TypeText{}},


### PR DESCRIPTION
Fixes: https://github.com/cortezaproject/corteza/issues/911

### Issue
When a user set's a  custom dedicated record revision table, then tries to update a record, the following error was appearing:  _“Could not update record: failed to complete transaction: Error 1366: Incorrect decimal value: ‘updated’ for column ‘operation’ at row 1”_

### Solution
Rearranged the order of the `rel_resource`, `revision`, and `operation` columns when custom dedicated record revision table is created and changed the `operation` column datatype to `text`.
