### PR TITLE
Fix error handling for avatar font file in auth profile

### DIFF
--- a/server/auth/handlers/handle_profile.go
+++ b/server/auth/handlers/handle_profile.go
@@ -149,7 +149,7 @@ func (h *AuthHandlers) profileProc(req *request.AuthReq) error {
 		service.UserErrNotAllowedToUpdate().Is(err),
 		service.AttachmentErrInvalidAvatarFileType().Is(err),
 		service.AttachmentErrInvalidAvatarFileSize().Is(err),
-		service.AttachmentErrInvalidInitialsLength().Is(err):
+		service.AttachmentErrInvalidAvatarGenerateFontFile().Is(err):
 		req.SetKV(map[string]string{
 			"error":            err.Error(),
 			"email":            u.Email,

--- a/server/system/service/attachment_actions.gen.go
+++ b/server/system/service/attachment_actions.gen.go
@@ -57,7 +57,6 @@ var (
 // setSize updates attachmentActionProps's size
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setSize(size int64) *attachmentActionProps {
 	p.size = size
 	return p
@@ -66,7 +65,6 @@ func (p *attachmentActionProps) setSize(size int64) *attachmentActionProps {
 // setName updates attachmentActionProps's name
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setName(name string) *attachmentActionProps {
 	p.name = name
 	return p
@@ -75,7 +73,6 @@ func (p *attachmentActionProps) setName(name string) *attachmentActionProps {
 // setMimetype updates attachmentActionProps's mimetype
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setMimetype(mimetype string) *attachmentActionProps {
 	p.mimetype = mimetype
 	return p
@@ -84,7 +81,6 @@ func (p *attachmentActionProps) setMimetype(mimetype string) *attachmentActionPr
 // setUrl updates attachmentActionProps's url
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setUrl(url string) *attachmentActionProps {
 	p.url = url
 	return p
@@ -93,7 +89,6 @@ func (p *attachmentActionProps) setUrl(url string) *attachmentActionProps {
 // setAttachment updates attachmentActionProps's attachment
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setAttachment(attachment *types.Attachment) *attachmentActionProps {
 	p.attachment = attachment
 	return p
@@ -102,7 +97,6 @@ func (p *attachmentActionProps) setAttachment(attachment *types.Attachment) *att
 // setFilter updates attachmentActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setFilter(filter *types.AttachmentFilter) *attachmentActionProps {
 	p.filter = filter
 	return p
@@ -111,7 +105,6 @@ func (p *attachmentActionProps) setFilter(filter *types.AttachmentFilter) *attac
 // Serialize converts attachmentActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p attachmentActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -142,7 +135,6 @@ func (p attachmentActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p attachmentActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -217,7 +209,6 @@ func (p attachmentActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *attachmentAction) String() string {
 	var props = &attachmentActionProps{}
 
@@ -245,7 +236,6 @@ func (e *attachmentAction) ToAction() *actionlog.Action {
 // AttachmentActionSearch returns "system:attachment.search" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionSearch(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -265,7 +255,6 @@ func AttachmentActionSearch(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionLookup returns "system:attachment.lookup" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionLookup(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -285,7 +274,6 @@ func AttachmentActionLookup(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionCreate returns "system:attachment.create" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionCreate(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -305,7 +293,6 @@ func AttachmentActionCreate(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionDelete returns "system:attachment.delete" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionDelete(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -328,9 +315,7 @@ func AttachmentActionDelete(props ...*attachmentActionProps) *attachmentAction {
 
 // AttachmentErrGeneric returns "system:attachment.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrGeneric(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -364,9 +349,7 @@ func AttachmentErrGeneric(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotFound returns "system:attachment.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -398,9 +381,7 @@ func AttachmentErrNotFound(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrInvalidID returns "system:attachment.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -432,9 +413,7 @@ func AttachmentErrInvalidID(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotAllowedToListAttachments returns "system:attachment.notAllowedToListAttachments" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToListAttachments(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -468,9 +447,7 @@ func AttachmentErrNotAllowedToListAttachments(mm ...*attachmentActionProps) *err
 
 // AttachmentErrNotAllowedToCreate returns "system:attachment.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreate(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -504,9 +481,7 @@ func AttachmentErrNotAllowedToCreate(mm ...*attachmentActionProps) *errors.Error
 
 // AttachmentErrNotAllowedToCreateEmptyAttachment returns "system:attachment.notAllowedToCreateEmptyAttachment" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreateEmptyAttachment(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -540,9 +515,7 @@ func AttachmentErrNotAllowedToCreateEmptyAttachment(mm ...*attachmentActionProps
 
 // AttachmentErrFailedToExtractMimeType returns "system:attachment.failedToExtractMimeType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToExtractMimeType(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -574,9 +547,7 @@ func AttachmentErrFailedToExtractMimeType(mm ...*attachmentActionProps) *errors.
 
 // AttachmentErrFailedToStoreFile returns "system:attachment.failedToStoreFile" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToStoreFile(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -608,9 +579,7 @@ func AttachmentErrFailedToStoreFile(mm ...*attachmentActionProps) *errors.Error 
 
 // AttachmentErrFailedToProcessImage returns "system:attachment.failedToProcessImage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToProcessImage(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -642,9 +611,7 @@ func AttachmentErrFailedToProcessImage(mm ...*attachmentActionProps) *errors.Err
 
 // AttachmentErrInvalidAvatarFileType returns "system:attachment.invalidAvatarFileType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidAvatarFileType(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -676,9 +643,7 @@ func AttachmentErrInvalidAvatarFileType(mm ...*attachmentActionProps) *errors.Er
 
 // AttachmentErrInvalidAvatarFileSize returns "system:attachment.invalidAvatarFileSize" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidAvatarFileSize(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -708,12 +673,10 @@ func AttachmentErrInvalidAvatarFileSize(mm ...*attachmentActionProps) *errors.Er
 	return e
 }
 
-// AttachmentErrInvalidInitialsLength returns "system:attachment.invalidInitialsLength" as *errors.Error
-//
+// AttachmentErrInvalidAvatarGenerateFontFile returns "system:attachment.invalidAvatarGenerateFontFile" as *errors.Error
 //
 // This function is auto-generated.
-//
-func AttachmentErrInvalidInitialsLength(mm ...*attachmentActionProps) *errors.Error {
+func AttachmentErrInvalidAvatarGenerateFontFile(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
 		p = mm[0]
@@ -722,16 +685,16 @@ func AttachmentErrInvalidInitialsLength(mm ...*attachmentActionProps) *errors.Er
 	var e = errors.New(
 		errors.KindInternal,
 
-		p.Format("initials characters length should not exceed 3 characters", nil),
+		p.Format("failed to generate avatar initial, font file configuration is invalid", nil),
 
-		errors.Meta("type", "invalidInitialsLength"),
+		errors.Meta("type", "invalidAvatarGenerateFontFile"),
 		errors.Meta("resource", "system:attachment"),
 
 		errors.Meta(attachmentPropsMetaKey{}, p),
 
 		// translation namespace & key
 		errors.Meta(locale.ErrorMetaNamespace{}, "system"),
-		errors.Meta(locale.ErrorMetaKey{}, "attachment.errors.invalidInitialsLength"),
+		errors.Meta(locale.ErrorMetaKey{}, "attachment.errors.invalidAvatarGenerateFontFile"),
 
 		errors.StackSkip(1),
 	)
@@ -750,7 +713,6 @@ func AttachmentErrInvalidInitialsLength(mm ...*attachmentActionProps) *errors.Er
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc attachment) recordAction(ctx context.Context, props *attachmentActionProps, actionFn func(...*attachmentActionProps) *attachmentAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/attachment_actions.yaml
+++ b/server/system/service/attachment_actions.yaml
@@ -78,6 +78,5 @@ errors:
     message: "file size is too large"
     severity: warning
 
-  - error: invalidInitialsLength
-    message: "initials characters length should not exceed 3 characters"
-    severity: warning
+  - error: invalidAvatarGenerateFontFile
+    message: "failed to generate avatar initial, font file configuration is invalid"

--- a/server/system/service/user.go
+++ b/server/system/service/user.go
@@ -1073,8 +1073,10 @@ func (svc user) UploadAvatar(ctx context.Context, userID uint64, upload *multipa
 			return
 		}
 
-		if !svc.ac.CanUpdateUser(ctx, u) {
-			return UserErrNotAllowedToUpdate()
+		if userID != internalAuth.GetIdentityFromContext(ctx).Identity() {
+			if !svc.ac.CanUpdateUser(ctx, u) {
+				return UserErrNotAllowedToUpdate()
+			}
 		}
 
 		if u.Meta.AvatarID != 0 {
@@ -1240,8 +1242,10 @@ func (svc user) GenerateAvatar(ctx context.Context, userID uint64, bgColor strin
 			return
 		}
 
-		if !svc.ac.CanUpdateUser(ctx, u) {
-			return UserErrNotAllowedToUpdate()
+		if userID != internalAuth.GetIdentityFromContext(ctx).Identity() {
+			if !svc.ac.CanUpdateUser(ctx, u) {
+				return UserErrNotAllowedToUpdate()
+			}
 		}
 
 		u.Meta.AvatarColor = initialColor


### PR DESCRIPTION
Ref: https://github.com/cortezaproject/corteza/issues/996

Fix error handling for missing font file when generating user avatar initial in auth profile.

Previously, if a user attempted to update their own profile and the update triggered avatar initial generation with invalid font file configuration, the system did not handle the resulting error properly. This PR adds proper error handling to catch invalid font file configuration and inform the user why their update was not persisted. 
