### PR TITLE
Fix multiline comments displaying as inline comments under privacy re…

### DIFF
--- a/client/web/privacy/src/components/Requests/Comments.vue
+++ b/client/web/privacy/src/components/Requests/Comments.vue
@@ -82,7 +82,11 @@
         <div
           class="border p-3"
         >
-          {{ c.comment }}
+          <p
+            class="mb-0 multiline"
+          >
+            {{ c.comment }}
+          </p>
         </div>
       </div>
     </template>
@@ -171,5 +175,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
+.multiline {
+  white-space: pre-line;
+}
 </style>


### PR DESCRIPTION
…quests

# The following changes are implemented
Multiline comments under requests are supported

# Changes in the user interface:
Visually it looks the same

<img width="912" alt="Screenshot 2023-05-18 at 18 28 56" src="https://github.com/cortezaproject/corteza/assets/85161724/64ee5623-a441-40ea-be7d-e5bdc3e9b068">

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
