### PR TITLE
Add option to allow duplicate values for single and each multi value …

### DIFF
--- a/client/web/compose/src/components/ModuleFields/Configurator/Record.vue
+++ b/client/web/compose/src/components/ModuleFields/Configurator/Record.vue
@@ -77,7 +77,17 @@
         v-model="f.options.selectType"
         :options="selectOptions"
         stacked
+        @change="onUpdateIsUniqueMultiValue"
       />
+      <b-form-checkbox
+        v-if="f.options.selectType !== 'multiple'"
+        v-model="f.options.isUniqueMultiValue"
+        :value="false"
+        :unchecked-value="true"
+        class="mt-2"
+      >
+        {{ $t('kind.select.allow-duplicates') }}
+      </b-form-checkbox>
     </b-form-group>
   </div>
 </template>
@@ -201,6 +211,14 @@ export default {
       this.f.options.labelField = undefined
       this.f.options.queryFields = []
       this.f.options.selectType = 'default'
+    },
+  },
+
+  methods: {
+    onUpdateIsUniqueMultiValue () {
+      if (this.f.options.selectType === 'multiple') {
+        this.f.options.isUniqueMultiValue = true
+      }
     },
   },
 }

--- a/client/web/compose/src/components/ModuleFields/Configurator/Select.vue
+++ b/client/web/compose/src/components/ModuleFields/Configurator/Select.vue
@@ -83,7 +83,17 @@
           v-model="f.options.selectType"
           :options="selectOptions"
           stacked
+          @change="onUpdateIsUniqueMultiValue"
         />
+        <b-form-checkbox
+          v-if="f.options.selectType !== 'multiple'"
+          v-model="f.options.isUniqueMultiValue"
+          :value="false"
+          :unchecked-value="true"
+          class="mt-2"
+        >
+          {{ $t('kind.select.allow-duplicates') }}
+        </b-form-checkbox>
       </b-form-group>
     </b-col>
   </b-row>
@@ -155,6 +165,12 @@ export default {
       if (this.newOption.value) {
         this.f.options.options.push(this.newOption)
         this.newOption = { value: undefined, text: undefined, new: true }
+      }
+    },
+
+    onUpdateIsUniqueMultiValue () {
+      if (this.f.options.selectType === 'multiple') {
+        this.f.options.isUniqueMultiValue = true
       }
     },
   },

--- a/client/web/compose/src/components/ModuleFields/Configurator/User.vue
+++ b/client/web/compose/src/components/ModuleFields/Configurator/User.vue
@@ -35,7 +35,17 @@
         v-model="f.options.selectType"
         :options="selectOptions"
         stacked
+        @change="onUpdateIsUniqueMultiValue"
       />
+      <b-form-checkbox
+        v-if="f.options.selectType !== 'multiple'"
+        v-model="f.options.isUniqueMultiValue"
+        :value="false"
+        :unchecked-value="true"
+        class="mt-2"
+      >
+        {{ $t('kind.select.allow-duplicates') }}
+      </b-form-checkbox>
     </b-form-group>
   </div>
 </template>
@@ -75,6 +85,12 @@ export default {
   methods: {
     getOptionKey ({ roleID }) {
       return roleID
+    },
+
+    onUpdateIsUniqueMultiValue () {
+      if (this.f.options.selectType === 'multiple') {
+        this.f.options.isUniqueMultiValue = true
+      }
     },
   },
 }

