### PR TITLE
Fix connection map not showing in privacy app on mobile

### DIFF
--- a/client/web/privacy/src/views/Privacy/Dashboard.vue
+++ b/client/web/privacy/src/views/Privacy/Dashboard.vue
@@ -58,6 +58,7 @@
 
       <connection-map
         :connections="connections"
+        style="min-height: 400px;"
         class="align-self-center justify-self-center flex-grow-1 rounded-lg shadow-lg"
       />
     </div>


### PR DESCRIPTION
# The following changes are implemented
Min height was added to privacy map container

# Changes in the user interface:
Min height was added to privacy map container

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
