### PR TITLE
Add https to-all urls input values across corteza

### DIFF
--- a/client/web/compose/src/components/PageBlocks/IFrameBase.vue
+++ b/client/web/compose/src/components/PageBlocks/IFrameBase.vue
@@ -8,7 +8,7 @@
       v-if="src"
       ref="iframe"
       class="h-100 w-100 border-0"
-      :src="src"
+      :src="src | checkValidURL"
     />
   </wrap>
 </template>

--- a/client/web/compose/src/components/PageBlocks/Navigation/Base.vue
+++ b/client/web/compose/src/components/PageBlocks/Navigation/Base.vue
@@ -59,7 +59,7 @@
                 >
                   <a
                     class="dropdown-item"
-                    :href="dropdown.url"
+                    :href="dropdown.url | checkValidURL"
                     :disabled="navItem.options.disabled"
                     :target="selectTargetOption(dropdown.target)"
                     :style="{ order: dIndex * 2 }"
@@ -165,7 +165,7 @@ export default {
         return
       }
 
-      return navItem.type === 'url' ? navItem.options.item.url : ''
+      return navItem.type === 'url' ? this.$options.filters.checkValidURL(navItem.options.item.url) : ''
     },
   },
 }

--- a/client/web/compose/src/components/PageBlocks/SocialFeedBase.vue
+++ b/client/web/compose/src/components/PageBlocks/SocialFeedBase.vue
@@ -88,7 +88,8 @@ export default {
       }
 
       // is this a twitter url?
-      if (url && url.indexOf('twitter.com')) {
+      if (url && url.indexOf('twitter.com') > -1) {
+        url = this.$options.filters.checkValidURL(url)
         twitterHandle = this.getTwitterHandle(url)
         if (twitterHandle === '') {
           // failed to get twitter handle from the url

--- a/lib/js/src/compose/types/page-block/navigation/navigation-item.ts
+++ b/lib/js/src/compose/types/page-block/navigation/navigation-item.ts
@@ -1,4 +1,5 @@
 import { Apply } from '../../../../cast'
+import { PageBlock } from '../base';
 
 interface DropdownItem {
   label: string;

--- a/lib/vue/src/components/navigation/CTopbar.vue
+++ b/lib/vue/src/components/navigation/CTopbar.vue
@@ -63,7 +63,7 @@
         <b-dropdown-item
           v-for="(helpLink, index) in helpLinks"
           :key="index"
-          :href="helpLink.url"
+          :href="helpLink.url | checkValidURL"
           :target="helpLink.newTab ? '_blank' : ''"
         >
           {{ helpLink.handle }}
@@ -150,7 +150,7 @@
         <b-dropdown-item
           v-for="(profileLink, index) in profileLinks"
           :key="index"
-          :href="profileLink.url"
+          :href="profileLink.url | checkValidURL"
           :target="profileLink.newTab ? '_blank' : ''"
         >
           {{ profileLink.handle }}

--- a/lib/vue/src/filters/index.ts
+++ b/lib/vue/src/filters/index.ts
@@ -1,1 +1,2 @@
 export * from './date'
+export * from './url'

--- a/lib/vue/src/filters/url.ts
+++ b/lib/vue/src/filters/url.ts
@@ -1,0 +1,7 @@
+export function checkValidURL (url: string): string {
+  if (url.indexOf('://') > 0) { // do not modify the link if it has sth before "://"", e.g. ftp, http, etc.
+    return url
+  } else {
+    return 'http://' + url
+  }
+}


### PR DESCRIPTION
Url inputs have been prefixed with "https" to the following places:

- Compose: twitter feed block
- Compose: iframe page block
- Compose: navigation page block
- Admin: admin user inteface settings
