### PR TITLE
Fix sorting for admin automation sessions list

### DIFF
--- a/client/web/admin/src/themes/corteza-base/custom.scss
+++ b/client/web/admin/src/themes/corteza-base/custom.scss
@@ -59,7 +59,12 @@ th {
 
 // custom height for resource lists with buttons
 .custom-resource-list-height {
-  height: calc(100vh - 115px);
+  height: calc(100vh - 120px);
+}
+
+// custom height for resource lists without buttons
+.custom-resource-list-height-no-buttons {
+  height: calc(100vh - 105px);
 }
 
 // to remove the gap on top of the sticky header table

--- a/client/web/admin/src/views/Automation/Scripts/Index.vue
+++ b/client/web/admin/src/views/Automation/Scripts/Index.vue
@@ -1,5 +1,6 @@
 <template>
   <b-container
+    fluid="xl"
     class="d-flex flex-column h-100 py-3"
   >
     <c-content-header

--- a/client/web/admin/src/views/Automation/Session/List.vue
+++ b/client/web/admin/src/views/Automation/Session/List.vue
@@ -1,6 +1,7 @@
 <template>
   <b-container
     fluid="xl"
+    class="d-flex flex-column h-100 py-3"
   >
     <c-content-header
       :title="$t('title')"
@@ -25,17 +26,45 @@
       }"
       sticky-header
       hide-search
-      class="custom-resource-height"
+      hide-total
+      class="custom-resource-list-height-no-buttons"
     >
       <template #header>
-        <c-resource-list-status-filter
-          v-model="filter.completed"
-          :label="$t('filterForm.inProgress.label')"
-          :excluded-label="$t('filterForm.excluded.label')"
-          :inclusive-label="$t('filterForm.inclusive.label')"
-          :exclusive-label="$t('filterForm.exclusive.label')"
-          @change="filterList"
-        />
+        <b-row>
+          <b-col
+            cols="12"
+            sm="5"
+          >
+            <b-form-group
+              :label="$t('columns.sessionID')"
+              label-class="text-primary"
+              class="mb-2"
+            >
+              <c-input-search
+                :value="filter.sessionID"
+                size="sm"
+                @input="filterBySessionID"
+              />
+            </b-form-group>
+          </b-col>
+
+          <b-col
+            cols="12"
+            sm="5"
+          >
+            <b-form-group
+              :label="$t('columns.workflowID')"
+              label-class="text-primary"
+            >
+              <c-input-search
+                :value="filter.workflowID"
+                size="sm"
+                @input="filterByWorkflowID"
+              />
+            </b-form-group>
+          </b-col>
+        </b-row>
+
         <b-form-radio-group
           v-model="filter.status"
           :options="statusOptions"
@@ -47,6 +76,24 @@
         <span class="ml-2 text-nowrap">
           {{ $t('filterForm.sessions.label') }}
         </span>
+      </template>
+
+      <template #sessionID="{ item }">
+        <a
+          href="javascript:;"
+          @click="filterBySessionID(item.sessionID)"
+        >
+          {{ item.sessionID }}
+        </a>
+      </template>
+
+      <template #workflowID="{ item }">
+        <a
+          href="javascript:;"
+          @click="filterByWorkflowID(item.workflowID)"
+        >
+          {{ item.workflowID }}
+        </a>
       </template>
 
       <template #actions="{ item }">
@@ -67,11 +114,12 @@
 <script>
 import listHelpers from 'corteza-webapp-admin/src/mixins/listHelpers'
 import { components } from '@cortezaproject/corteza-vue'
