### PR TITLE
Fix max-height issue for ItemPicker in safari

### DIFF
--- a/client/web/compose/src/components/Admin/Module/DiscoverySettings.vue
+++ b/client/web/compose/src/components/Admin/Module/DiscoverySettings.vue
@@ -27,7 +27,7 @@
           :module="module"
           :fields.sync="currentFields"
           disable-system-fields
-          style="max-height: 70vh;"
+          style="height: 70vh;"
         />
       </b-tab>
     </b-tabs>

--- a/client/web/compose/src/components/Admin/Module/Records/ColumnPicker.vue
+++ b/client/web/compose/src/components/Admin/Module/Records/ColumnPicker.vue
@@ -23,7 +23,7 @@
         <field-picker
           :module="module"
           :fields.sync="filteredFields"
-          style="max-height: 71vh;"
+          style="height: 71vh;"
         />
       </b-card-body>
     </b-modal>

--- a/client/web/compose/src/components/Admin/Module/Validation.vue
+++ b/client/web/compose/src/components/Admin/Module/Validation.vue
@@ -15,7 +15,7 @@
         :fields.sync="strictFields"
         :field-subset="module.fields"
         disable-system-fields
-        style="max-height: 35vh;"
+        style="height: 35vh;"
         class="mt-3"
       />
     </b-form-group>
@@ -33,7 +33,7 @@
         :fields.sync="nonStrictFields"
         :field-subset="module.fields"
         disable-system-fields
-        style="max-height: 35vh;"
+        style="height: 35vh;"
         class="mt-3"
       />
     </b-form-group>

--- a/client/web/compose/src/components/PageBlocks/RecordConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordConfigurator.vue
@@ -84,7 +84,7 @@
           <field-picker
             :module="fieldModule"
             :fields.sync="options.fields"
-            style="max-height: 52vh;"
+            style="height: 52vh;"
           />
         </b-col>
       </b-row>

--- a/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
@@ -71,7 +71,7 @@
             <field-picker
               :module="recordListModule"
               :fields.sync="options.fields"
-              style="max-height: 40vh;"
+              style="height: 40vh;"
             />
           </b-col>
         </b-row>
@@ -97,7 +97,7 @@
             :fields.sync="options.editFields"
             :field-subset="options.fields"
             disable-system-fields
-            style="max-height: 40vh;"
+            style="height: 40vh;"
           />
         </b-form-group>
 

--- a/client/web/compose/src/components/Public/Record/Exporter/Configurator.vue
+++ b/client/web/compose/src/components/Public/Record/Exporter/Configurator.vue
@@ -14,7 +14,7 @@
         :system-fields="systemFields"
         :disabled-types="disabledTypes"
         :fields.sync="selectedFields"
-        style="max-height: 45vh;"
+        style="height: 45vh;"
       />
     </b-form-group>
 


### PR DESCRIPTION
# The following changes are implemented
All cmps that use field picker cmp have max-height property changed to height

# Changes in the user interface:
UI is the same. All of the items of a list are visible when scrolling

# Checklist when submitting a final (!draft) PR
 - [ ] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [ ] PR is linked to the relevant issue(s)
 - [ ] Rebased with the target branch
