### PR TITLE
Fix unsaved changes alert from triggering when RTE is empty

### DIFF
--- a/lib/vue/src/components/input/CRichTextInput/index.vue
+++ b/lib/vue/src/components/input/CRichTextInput/index.vue
@@ -98,7 +98,9 @@ export default {
     init () {
       this.editor = new Editor({
         extensions: this.formats,
-        content: this.value,
+        // Bypass Editor default empty white space script with an empty space string if there is no value because it's not really valid html
+        // also ensuring that the unsaved changes alert detection is not triggered when the Editor does not have any changes
+        content: this.value || ' ',
         parseOptions: {
           preserveWhitespace: 'full',
         },


### PR DESCRIPTION
# The following changes are implemented
TODO: Summary

# Changes in the user interface:
TODO: Add screenshots, recordings or remove this section

# Checklist when submitting a final (!draft) PR
 - [ ] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [ ] PR is linked to the relevant issue(s)
 - [ ] Rebased with the target branch