-const { CResourceList } = components
+const { CResourceList, CInputSearch } = components
 
 export default {
   components: {
     CResourceList,
+    CInputSearch,
   },
 
   mixins: [
@@ -91,7 +139,10 @@ export default {
       editRoute: 'automation.session.edit',
 
       filter: {
-        status: undefined,
+        // Use null not undefined!
+        sessionID: null,
+        workflowID: null,
+        status: null,
         completed: 1,
       },
 
@@ -109,7 +160,6 @@ export default {
         },
         {
           key: 'status',
-          sortable: true,
         },
         {
           key: 'eventType',
@@ -135,7 +185,7 @@ export default {
   computed: {
     statusOptions () {
       return [
-        { value: undefined, text: this.$t('filterForm.all.label') },
+        { value: null, text: this.$t('filterForm.all.label') },
         { value: 0, text: this.$t('filterForm.started.label') },
         { value: 1, text: this.$t('filterForm.prompted.label') },
         { value: 2, text: this.$t('filterForm.suspended.label') },
@@ -152,6 +202,16 @@ export default {
 
     rowClass (item) {
       return { 'text-primary': item && !!item.completedAt }
+    },
+
+    filterBySessionID (sessionID) {
+      this.filter.sessionID = sessionID || null
+      this.filterList()
+    },
+
+    filterByWorkflowID (workflowID) {
+      this.filter.workflowID = workflowID || null
+      this.filterList()
     },
   },
 }

--- a/client/web/admin/src/views/Automation/Session/List.vue
+++ b/client/web/admin/src/views/Automation/Session/List.vue
@@ -93,7 +93,6 @@ export default {
       filter: {
         status: undefined,
         completed: 1,
-        sort: 'createdAt DESC',
       },
 
       sorting: {

--- a/client/web/admin/src/views/System/Actionlog/Index.vue
+++ b/client/web/admin/src/views/System/Actionlog/Index.vue
@@ -1,6 +1,7 @@
 <template>
   <b-container
-    class="py-3"
+    fluid="xl"
+    class="d-flex flex-column h-100 py-3"
   >
     <c-content-header
       :title="$t('title')"

--- a/lib/vue/src/components/input/CInputSearch.vue
+++ b/lib/vue/src/components/input/CInputSearch.vue
@@ -1,5 +1,7 @@
 <template>
-  <b-input-group>
+  <b-input-group
+    :size="size"
+  >
     <b-input
       ref="searchInput"
       data-test-id="input-search"
@@ -10,7 +12,6 @@
       :disabled="disabled"
       :placeholder="placeholder"
       :autocomplete="autocomplete"
-      :size="size"
       class="h-100 pr-0 border-light border-right-0 text-truncate bg-white"
       @update="search"
       @keyup.enter="submitQuery"
@@ -23,6 +24,7 @@
         v-if="showSubmittable"
         variant="link"
         :disabled="disabled"
+        class="py-0"
         :class="{
           'search-icon-border': showSubmittableAndClearable,
           'cursor-default': !isSubmittable

--- a/lib/vue/src/components/resourceList/CResourceList.vue
+++ b/lib/vue/src/components/resourceList/CResourceList.vue
@@ -122,7 +122,10 @@
       </b-table>
     </b-card-body>
 
-    <template #footer>
+    <template
+      v-if="showFooter"
+      #footer
+    >
       <div
         class="d-flex align-items-center justify-content-between"
       >
@@ -138,7 +141,7 @@
         </div>
 
         <b-button-group
-          v-if="showPagination"
+          v-if="!hidePagination"
         >
           <b-button
             :disabled="!hasPrevPage"
@@ -328,8 +331,8 @@ export default {
       return !!this.pagination.nextPage
     },
 
-    showPagination () {
-      return !this.hidePagination && (this.hasPrevPage || this.hasNextPage)
+    showFooter () {
+      return !(this.hideTotal && this.hidePagination)
     }
   },
 

--- a/server/automation/rest/session.go
+++ b/server/automation/rest/session.go
@@ -67,6 +67,14 @@ func (ctrl Session) List(ctx context.Context, r *request.SessionList) (interface
 		return nil, err
 	}
 
+	// fixes issue with sorting of status column and pagination
+	// need to improve on cursor for this
+	if f.Paging.PageCursor != nil {
+		for _, status := range r.Status {
+			f.Paging.PageCursor.Set("status", status, false)
+		}
+	}
+
 	f.IncTotal = r.IncTotal
 
 	if f.Sorting, err = filter.NewSorting(r.Sort); err != nil {

--- a/server/pkg/filter/pagination.go
+++ b/server/pkg/filter/pagination.go
@@ -252,7 +252,7 @@ func (p *PagingCursor) UnmarshalJSON(in []byte) error {
 		}
 	}
 
-	if err := json.Unmarshal(in, &aux); err != nil {
+	if err = json.Unmarshal(in, &aux); err != nil {
 		return err
 	}
 
@@ -287,10 +287,10 @@ func (p *PagingCursor) Decode(cursor string) error {
 }
 
 // Sort returns:
-//  - sort if cursor is nil
-//  - sort from cursor when sort is empty
-//  - sort from cursor when sort is compatible with cursor
-//  - error if sort & cursor are incompatible
+//   - sort if cursor is nil
+//   - sort from cursor when sort is empty
+//   - sort from cursor when sort is compatible with cursor
+//   - error if sort & cursor are incompatible
 func (p *PagingCursor) Sort(sort SortExprSet) (SortExprSet, error) {
 	if p == nil {
 		return sort, nil


### PR DESCRIPTION
# The following changes are implemented
Problem: When we have string func for the columns and we encode pagingCursor according but while decoding it(pagingCursor), It takes string value of column instead of struct(interface value) which fails the query. IE. Here status column and It's underlying values are started (0), prompted (1), suspended (2), failed (3) and completed (4) and while sorting this column and going to the next page it will fail due to pageCursor decode column value as string but It should decode interface value.

For now updated PR with solution, Updationg paginag cursor if there is status in filter.

# Changes in the user interface:
TODO: Add screenshots, recordings or remove this section

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [x] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
