### PR TITLE
Fix #1486

### DIFF
--- a/server/system/commands/users.go
+++ b/server/system/commands/users.go
@@ -118,7 +118,7 @@ func Users(ctx context.Context, app serviceInitializer) *cobra.Command {
 
 			if !flagNoPassword && !flagMakePasswordLink && len(password) == 0 {
 				cmd.Print("Set password: ")
-				if password, err = terminal.ReadPassword(syscall.Stdin); err != nil {
+				if password, err = terminal.ReadPassword(int(syscall.Stdin)); err != nil {
 					cli.HandleError(err)
 				}
 			}
@@ -230,7 +230,7 @@ func Users(ctx context.Context, app serviceInitializer) *cobra.Command {
 			}
 
 			cmd.Print("Set password: ")
-			if password, err = terminal.ReadPassword(syscall.Stdin); err != nil {
+			if password, err = terminal.ReadPassword(int(syscall.Stdin)); err != nil {
 				cli.HandleError(err)
 			}
 


### PR DESCRIPTION
`terminal.ReadPassword` requires an int.
Passing a string will make the building process fail on Windows.
After changing the type, I ran `make watch` and it compiled successfully.

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
