### PR TITLE
Redirect user to webapp one upon successful signup

### DIFF
--- a/locale/en/corteza-server/auth/oauth2-authorize-client.yaml
+++ b/locale/en/corteza-server/auth/oauth2-authorize-client.yaml
@@ -11,4 +11,4 @@ template:
   errors:
     invalid-user: Cannot continue with unauthorized email, visit <a data-test-id="link-redirect-to-profile" href="{{link}}">your profile</a> and resolve the issue.
 alerts:
-  denied: cannot authorize {{client}}, no permissions
+  denied: 'Failed to authorize {{client}}: insufficient permissions'

--- a/server/app/boot_auth.go
+++ b/server/app/boot_auth.go
@@ -39,6 +39,10 @@ func (app *CortezaApp) initAuth(ctx context.Context) (err error) {
 	// set base path for links&routes in auth server
 	authHandlers.BasePath = app.Opt.HTTPServer.BaseUrl
 
+	// set webapp base path in auth server
+	// @todo refactor, consider passing this into the functions that need it instead of setting it globally
+	authHandlers.WebappBasePath = app.Opt.HTTPServer.WebappBaseUrl
+
 	auth.DefaultSigner = auth.HmacSigner(app.Opt.Auth.Secret)
 
 	if auth.HttpTokenVerifier, err = auth.TokenVerifierMiddlewareWithSecretSigner(app.Opt.Auth.Secret); err != nil {

--- a/server/auth/assets/templates/inc_nav.html.tpl
+++ b/server/auth/assets/templates/inc_nav.html.tpl
@@ -12,18 +12,7 @@
 {{ $activeNav := default "" .activeNav }}
 
 {{ if not .hideNav }}
-	{{ if and .user .client }}
-	<div class="py-1 px-3">
-		<a
-			data-test-id="link-finalize-authorization"
-			class="text-danger"
-			href="{{ links.OAuth2AuthorizeClient }}"
-		>
-		 {{ tr "inc_nav.template.authorize-client" }} {{ .client.Name }}
-		 <i class="bi bi-chevron-double-right"></i>
-		 </a>
-	</div>
-	{{ else if .user }}
+	{{ if .user }}
 	<ul class="nav ml-1 d-flex justify-content-around">
 		<li class="nav-item {{ if eq $activeNav "profile" }}active{{ end  }}">
 			<a

--- a/server/auth/handlers/handle_signup.go
+++ b/server/auth/handlers/handle_signup.go
@@ -43,7 +43,17 @@ func (h *AuthHandlers) signupProc(req *request.AuthReq) error {
 				zap.String("email", newUser.Email),
 				logger.Uint64s("roles", newUser.Roles()),
 			)
-			req.RedirectTo = GetLinks().Profile
+
+			// redirect to the webapp base path
+			req.RedirectTo = WebappBasePath
+
+			// if the client is nil, redirect to the profile
+			// else check if the client is trusted
+			if req.Client == nil {
+				req.RedirectTo = GetLinks().Profile
+			} else if !req.Client.Trusted {
+				req.RedirectTo = GetLinks().OAuth2AuthorizeClient
+			}
 
 			req.AuthUser = request.NewAuthUser(h.Settings, newUser, false)
 
@@ -115,7 +125,12 @@ func (h *AuthHandlers) confirmEmail(req *request.AuthReq) (err error) {
 				Text: t("signup.alerts.email-confirmed-logged-in"),
 			})
 
-			req.RedirectTo = GetLinks().Profile
+			// redirect to the webapp base path
+			req.RedirectTo = WebappBasePath
+
+			if req.Client != nil && !req.Client.Trusted {
+				req.RedirectTo = GetLinks().OAuth2AuthorizeClient
+			}
 
 			req.AuthUser = request.NewAuthUser(h.Settings, user, false)
 

--- a/server/auth/handlers/links.go
+++ b/server/auth/handlers/links.go
@@ -58,6 +58,7 @@ var (
 	invalidLinkChars        = regexp.MustCompile(`[^-A-Za-z0-9+&@#/%?=~_|!:,.;\\(\\)]`)
 	stripSchema             = regexp.MustCompile(`(.*\/\/)`)
 	BasePath         string = "/"
+	WebappBasePath   string = "/"
 )
 
 func GetLinks() Links {


### PR DESCRIPTION
Ref: https://github.com/cortezaproject/corteza/issues/1213

This PR introduces a change that is meant to enhance the signup flow by introducing the following changes:
1. After successful signup or email confirmation, the user is automatically redirected to the webapp one.
2. In case the authorization client is not trusted, the user will be directed to the authorize-client page.
3. If auth client is nil, the user will be redirected to their own profile page.
