### PR TITLE
fixing the year issue in TestStepAggregate

### DIFF
--- a/server/pkg/dal/exec_aggregate_test.go
+++ b/server/pkg/dal/exec_aggregate_test.go
@@ -3,6 +3,7 @@ package dal
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cortezaproject/corteza/server/pkg/filter"
 	"github.com/cortezaproject/corteza/server/pkg/ql"
@@ -632,7 +633,6 @@ func TestStepAggregate(t *testing.T) {
 			},
 			group: []simpleAttribute{{
 				ident: "d",
-				// @note will only run for a year then will need to be changed
 				expr: "year(now())",
 			}},
 			outAttributes: []simpleAttribute{{
@@ -647,7 +647,7 @@ func TestStepAggregate(t *testing.T) {
 			},
 
 			out: []simpleRow{
-				{"d": 2023, "users": float64(3)},
+				{"d": time.Now().Year(), "users": float64(3)},
 			},
 
 			f: internalFilter{


### PR DESCRIPTION
# The following changes are implemented
The TestStepAggregate function in exec_aggregate_test.go contained the current year hardcoded. Now, it's dynamic.

# Changes in the user interface:
N/A

# Checklist when submitting a final (!draft) PR
 - [X] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [X] Code builds
 - [X] All existing tests pass
 - [X] All new critical code is covered by tests
 - [ ] PR is linked to the relevant issue(s)
 - [X] Rebased with the target branch
