### PR TITLE
Add decimal places to number columns in MSSQL

### DIFF
--- a/server/store/adapters/rdbms/drivers/mssql/dialect.go
+++ b/server/store/adapters/rdbms/drivers/mssql/dialect.go
@@ -193,6 +193,8 @@ func (mssqlDialect) AttributeToColumn(attr *dal.Attribute) (col *ddl.Column, err
 
 	case *dal.TypeNumber:
 		col.Type.Name = "DECIMAL"
+		// @todo temporary fix to store numbers with decimal places
+		col.Type.Name += "(18,6)"
 		// @todo precision, scale?
 		col.Default = ddl.DefaultNumber(t.HasDefault, t.Precision, t.DefaultValue)
 


### PR DESCRIPTION
temporary fix to store numbers with decimal places in MSSQL - use DECIMAL(18,6) instead of DECIMAL

# The following changes are implemented
Use column type DECIMAL(18,6) instead of DECIMAL, which has no decimal places by default

Related to #1646