### PR TITLE
Add open in new tab on redirect WF prompts

### DIFF
--- a/client/web/admin/src/app.js
+++ b/client/web/admin/src/app.js
@@ -148,7 +148,7 @@ export default (options = {}) => {
               break
 
             case 'error':
-              console.error('websocket message with error', msg['@value'])
+              this.toastDanger('Websocket message with error', msg['@value'])
           }
         })
       },

--- a/client/web/compose/src/app.js
+++ b/client/web/compose/src/app.js
@@ -154,7 +154,7 @@ export default (options = {}) => {
               break
 
             case 'error':
-              console.error('websocket message with error', msg['@value'])
+              this.toastDanger('Websocket message with error', msg['@value'])
           }
         })
       },

--- a/client/web/one/src/app.js
+++ b/client/web/one/src/app.js
@@ -96,7 +96,7 @@ export default (options = {}) => {
               break
 
             case 'error':
-              console.error('websocket message with error', msg['@value'])
+              this.toastDanger('Websocket message with error', msg['@value'])
           }
         })
       },

--- a/client/web/workflow/src/components/Configurator/Function.vue
+++ b/client/web/workflow/src/components/Configurator/Function.vue
@@ -132,7 +132,7 @@
                     @input="$root.$emit('change-detected')"
                     @search="searchWorkflows"
                   />
-
+                  <!-- Clearable -->
                   <c-input-select
                     v-else-if="a.input.type === 'select'"
                     v-model="a.value"
@@ -142,6 +142,7 @@
                     :filter="varFilter"
                     :reduce="a => a.value"
                     :placeholder="$t('steps:function.configurator.option-select')"
+                    :clearable="false"
                     @input="$root.$emit('change-detected')"
                   />
 
@@ -520,7 +521,7 @@ export default {
             target: param.name,
             type: arg.type || this.paramTypes[func.ref][param.name][0],
             valueType: this.getValueType(arg, arg.type || this.paramTypes[func.ref][param.name][0], input),
-            value: arg.value || null,
+            value: arg.value || input.default || null,
             expr: arg.expr || arg.source || null,
             required: param.required || false,
             input,

--- a/lib/vue/src/components/prompts/definitions.ts
+++ b/lib/vue/src/components/prompts/definitions.ts
@@ -11,6 +11,11 @@ const variants = [
   { value: 'dark', text: 'Dark' },
 ]
 
+const openModeVariants = [
+  { value: 'newTab', text: 'Open link in a new tab' },
+  { value: 'sameTab', text: 'Open link in the same tab' },
+]
+
 export const prompts = Object.freeze([
   {
     ref: 'redirect',
@@ -19,6 +24,7 @@ export const prompts = Object.freeze([
       { name: 'owner', types: ['User', 'ID'], required: false },
       { name: 'url', types: ['String'], required: true },
       { name: 'delay', types: ['Integer'], meta: { description: 'Redirection delay in seconds' } },
+      { name: 'openMode', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: openModeVariants }, default: 'sameTab' } } } },
     ],
   },
   {
@@ -30,6 +36,7 @@ export const prompts = Object.freeze([
       { name: 'params', types: ['KV'] },
       { name: 'query', types: ['KV'] },
       { name: 'delay', types: ['Integer'], meta: { description: 'Redirection delay in seconds' } },
+      { name: 'openMode', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: openModeVariants }, default: 'sameTab' } } } },
     ],
   },
   {
@@ -45,6 +52,7 @@ export const prompts = Object.freeze([
       { name: 'record', types: ['ID', 'ComposeRecord'] },
       { name: 'edit', types: ['Boolean'] },
       { name: 'delay', types: ['Integer'], meta: { description: 'Redirection delay in seconds' } },
+      { name: 'openMode', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: [...openModeVariants, { value: 'modal', text: 'Open in a modal' }] }, default: 'sameTab' } } } },
     ],
   },
   {
@@ -58,7 +66,7 @@ export const prompts = Object.freeze([
       { name: 'owner', types: ['User', 'ID'], required: false },
       { name: 'title', types: ['String'] },
       { name: 'message', types: ['String'], required: true },
-      { name: 'variant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants } } } } },
+      { name: 'variant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants }, default: 'primary' } } } },
       { name: 'timeout', types: ['Integer'], meta: { description: 'How long do we show the notification in seconds' } },
     ],
   },
@@ -70,7 +78,7 @@ export const prompts = Object.freeze([
       { name: 'title', types: ['String'] },
       { name: 'message', types: ['String'], required: true },
       { name: 'buttonLabel', types: ['String'] },
-      { name: 'buttonVariant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants } } } } },
+      { name: 'buttonVariant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants }, default: 'primary' } } } },
       { name: 'buttonValue', types: ['Any'] },
     ],
   },
@@ -82,10 +90,10 @@ export const prompts = Object.freeze([
       { name: 'title', types: ['String'] },
       { name: 'message', types: ['String'], required: true },
       { name: 'confirmButtonLabel', types: ['String'] },
-      { name: 'confirmButtonVariant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants } } } } },
+      { name: 'confirmButtonVariant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants }, default: 'primary' } } } },
       { name: 'confirmButtonValue', types: ['Any'] },
       { name: 'rejectButtonLabel', types: ['String'] },
-      { name: 'rejectButtonVariant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants } } } } },
+      { name: 'rejectButtonVariant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants }, default: 'danger' } } } },
       { name: 'rejectButtonValue', types: ['Any'] },
     ],
     results: [
@@ -147,7 +155,7 @@ export const prompts = Object.freeze([
     parameters: [
       { name: 'owner', types: ['User', 'ID'], required: false },
       { name: 'title', types: ['String'] },
-      { name: 'variant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants } } } } },
+      { name: 'variant', types: ['String'], meta: { visual: { input: { type: 'select', properties: { options: variants }, default: 'primary' } } } },
       { name: 'message', types: ['String'], required: true },
       { name: 'label', types: ['String'] },
       {


### PR DESCRIPTION
Ref: https://github.com/cortezaproject/corteza/issues/1709

- [x] Add open in new tab and in modal redirects
- [x] Add prompt error notification.
- [x] Redirect in edit mode, If no recordID is provided in `recordPage` redirect.
- [x] Add default values on redirect and button variants