### PR TITLE
Fix geometry configurator center input not adjusting to map center

### DIFF
--- a/client/web/compose/src/components/PageBlocks/GeometryConfigurator/Configurator.vue
+++ b/client/web/compose/src/components/PageBlocks/GeometryConfigurator/Configurator.vue
@@ -102,31 +102,6 @@
         md="4"
       >
         <b-form-group
-          label-class="text-primary"
-          :label="$t('geometry.centerLabel')"
-        >
-          <b-input-group>
-            <b-form-input
-              v-model="options.center[0]"
-              type="number"
-              number
-              :placeholder="$t('latitude')"
-            />
-            <b-form-input
-              v-model="options.center[1]"
-              type="number"
-              number
-              :placeholder="$t('longitude')"
-            />
-          </b-input-group>
-        </b-form-group>
-      </b-col>
-
-      <b-col
-        sm="12"
-        md="4"
-      >
-        <b-form-group
           :label="$t('geometry.bounds.lockBounds')"
           class="rounded-left"
         >


### PR DESCRIPTION
# The following changes are implemented
Fix geometry configurator center input not adjusting to map center

# Changes in the user interface:


# Checklist when submitting a final (!draft) PR
 - [ ] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [ ] PR is linked to the relevant issue(s)
 - [ ] Rebased with the target branch
