### PR TITLE
Navigation Block Dropdown Overflow

### DIFF
--- a/client/web/compose/src/components/PageBlocks/Navigation/NavTypes/ComposePage.vue
+++ b/client/web/compose/src/components/PageBlocks/Navigation/NavTypes/ComposePage.vue
@@ -22,7 +22,7 @@
           :reduce="f => f.pageID"
           option-value="pageID"
           option-text="title"
-          class="bg-white"
+          class="nav-page-selector bg-white"
           @input="updateLabelValue"
         />
       </b-form-group>
@@ -117,7 +117,7 @@ export default {
 
 <style lang="scss" scoped>
 
-.block-selector {
+.nav-page-selector {
   position: relative;
 
   &:not(.vs--open) .vs__selected + .vs__search {
@@ -142,6 +142,13 @@ export default {
     max-width: 100%;
     overflow: hidden;
   }
+}
+</style>
+
+<style lang="css">
+
+.vs__dropdown-menu{
+  min-width: auto;
 }
 
 .vs__dropdown-menu .vs__dropdown-option {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26258032/229056120-6cff0771-ac55-4342-ac37-4530e5a523dd.png)

## Problem Summary
On smaller screen sizes, e.g. 13'' - 14'' laptops, the navigation dropdowns overflow. This PR addresses this

## Changelog

### What was fixed?
When you create a navigation block and pick a compose page for the navigation item, the select dropdown has bigger width than the selected item on some smaller laptops (less than 1500px width). This is because of the way bootstrap implements modals and causes the actual items to shrink on smaller width.

### How was fixed?
Block selector class was added to the vue-select dropdown to add overflow elipsis on long name in the select dropdown, so they do not go on next line. Min width was removed, as it forced the vue-select dropdown to be wider than the actual vue-select item.

### Why was fixed?
It is more visually appealing and consistent like that, especially if you are working on a smaller screen size.