### PR TITLE
Fix hash and query URL trimming on URL input field

### DIFF
--- a/client/web/compose/src/components/ModuleFields/Configurator/Url.vue
+++ b/client/web/compose/src/components/ModuleFields/Configurator/Url.vue
@@ -1,17 +1,17 @@
 <template>
   <div>
     <div>
-      <b-form-checkbox v-model="f.options.trimFragment">
+      <b-form-checkbox v-model="f.options.trimPath">
         {{ $t('kind.url.label') }}
       </b-form-checkbox>
     </div>
     <div>
-      <b-form-checkbox v-model="f.options.trimQuery">
+      <b-form-checkbox v-model="f.options.trimFragment">
         {{ $t('kind.url.trimHash') }}
       </b-form-checkbox>
     </div>
     <div>
-      <b-form-checkbox v-model="f.options.trimPath">
+      <b-form-checkbox v-model="f.options.trimQuery">
         {{ $t('kind.url.trimQuestionMark') }}
       </b-form-checkbox>
     </div>


### PR DESCRIPTION
Ref: https://github.com/cortezaproject/corteza/issues/1062

This PR resolves several issues with the URL input field:

1. Fixed an issue where the `Trim '?' from the Url` field configuration feature was trimming the input string before the question mark instead of after `?`.

   **For example** 
      input: _https://www.planetcrust.com/why-using-a-low-code-crm-is-a-game-changer-for-nonprofit-organizations?utm_campaign=blog_ 
      output: _https://www.planetcrust.com/?utm_campaign=blog_
      expected:  _https://www.planetcrust.com/why-using-a-low-code-crm-is-a-game-changer-for-nonprofit-organizations_
      
2. Resolved an issue where the `Trim '#' from the Url` feature was not trimming the input string when it contained a `#`.

      **For example** 
      input: _https://stackoverflow.com/questions/75831150/nested-array-or-objects#answer-75831216_ 
      output: _https://stackoverflow.com/questions/75831150/nested-array-or-objects#answer-75831216_
      expected:  _https://stackoverflow.com/questions/75831150/nested-array-or-objects_
      
3. Corrected a bug where enabling both `Trim '?' from the Url` and `Trim '#' from the Url` from the Url field configuration was only trimming the string before the #, but not the `?`

      **For example** 
      input: _https://stackoverflow.com/questions/75831150/nested-array-or-objects#answer-75831216_ 
      output: _https://stackoverflow.com/questions/75831150/#answer-75831216_
      expected:  _https://stackoverflow.com/questions/75831150/nested-array-or-objects_

These fixes ensure that the URL input field trims the desired characters as configured by the user.