### PR TITLE
Fix the number of  Dart sass transpiler instances spun up

### DIFF
--- a/server/app/boot_levels.go
+++ b/server/app/boot_levels.go
@@ -1,54 +1,53 @@
 package app
 
 import (
-	"context"
-	"crypto/tls"
-	"fmt"
-	"github.com/cortezaproject/corteza/server/pkg/sass"
-	"net/url"
-	"os"
-	"regexp"
-	"strings"
-	"time"
+    "context"
+    "crypto/tls"
+    "fmt"
+    "net/url"
+    "os"
+    "regexp"
+    "strings"
+    "time"
 
-	authService "github.com/cortezaproject/corteza/server/auth"
-	"github.com/cortezaproject/corteza/server/auth/saml"
-	authSettings "github.com/cortezaproject/corteza/server/auth/settings"
-	autService "github.com/cortezaproject/corteza/server/automation/service"
-	cmpService "github.com/cortezaproject/corteza/server/compose/service"
-	cmpEvent "github.com/cortezaproject/corteza/server/compose/service/event"
-	discoveryService "github.com/cortezaproject/corteza/server/discovery/service"
-	fedService "github.com/cortezaproject/corteza/server/federation/service"
-	"github.com/cortezaproject/corteza/server/pkg/actionlog"
-	"github.com/cortezaproject/corteza/server/pkg/apigw"
-	apigwTypes "github.com/cortezaproject/corteza/server/pkg/apigw/types"
-	"github.com/cortezaproject/corteza/server/pkg/auth"
-	"github.com/cortezaproject/corteza/server/pkg/corredor"
-	"github.com/cortezaproject/corteza/server/pkg/eventbus"
-	"github.com/cortezaproject/corteza/server/pkg/healthcheck"
-	"github.com/cortezaproject/corteza/server/pkg/http"
-	"github.com/cortezaproject/corteza/server/pkg/id"
-	"github.com/cortezaproject/corteza/server/pkg/locale"
-	"github.com/cortezaproject/corteza/server/pkg/logger"
-	"github.com/cortezaproject/corteza/server/pkg/mail"
-	"github.com/cortezaproject/corteza/server/pkg/messagebus"
-	"github.com/cortezaproject/corteza/server/pkg/monitor"
-	"github.com/cortezaproject/corteza/server/pkg/options"
-	"github.com/cortezaproject/corteza/server/pkg/provision"
-	"github.com/cortezaproject/corteza/server/pkg/rbac"
-	"github.com/cortezaproject/corteza/server/pkg/scheduler"
-	"github.com/cortezaproject/corteza/server/pkg/sentry"
-	"github.com/cortezaproject/corteza/server/pkg/valuestore"
-	"github.com/cortezaproject/corteza/server/pkg/version"
-	"github.com/cortezaproject/corteza/server/pkg/websocket"
-	"github.com/cortezaproject/corteza/server/store"
-	"github.com/cortezaproject/corteza/server/system/service"
-	sysService "github.com/cortezaproject/corteza/server/system/service"
-	sysEvent "github.com/cortezaproject/corteza/server/system/service/event"
-	"github.com/cortezaproject/corteza/server/system/types"
-	"github.com/lestrrat-go/jwx/jwt"
-	"go.uber.org/zap"
-	gomail "gopkg.in/mail.v2"
+    authService "github.com/cortezaproject/corteza/server/auth"
+    "github.com/cortezaproject/corteza/server/auth/saml"
+    authSettings "github.com/cortezaproject/corteza/server/auth/settings"
+    autService "github.com/cortezaproject/corteza/server/automation/service"
+    cmpService "github.com/cortezaproject/corteza/server/compose/service"
+    cmpEvent "github.com/cortezaproject/corteza/server/compose/service/event"
+    discoveryService "github.com/cortezaproject/corteza/server/discovery/service"
+    fedService "github.com/cortezaproject/corteza/server/federation/service"
+    "github.com/cortezaproject/corteza/server/pkg/actionlog"
+    "github.com/cortezaproject/corteza/server/pkg/apigw"
+    apigwTypes "github.com/cortezaproject/corteza/server/pkg/apigw/types"
+    "github.com/cortezaproject/corteza/server/pkg/auth"
+    "github.com/cortezaproject/corteza/server/pkg/corredor"
+    "github.com/cortezaproject/corteza/server/pkg/eventbus"
+    "github.com/cortezaproject/corteza/server/pkg/healthcheck"
+    "github.com/cortezaproject/corteza/server/pkg/http"
+    "github.com/cortezaproject/corteza/server/pkg/id"
+    "github.com/cortezaproject/corteza/server/pkg/locale"
+    "github.com/cortezaproject/corteza/server/pkg/logger"
+    "github.com/cortezaproject/corteza/server/pkg/mail"
+    "github.com/cortezaproject/corteza/server/pkg/messagebus"
+    "github.com/cortezaproject/corteza/server/pkg/monitor"
+    "github.com/cortezaproject/corteza/server/pkg/options"
+    "github.com/cortezaproject/corteza/server/pkg/provision"
+    "github.com/cortezaproject/corteza/server/pkg/rbac"
+    "github.com/cortezaproject/corteza/server/pkg/scheduler"
+    "github.com/cortezaproject/corteza/server/pkg/sentry"
+    "github.com/cortezaproject/corteza/server/pkg/valuestore"
+    "github.com/cortezaproject/corteza/server/pkg/version"
+    "github.com/cortezaproject/corteza/server/pkg/websocket"
+    "github.com/cortezaproject/corteza/server/store"
+    "github.com/cortezaproject/corteza/server/system/service"
+    sysService "github.com/cortezaproject/corteza/server/system/service"
+    sysEvent "github.com/cortezaproject/corteza/server/system/service/event"
+    "github.com/cortezaproject/corteza/server/system/types"
+    "github.com/lestrrat-go/jwx/jwt"
+    "go.uber.org/zap"
+    gomail "gopkg.in/mail.v2"
 )
 
 const (
@@ -561,12 +560,11 @@ func (app *CortezaApp) Activate(ctx context.Context) (err error) {
 	updateDiscoverySettings(app.Opt.Discovery, service.CurrentSettings)
 	updateLocaleSettings(app.Opt.Locale)
 
-	updateSassInstallSettings(ctx, app.Log)
-
 	app.AuthService.Watch(ctx)
 
+    updateSassInstallSettings(ctx, sysService.DefaultStylesheet.SassInstalled(), app.Log)
 	//Generate CSS for webapps
-	if err = service.GenerateCSS(sysService.CurrentSettings, app.Opt.Webapp.ScssDirPath, app.Log); err != nil {
+    if err = sysService.DefaultStylesheet.GenerateCSS(sysService.CurrentSettings, app.Opt.Webapp.ScssDirPath, app.Log); err != nil {
 		return fmt.Errorf("could not generate css for webapps: %w", err)
 	}
 
@@ -970,9 +968,7 @@ func updateSmtpSettings(log *zap.Logger, current *types.AppSettings) {
 	setupSmtpDialer(log, current.SMTP.Servers...)
 }
 
-func updateSassInstallSettings(ctx context.Context, log *zap.Logger) {
-	sassInstalled := sass.DartSassTranspiler(log) != nil
-
+func updateSassInstallSettings(ctx context.Context, sassInstalled bool, log *zap.Logger) {
 	// update dart-sass installed setting
 	err := updateSetting(ctx, "ui.studio.sass-installed", sassInstalled)
 	if err != nil {

--- a/server/system/service/settings.go
+++ b/server/system/service/settings.go
@@ -256,7 +256,7 @@ func (svc *settings) BulkSet(ctx context.Context, vv types.SettingValueSet) (err
 				compStyles = current.FindByName("ui.studio.themes")
 			}
 
-			updateCSS(v, current.FindByName(v.Name), compStyles, v.Name, svc.webappsConf.ScssDirPath, svc.logger)
+            DefaultStylesheet.updateCSS(v, current.FindByName(v.Name), compStyles, v.Name, svc.webappsConf.ScssDirPath, svc.logger)
 		}
 
 		svc.logChange(ctx, v)


### PR DESCRIPTION
Reduce the number of instances Dart Sass transpiler is spun up to a single instance for proper resources management.

Fixes: https://github.com/cortezaproject/corteza/issues/1856