### PR TITLE
Remove handle field on signup

### DIFF
--- a/server/auth/assets/templates/signup.html.tpl
+++ b/server/auth/assets/templates/signup.html.tpl
@@ -22,7 +22,7 @@
 				{{ tr "signup.template.form.email.label" }}
             </label>
             <input
-								data-test-id="input-email"
+				data-test-id="input-email"
                 type="email"
                 class="form-control"
                 name="email"
@@ -59,20 +59,6 @@
 				value="{{ .form.name }}"
 				autocomplete="name"
 				aria-label="{{ tr "signup.template.form.name.label" }}">
-        </div>
-        <div class="mb-3">
-            <label>
-                {{ tr "signup.template.form.nickname.label" }}
-            </label>
-			<input
-				data-test-id="input-handle"
-				type="text"
-				class="form-control handle-mask"
-				name="handle"
-				placeholder="{{ tr "signup.template.form.nickname.placeholder" }}"
-				value="{{ .form.handle }}"
-				autocomplete="handle"
-				aria-label="{{ tr "signup.template.form.nickname.label" }}">
         </div>
 		<div>
 			<button

--- a/server/system/service/user_test.go
+++ b/server/system/service/user_test.go
@@ -2,8 +2,9 @@ package service
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	a "github.com/cortezaproject/corteza/server/pkg/auth"
 	"github.com/cortezaproject/corteza/server/pkg/eventbus"
@@ -13,6 +14,13 @@ import (
 	"github.com/cortezaproject/corteza/server/system/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+)
+
+type (
+	u struct {
+		store.Users
+		L func(ctx context.Context, handle string) (*types.User, error)
+	}
 )
 
 func TestUser_ProtectedSearch(t *testing.T) {
@@ -95,6 +103,84 @@ func TestUser_ProtectedSearch(t *testing.T) {
 	})
 }
 
+func Test_createUserHandle(t *testing.T) {
+	ctx := context.Background()
+
+	// Define test cases
+	tests := []struct {
+		name     string
+		user     *types.User
+		expected string
+		s        u
+	}{
+		{
+			name: "Test with valid name",
+			user: &types.User{
+				Name: "John Doe",
+			},
+			expected: "JohnDoe_1",
+			s: u{
+				L: func(ctx context.Context, handle string) (*types.User, error) {
+					return nil, store.ErrNotFound
+				},
+			},
+		},
+		{
+			name: "Test with valid name and username",
+			user: &types.User{
+				Name:     "John",
+				Username: "username_provided_here123",
+			},
+			expected: "John_username_provided_here123",
+			s: u{
+				L: func(ctx context.Context, handle string) (*types.User, error) {
+					if handle == "John1" {
+						return nil, store.ErrNotUnique
+					}
+					return nil, store.ErrNotFound
+				},
+			},
+		},
+		{
+			name: "Test with valid name and email",
+			user: &types.User{
+				Name:  "John John",
+				Email: "jj+test@example.ltd",
+			},
+			expected: "jjTest",
+			s: u{
+				L: func(ctx context.Context, handle string) (*types.User, error) {
+					return nil, store.ErrNotFound
+				},
+			},
+		},
+		{
+			name: "Test with valid name, not unique handle",
+			user: &types.User{
+				Name:  "John Gardener",
+				Email: "johng@example.ltd",
+			},
+			expected: "JohnGardener_1",
+			s: u{
+				L: func(ctx context.Context, handle string) (*types.User, error) {
+					if handle == "johng" {
+						return nil, store.ErrNotUnique
+					}
+					return nil, store.ErrNotFound
+				},
+			},
+		},
+	}
+
+	// Run test cases
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			createUserHandle(ctx, tc.s, tc.user)
+			assert.Equal(t, tc.expected, tc.user.Handle)
+		})
+	}
+}
+
 func Test_processAvatarInitials(t *testing.T) {
 	// Define test cases
 	tests := []struct {
@@ -174,4 +260,8 @@ func Test_processAvatarInitials(t *testing.T) {
 			assert.Equal(t, tc.expectedInitial, initial)
 		})
 	}
+}
+
+func (uu u) LookupUserByHandle(ctx context.Context, handle string) (*types.User, error) {
+	return uu.L(ctx, handle)
 }


### PR DESCRIPTION
# The following changes are implemented
Handle field removed from signup page, since the user experience was not optimal, especially on duplicated handle values.
The handles are uniquely auto generated.

Closes https://github.com/cortezaproject/corteza/issues/1369

# Changes in the user interface:
_Before_
![image](https://github.com/cortezaproject/corteza/assets/4668490/9207eb57-09a7-4804-9a4b-85fe3a2e4329)

_After_
Handle field is removed on the signup page.

![image](https://github.com/cortezaproject/corteza/assets/4668490/b86bcace-a62f-4b5b-8dbd-1877dfc93680)