--- a/client/web/compose/src/components/ModuleFields/Editor/Record.vue
+++ b/client/web/compose/src/components/ModuleFields/Editor/Record.vue
@@ -308,7 +308,7 @@ export default {
       if (value !== crtValue) {
         if (value) {
           if (index !== undefined) {
-            this.value[index] = value
+            this.value.splice(index, 1, value)
           } else {
             this.value = value
           }
@@ -330,7 +330,9 @@ export default {
       return {
         value: r.recordID,
         label: this.processing ? '' : this.recordValues[r.recordID] || r.recordID,
-        selectable: this.field.isMulti ? !(this.value || []).includes(r.recordID) : this.value !== r.recordID,
+        selectable: this.field.isMulti && !this.field.options.isUniqueMultiValue
+          ? this.value !== r.recordID
+          : !(this.value || []).includes(r.recordID),
       }
     },
 
@@ -493,10 +495,6 @@ export default {
           this.$refs.singleSelect._data._value = undefined
         }
       }
-    },
-
-    onOpen () {
-      // this.loadLatest()
     },
 
     goToPage (next = true) {

--- a/client/web/compose/src/components/ModuleFields/Editor/Select.vue
+++ b/client/web/compose/src/components/ModuleFields/Editor/Select.vue
@@ -109,7 +109,9 @@ export default {
   computed: {
     selectOptions () {
       return this.field.options.options.map(o => {
-        const disabled = o.value && this.field.isMulti ? (this.value || []).includes(o.value) : this.value === o.value
+        const disabled = o.value && this.field.isMulti && !this.field.options.isUniqueMultiValue
+          ? this.value === o.value
+          : (this.value || []).includes(o.value)
         return { ...o, disabled }
       }).filter(({ value = '' }) => value)
     },

--- a/client/web/compose/src/components/ModuleFields/Editor/User.vue
+++ b/client/web/compose/src/components/ModuleFields/Editor/User.vue
@@ -194,7 +194,12 @@ export default {
 
     options () {
       return this.users.map(u => {
-        return { ...u, selectable: this.field.isMulti ? !(this.value || []).includes(u.userID) : this.value !== u.userID }
+        return {
+          ...u,
+          selectable: this.field.isMulti && !this.field.options.isUniqueMultiValue
+            ? this.value !== u.userID
+            : !(this.value || []).includes(u.userID),
+        }
       })
     },
 

--- a/lib/js/src/compose/types/module-field/record.ts
+++ b/lib/js/src/compose/types/module-field/record.ts
@@ -12,6 +12,7 @@ interface RecordOptions extends Options {
   queryFields: Array<string>;
   selectType: string;
   multiDelimiter: string;
+  isUniqueMultiValue: boolean;
   prefilter?: string;
 }
 
@@ -23,6 +24,7 @@ const defaults = (): Readonly<RecordOptions> => Object.freeze({
   queryFields: [],
   selectType: '',
   multiDelimiter: '\n',
+  isUniqueMultiValue: false,
   prefilter: undefined,
 })
 
@@ -42,6 +44,7 @@ export class ModuleFieldRecord extends ModuleField {
 
     Apply(this.options, o, CortezaID, 'moduleID')
     Apply(this.options, o, String, 'labelField', 'recordLabelField', 'selectType', 'multiDelimiter', 'prefilter')
+    Apply(this.options, o, Boolean, 'isUniqueMultiValue')
     Apply(this.options, o, (o) => {
       if (!o) {
         return []

--- a/lib/js/src/compose/types/module-field/select.ts
+++ b/lib/js/src/compose/types/module-field/select.ts
@@ -10,6 +10,7 @@ interface SelectOptions extends Options {
   options: Array<string | { value: string; text?: string }>;
   selectType: string;
   multiDelimiter: string;
+  isUniqueMultiValue: boolean;
 }
 
 const defaults = (): Readonly<SelectOptions> => Object.freeze({
@@ -17,6 +18,7 @@ const defaults = (): Readonly<SelectOptions> => Object.freeze({
   options: [],
   selectType: 'default',
   multiDelimiter: '\n',
+  isUniqueMultiValue: false,
 })
 
 export class ModuleFieldSelect extends ModuleField {
@@ -34,6 +36,7 @@ export class ModuleFieldSelect extends ModuleField {
     super.applyOptions(o)
 
     Apply(this.options, o, String, 'selectType', 'multiDelimiter')
+    Apply(this.options, o, Boolean, 'isUniqueMultiValue')
 
     if (o.options) {
       let opt: Array<{ value: string; text: string }> = []

--- a/lib/js/src/compose/types/module-field/user.ts
+++ b/lib/js/src/compose/types/module-field/user.ts
@@ -11,6 +11,7 @@ interface UserOptions extends Options {
   presetWithAuthenticated: boolean;
   selectType: string;
   multiDelimiter: string;
+  isUniqueMultiValue: boolean;
 }
 
 const defaults = (): Readonly<UserOptions> => Object.freeze({
@@ -19,6 +20,7 @@ const defaults = (): Readonly<UserOptions> => Object.freeze({
   presetWithAuthenticated: false,
   selectType: 'default',
   multiDelimiter: '\n',
+  isUniqueMultiValue: false,
 })
 
 export class ModuleFieldUser extends ModuleField {
@@ -35,7 +37,7 @@ export class ModuleFieldUser extends ModuleField {
     if (!o) return
     super.applyOptions(o)
 
-    Apply(this.options, o, Boolean, 'presetWithAuthenticated')
+    Apply(this.options, o, Boolean, 'presetWithAuthenticated', 'isUniqueMultiValue')
     Apply(this.options, o, String, 'selectType', 'multiDelimiter')
     Apply(this.options, o, (o) => {
       if (!o) {

--- a/locale/en/corteza-webapp-compose/field.yaml
+++ b/locale/en/corteza-webapp-compose/field.yaml
@@ -107,6 +107,7 @@ kind:
     prefilterLabel: Prefilter records
     prefilterPlaceholder: field1 = 1 AND field2 = 232
   select:
+    allow-duplicates: Allow duplicates
     label: Select
     optionAdd: Add
     optionLabelPlaceholder: Label


### PR DESCRIPTION
…fields

# The following changes are implemented
Added option to allow duplicate values for single and each multi value fields

# Changes in the user interface:
The option is added to user, record  and select fields. The option is present only for default and each multi value types
<img width="796" alt="Screenshot 2023-04-13 at 17 56 35" src="https://user-images.githubusercontent.com/85161724/231800376-6d8c1ad5-854e-4c0f-8d1f-021f996871c4.png">


# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
