### PR TITLE
Fix compose public attachment access

### DIFF
--- a/server/compose/rest/attachment.go
+++ b/server/compose/rest/attachment.go
@@ -77,7 +77,7 @@ func (ctrl Attachment) Delete(ctx context.Context, r *request.AttachmentDelete) 
 }
 
 func (ctrl Attachment) Original(ctx context.Context, r *request.AttachmentOriginal) (interface{}, error) {
-	if err := ctrl.isAccessible(r.NamespaceID, r.AttachmentID, r.UserID, r.Sign); err != nil {
+	if err := ctrl.isAccessible(r.Kind, r.NamespaceID, r.AttachmentID, r.UserID, r.Sign); err != nil {
 		return nil, err
 	}
 
@@ -85,14 +85,19 @@ func (ctrl Attachment) Original(ctx context.Context, r *request.AttachmentOrigin
 }
 
 func (ctrl Attachment) Preview(ctx context.Context, r *request.AttachmentPreview) (interface{}, error) {
-	if err := ctrl.isAccessible(r.NamespaceID, r.AttachmentID, r.UserID, r.Sign); err != nil {
+	if err := ctrl.isAccessible(r.Kind, r.NamespaceID, r.AttachmentID, r.UserID, r.Sign); err != nil {
 		return nil, err
 	}
 
 	return ctrl.serve(ctx, r.NamespaceID, r.AttachmentID, true, false)
 }
 
-func (ctrl Attachment) isAccessible(namespaceID, attachmentID, userID uint64, signature string) error {
+func (ctrl Attachment) isAccessible(kind string, namespaceID, attachmentID, userID uint64, signature string) error {
+	if kind == types.PageAttachment || kind == types.IconAttachment || kind == types.NamespaceAttachment {
+		// Public Attachments
+		return nil
+	}
+
 	if signature == "" {
 		return errors.Unauthorized("missing signature")
 	}


### PR DESCRIPTION
By adding exception to Page, Namespace, and Icon attachment while serving it(Original, Preview)

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [x] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
