### PR TITLE
Fixed From header on env SMTP vars

### DIFF
--- a/server/app/boot_levels.go
+++ b/server/app/boot_levels.go
@@ -973,6 +973,7 @@ func setupSmtpDialer(log *zap.Logger, servers ...types.SmtpServers) {
 		zap.String("host", s.Host),
 		zap.Int("port", s.Port),
 		zap.String("user", s.User),
+		zap.String("from", s.From),
 		logger.Mask("pass", s.Pass),
 		zap.Bool("tsl-insecure", s.TlsInsecure),
 		zap.String("tls-server-name", s.TlsServerName),

--- a/server/system/service/auth_notification.go
+++ b/server/system/service/auth_notification.go
@@ -76,17 +76,7 @@ func (svc authNotification) InviteEmail(ctx context.Context, emailAddress string
 }
 
 func (svc authNotification) newMail() *gomail.Message {
-	var (
-		m    = mail.New()
-		addr = svc.settings.Auth.Mail.FromAddress
-		name = svc.settings.Auth.Mail.FromName
-	)
-
-	if addr != "" {
-		m.SetAddressHeader("From", addr, name)
-	}
-
-	return m
+	return mail.New()
 }
 
 func (svc authNotification) send(ctx context.Context, name, sendTo string, payload map[string]interface{}) error {
@@ -117,8 +107,6 @@ func (svc authNotification) send(ctx context.Context, name, sendTo string, paylo
 	// Prepare payload
 	payload["Logo"] = htpl.URL(svc.settings.General.Mail.Logo)
 	payload["BaseURL"] = svc.opt.BaseURL
-	payload["SignatureName"] = svc.settings.Auth.Mail.FromName
-	payload["SignatureEmail"] = svc.settings.Auth.Mail.FromAddress
 	payload["EmailAddress"] = sendTo
 
 	// Render document


### PR DESCRIPTION
# The following changes are implemented
Fixes #1149 as the default provisioned value for an email is invalid on some smtp servers (providers).

Removed the email that is fetched from settings as the `.env` vars are not added to settings at that time, the default SMTP dialer does set the default `From` value to the correct one.

Omitted the email from template as it did not add any benefits to the user experience and would only complicate the solution.
