### PR TITLE
Added error wrapping for compose record wf functions

### DIFF
--- a/server/compose/automation/records_handler.go
+++ b/server/compose/automation/records_handler.go
@@ -2,7 +2,11 @@ package automation
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/cortezaproject/corteza/server/compose/types"
 	. "github.com/cortezaproject/corteza/server/pkg/expr"
@@ -272,13 +276,14 @@ func (h recordsHandler) new(ctx context.Context, args *recordsNewArgs) (*records
 
 func (h recordsHandler) create(ctx context.Context, args *recordsCreateArgs) (results *recordsCreateResults, err error) {
 	results = &recordsCreateResults{}
-	results.Record, _, err = h.rec.Create(ctx, args.Record)
+	results.Record, err = wrapRecordValueErrorSet(h.rec.Create(ctx, args.Record))
+
 	return
 }
 
 func (h recordsHandler) update(ctx context.Context, args *recordsUpdateArgs) (results *recordsUpdateResults, err error) {
 	results = &recordsUpdateResults{}
-	results.Record, _, err = h.rec.Update(ctx, args.Record)
+	results.Record, err = wrapRecordValueErrorSet(h.rec.Update(ctx, args.Record))
 	return
 }
 
@@ -397,4 +402,37 @@ func (i *recordSetIterator) Next(context.Context, *Vars) (out *Vars, err error) 
 
 	i.ptr++
 	return out, nil
+}
+
+func wrapRecordValueErrorSet(rr *types.Record, res *types.RecordValueErrorSet, ee error) (r *types.Record, err error) {
+	var (
+		ss string
+		j  []byte
+		e  error
+	)
+
+	r = rr
+	err = ee
+
+	if res = types.IsRecordValueErrorSet(err); res == nil {
+		return
+	}
+
+	if !res.Safe() {
+		return rr, err
+	}
+
+	for _, vv := range res.Set {
+		if j, e = json.Marshal(vv.Meta); e != nil {
+			continue
+		}
+
+		ss = fmt.Sprintf("%s, %s (%s)", ss, strings.ToLower(vv.Message), j)
+
+	}
+
+	re := regexp.MustCompile("^,\\s")
+	ss = re.ReplaceAllString(ss, "")
+
+	return rr, errors.New(ss)
 }


### PR DESCRIPTION
# The following changes are implemented
Workflow record `create` and `update` functions have been wrapped with extra meta data when the values are invalid. It improves upon workflow developing, since before it was impossible to get info on which values were invalid for a specific module when a record was created.

It uses the `Safe()` method which is a stub for future secure values support, for now it always displays data.

# Changes in the user interface:
Before
![image](https://github.com/cortezaproject/corteza/assets/4668490/0dd189dd-3292-49bf-98a6-6ca51a5951a3)

After
![image](https://github.com/cortezaproject/corteza/assets/4668490/0336c9d8-0a2f-4667-bb84-27aa3abf2c16)
