### PR TITLE
Add ability to select and perform operations on all records

### DIFF
--- a/client/web/compose/src/components/Public/Record/Exporter/Configurator.vue
+++ b/client/web/compose/src/components/Public/Record/Exporter/Configurator.vue
@@ -232,6 +232,11 @@ export default {
       required: false,
       default: () => [],
     },
+    selectedAllRecordsCount: {
+      type: Number,
+      required: false,
+      default: 0,
+    },
     filterRangeType: {
       type: String,
       default: 'all',
@@ -375,6 +380,10 @@ export default {
     getExportableCount () {
       // when exporting selection, only selected records are applicable
       if (this.rangeType === 'selection') {
+        if (this.selectedAllRecordsCount !== 0) {
+          return this.selectedAllRecordsCount
+        }
+
         return this.selection.length
       }
 

--- a/client/web/compose/src/mixins/record.js
+++ b/client/web/compose/src/mixins/record.js
@@ -281,8 +281,10 @@ export default {
 
       const { moduleID, namespaceID } = this.module
 
+      const query = records.map(r => `recordID='${r}'`).join(' OR ')
+
       return this
-        .$ComposeAPI.recordPatch({ moduleID, namespaceID, records, values })
+        .$ComposeAPI.recordPatch({ moduleID, namespaceID, values, query })
         .catch(err => {
           const { details = undefined } = err
           if (!!details && Array.isArray(details) && details.length > 0) {

--- a/lib/js/src/api-clients/compose.ts
+++ b/lib/js/src/api-clients/compose.ts
@@ -2185,8 +2185,8 @@ export default class Compose {
     const {
       namespaceID,
       moduleID,
-      records,
       values,
+      query,
     } = (a as KV) || {}
     if (!namespaceID) {
       throw Error('field namespaceID is empty')
@@ -2202,8 +2202,8 @@ export default class Compose {
       }),
     }
     cfg.data = {
-      records,
       values,
+      query,
     }
     return this.api().request(cfg).then(result => stdResolve(result))
   }
@@ -2221,8 +2221,8 @@ export default class Compose {
     const {
       namespaceID,
       moduleID,
-      recordIDs,
       truncate,
+      query,
     } = (a as KV) || {}
     if (!namespaceID) {
       throw Error('field namespaceID is empty')
@@ -2238,8 +2238,8 @@ export default class Compose {
       }),
     }
     cfg.data = {
-      recordIDs,
       truncate,
+      query,
     }
     return this.api().request(cfg).then(result => stdResolve(result))
   }
@@ -2329,7 +2329,7 @@ export default class Compose {
     const {
       namespaceID,
       moduleID,
-      recordIDs,
+      query,
     } = (a as KV) || {}
     if (!namespaceID) {
       throw Error('field namespaceID is empty')
@@ -2345,7 +2345,7 @@ export default class Compose {
       }),
     }
     cfg.data = {
-      recordIDs,
+      query,
     }
     return this.api().request(cfg).then(result => stdResolve(result))
   }

--- a/locale/en/corteza-webapp-compose/block.yaml
+++ b/locale/en/corteza-webapp-compose/block.yaml
@@ -484,6 +484,9 @@ recordList:
     label: Parent field
   selectable: Users will be able to select records
   selected: '{{count}} of {{total}} records selected'
+  selectedFromAllPages: 'All {{count}} records from all pages selected'
+  selectAllRecords: Select all records on all pages
+  unselectAllRecords: Clear selection
   sort:
     tooltip: Sort column
   showRecords:

--- a/server/compose/automation/records_handler.gen.go
+++ b/server/compose/automation/records_handler.gen.go
@@ -81,9 +81,10 @@ func (a recordsLookupArgs) GetRecord() (bool, uint64, *types.Record) {
 // Lookup function Compose record lookup
 //
 // expects implementation of lookup function:
-// func (h recordsHandler) lookup(ctx context.Context, args *recordsLookupArgs) (results *recordsLookupResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) lookup(ctx context.Context, args *recordsLookupArgs) (results *recordsLookupResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsLookup",
@@ -255,9 +256,10 @@ func (a recordsSearchArgs) GetNamespace() (bool, uint64, string, *types.Namespac
 // Search function Compose records search
 //
 // expects implementation of search function:
-// func (h recordsHandler) search(ctx context.Context, args *recordsSearchArgs) (results *recordsSearchResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) search(ctx context.Context, args *recordsSearchArgs) (results *recordsSearchResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Search() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsSearch",
@@ -508,9 +510,10 @@ func (a recordsFirstArgs) GetNamespace() (bool, uint64, string, *types.Namespace
 // First function Compose record lookup (first created)
 //
 // expects implementation of first function:
-// func (h recordsHandler) first(ctx context.Context, args *recordsFirstArgs) (results *recordsFirstResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) first(ctx context.Context, args *recordsFirstArgs) (results *recordsFirstResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) First() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsFirst",
@@ -637,9 +640,10 @@ func (a recordsLastArgs) GetNamespace() (bool, uint64, string, *types.Namespace)
 // Last function Compose record lookup (last created)
 //
 // expects implementation of last function:
-// func (h recordsHandler) last(ctx context.Context, args *recordsLastArgs) (results *recordsLastResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) last(ctx context.Context, args *recordsLastArgs) (results *recordsLastResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Last() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsLast",
@@ -792,9 +796,10 @@ func (a recordsEachArgs) GetNamespace() (bool, uint64, string, *types.Namespace)
 // Each function Compose records
 //
 // expects implementation of each function:
-// func (h recordsHandler) each(ctx context.Context, args *recordsEachArgs) (results *recordsEachResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) each(ctx context.Context, args *recordsEachArgs) (results *recordsEachResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Each() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsEach",
@@ -959,9 +964,10 @@ func (a recordsNewArgs) GetNamespace() (bool, uint64, string, *types.Namespace) 
 // New function Compose record maker
 //
 // expects implementation of new function:
-// func (h recordsHandler) new(ctx context.Context, args *recordsNewArgs) (results *recordsNewResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) new(ctx context.Context, args *recordsNewArgs) (results *recordsNewResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) New() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsNew",
@@ -1072,9 +1078,10 @@ type (
 // Validate function Compose record validator
 //
 // expects implementation of validate function:
-// func (h recordsHandler) validate(ctx context.Context, args *recordsValidateArgs) (results *recordsValidateResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) validate(ctx context.Context, args *recordsValidateArgs) (results *recordsValidateResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Validate() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsValidate",
@@ -1152,9 +1159,10 @@ type (
 // Create function Compose record create
 //
 // expects implementation of create function:
-// func (h recordsHandler) create(ctx context.Context, args *recordsCreateArgs) (results *recordsCreateResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) create(ctx context.Context, args *recordsCreateArgs) (results *recordsCreateResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Create() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsCreate",
@@ -1229,9 +1237,10 @@ type (
 // Update function Compose record update
 //
 // expects implementation of update function:
-// func (h recordsHandler) update(ctx context.Context, args *recordsUpdateArgs) (results *recordsUpdateResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) update(ctx context.Context, args *recordsUpdateArgs) (results *recordsUpdateResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Update() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsUpdate",
@@ -1328,9 +1337,10 @@ func (a recordsDeleteArgs) GetRecord() (bool, uint64, *types.Record) {
 // Delete function Compose record delete
 //
 // expects implementation of delete function:
-// func (h recordsHandler) delete(ctx context.Context, args *recordsDeleteArgs) (err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) delete(ctx context.Context, args *recordsDeleteArgs) (err error) {
+//	   return
+//	}
 func (h recordsHandler) Delete() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsDelete",
@@ -1454,9 +1464,10 @@ func (a recordsReportArgs) GetNamespace() (bool, uint64, string, *types.Namespac
 // Report function Report
 //
 // expects implementation of report function:
-// func (h recordsHandler) report(ctx context.Context, args *recordsReportArgs) (results *recordsReportResults, err error) {
-//    return
-// }
+//
+//	func (h recordsHandler) report(ctx context.Context, args *recordsReportArgs) (results *recordsReportResults, err error) {
+//	   return
+//	}
 func (h recordsHandler) Report() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeRecordsReport",

--- a/server/compose/rest.yaml
+++ b/server/compose/rest.yaml
@@ -1167,22 +1167,22 @@ endpoints:
     path: "/"
     parameters:
       post:
-      - { name: records, type: "[]string", title: Records to update }
       - { name: values, type: "types.RecordValueSet", title: Fields to update and their values }
+      - { name: query, type: "string", title: Search query for records to operate on }
   - name: bulkDelete
     method: DELETE
     title: Delete record row from module section
     path: "/"
     parameters:
       post:
-      - type: "[]string"
-        name: recordIDs
-        required: false
-        title: IDs of records to delete
       - type: bool
         name: truncate
         required: false
         title: Remove ALL records of a specified module (pending implementation)
+      - name: query
+        type: string
+        required: false
+        title: Search query for records to operate on
   - name: delete
     method: DELETE
     title: Delete record row from module section
@@ -1209,10 +1209,10 @@ endpoints:
     path: "/undelete"
     parameters:
       post:
-        - type: "[]string"
-          name: recordIDs
+        - name: query
+          type: string
           required: false
-          title: IDs of records to undelete
+          title: Search query for records to operate on
   - name: upload
     path: "/attachment"
     method: POST

--- a/server/compose/rest/request/record.go
+++ b/server/compose/rest/request/record.go
@@ -336,15 +336,15 @@ type (
 		// Module ID
 		ModuleID uint64 `json:",string"`
 
-		// Records POST parameter
-		//
-		// Records to update
-		Records []string
-
 		// Values POST parameter
 		//
 		// Fields to update and their values
 		Values types.RecordValueSet
+
+		// Query POST parameter
+		//
+		// Search query for records to operate on
+		Query string
 	}
 
 	RecordBulkDelete struct {
@@ -358,15 +358,15 @@ type (
 		// Module ID
 		ModuleID uint64 `json:",string"`
 
-		// RecordIDs POST parameter
-		//
-		// IDs of records to delete
-		RecordIDs []string
-
 		// Truncate POST parameter
 		//
 		// Remove ALL records of a specified module (pending implementation)
 		Truncate bool
+
+		// Query POST parameter
+		//
+		// Search query for records to operate on
+		Query string
 	}
 
 	RecordDelete struct {
@@ -414,10 +414,10 @@ type (
 		// Module ID
 		ModuleID uint64 `json:",string"`
 
-		// RecordIDs POST parameter
+		// Query POST parameter
 		//
-		// IDs of records to undelete
-		RecordIDs []string
+		// Search query for records to operate on
+		Query string
 	}
 
 	RecordUpload struct {
@@ -1653,8 +1653,8 @@ func (r RecordPatch) Auditable() map[string]interface{} {
 	return map[string]interface{}{
 		"namespaceID": r.NamespaceID,
 		"moduleID":    r.ModuleID,
-		"records":     r.Records,
 		"values":      r.Values,
+		"query":       r.Query,
 	}
 }
 
@@ -1669,13 +1669,13 @@ func (r RecordPatch) GetModuleID() uint64 {
 }
 
 // Auditable returns all auditable/loggable parameters
-func (r RecordPatch) GetRecords() []string {
-	return r.Records
+func (r RecordPatch) GetValues() types.RecordValueSet {
+	return r.Values
 }
 
 // Auditable returns all auditable/loggable parameters
-func (r RecordPatch) GetValues() types.RecordValueSet {
-	return r.Values
+func (r RecordPatch) GetQuery() string {
+	return r.Query
 }
 
 // Fill processes request and fills internal variables
@@ -1699,6 +1699,12 @@ func (r *RecordPatch) Fill(req *http.Request) (err error) {
 		} else if err == nil {
 			// Multipart params
 
+			if val, ok := req.MultipartForm.Value["query"]; ok && len(val) > 0 {
+				r.Query, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -1709,19 +1715,19 @@ func (r *RecordPatch) Fill(req *http.Request) (err error) {
 
 		// POST params
 
-		//if val, ok := req.Form["records[]"]; ok && len(val) > 0  {
-		//    r.Records, err = val, nil
-		//    if err != nil {
-		//        return err
-		//    }
-		//}
-
 		//if val, ok := req.Form["values[]"]; ok && len(val) > 0  {
 		//    r.Values, err = types.RecordValueSet(val), nil
 		//    if err != nil {
 		//        return err
 		//    }
 		//}
+
+		if val, ok := req.Form["query"]; ok && len(val) > 0 {
+			r.Query, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	{
@@ -1755,8 +1761,8 @@ func (r RecordBulkDelete) Auditable() map[string]interface{} {
 	return map[string]interface{}{
 		"namespaceID": r.NamespaceID,
 		"moduleID":    r.ModuleID,
-		"recordIDs":   r.RecordIDs,
 		"truncate":    r.Truncate,
+		"query":       r.Query,
 	}
 }
 
@@ -1771,13 +1777,13 @@ func (r RecordBulkDelete) GetModuleID() uint64 {
 }
 
 // Auditable returns all auditable/loggable parameters
-func (r RecordBulkDelete) GetRecordIDs() []string {
-	return r.RecordIDs
+func (r RecordBulkDelete) GetTruncate() bool {
+	return r.Truncate
 }
 
 // Auditable returns all auditable/loggable parameters
-func (r RecordBulkDelete) GetTruncate() bool {
-	return r.Truncate
+func (r RecordBulkDelete) GetQuery() string {
+	return r.Query
 }
 
 // Fill processes request and fills internal variables
@@ -1807,6 +1813,13 @@ func (r *RecordBulkDelete) Fill(req *http.Request) (err error) {
 					return err
 				}
 			}
+
+			if val, ok := req.MultipartForm.Value["query"]; ok && len(val) > 0 {
+				r.Query, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -1817,15 +1830,15 @@ func (r *RecordBulkDelete) Fill(req *http.Request) (err error) {
 
 		// POST params
 
-		//if val, ok := req.Form["recordIDs[]"]; ok && len(val) > 0  {
-		//    r.RecordIDs, err = val, nil
-		//    if err != nil {
-		//        return err
-		//    }
-		//}
-
 		if val, ok := req.Form["truncate"]; ok && len(val) > 0 {
 			r.Truncate, err = payload.ParseBool(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["query"]; ok && len(val) > 0 {
+			r.Query, err = val[0], nil
 			if err != nil {
 				return err
 			}
@@ -1981,7 +1994,7 @@ func (r RecordBulkUndelete) Auditable() map[string]interface{} {
 	return map[string]interface{}{
 		"namespaceID": r.NamespaceID,
 		"moduleID":    r.ModuleID,
-		"recordIDs":   r.RecordIDs,
+		"query":       r.Query,
 	}
 }
 
@@ -1996,8 +2009,8 @@ func (r RecordBulkUndelete) GetModuleID() uint64 {
 }
 
 // Auditable returns all auditable/loggable parameters
-func (r RecordBulkUndelete) GetRecordIDs() []string {
-	return r.RecordIDs
+func (r RecordBulkUndelete) GetQuery() string {
+	return r.Query
 }
 
 // Fill processes request and fills internal variables
@@ -2021,6 +2034,12 @@ func (r *RecordBulkUndelete) Fill(req *http.Request) (err error) {
 		} else if err == nil {
 			// Multipart params
 
+			if val, ok := req.MultipartForm.Value["query"]; ok && len(val) > 0 {
+				r.Query, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -2031,12 +2050,12 @@ func (r *RecordBulkUndelete) Fill(req *http.Request) (err error) {
 
 		// POST params
 
-		//if val, ok := req.Form["recordIDs[]"]; ok && len(val) > 0  {
-		//    r.RecordIDs, err = val, nil
-		//    if err != nil {
-		//        return err
-		//    }
-		//}
+		if val, ok := req.Form["query"]; ok && len(val) > 0 {
+			r.Query, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	{

--- a/server/compose/types/record.go
+++ b/server/compose/types/record.go
@@ -101,10 +101,11 @@ type (
 )
 
 const (
-	OperationTypeCreate OperationType = "create"
-	OperationTypeUpdate OperationType = "update"
-	OperationTypeDelete OperationType = "delete"
-	OperationTypePatch  OperationType = "patch"
+	OperationTypeCreate   OperationType = "create"
+	OperationTypeUpdate   OperationType = "update"
+	OperationTypeDelete   OperationType = "delete"
+	OperationTypePatch    OperationType = "patch"
+	OperationTypeUndelete OperationType = "undelete"
 )
 
 func (f RecordFilter) ToConstraintedFilter(c map[string][]any) filter.Filter {

--- a/server/pkg/slice/ints.go
+++ b/server/pkg/slice/ints.go
@@ -12,8 +12,8 @@ type (
 )
 
 func HasUint64(ss []uint64, s uint64) bool {
-	for i := range ss {
-		if ss[i] == s {
+	for _, value := range ss {
+		if value == s {
 			return true
 		}
 	}

--- a/server/pkg/slice/ints_test.go
+++ b/server/pkg/slice/ints_test.go
@@ -35,7 +35,8 @@ func TestHasUint64(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			assert.EqualValues(t, HasUint64(c.ss, c.s), c.o)
+			ok := HasUint64(c.ss, c.s)
+			assert.EqualValues(t, ok, c.o)
 		})
 	}
 }


### PR DESCRIPTION
Ref: https://github.com/cortezaproject/corteza/issues/1167

This PR introduces the capability to select all records and perform batch operations for editing, deleting, and undeleting records. It also includes the ability to exclude specific ones from the operation.

Key Features:

- Perform edit, delete, and undelete operations on all records in the recordlist
- Select all records and exclude specific ones from the operation
- Batch processing of records in groups of 500 for improved efficiency and performance

### Screenshots and videos

1. Select all records bulk edit sample video


https://github.com/cortezaproject/corteza/assets/32476094/5fd4164e-c1f7-4955-80d3-5b7cbf0965b0




2.  Automation video for prompting selected record ids from multiple pages




https://github.com/cortezaproject/corteza/assets/32476094/e1e1324d-6c0f-484f-84e6-4573e7c1f252


