### PR TITLE
Add record values formatter on records patch

### DIFF
--- a/server/compose/service/record.go
+++ b/server/compose/service/record.go
@@ -1249,6 +1249,7 @@ func (svc record) patch(ctx context.Context, upd *types.Record, values types.Rec
 	}
 	upd.Values = newValues
 
+	values = svc.formatter.Run(m, values)
 	for _, v := range values {
 		err = upd.SetValue(v.Name, v.Place, v.Value)
 		if err != nil {


### PR DESCRIPTION
Add record values formatter on records patch to fix `time-only` inline edit.