### PR TITLE
Add namespaceID to loaded module-field resource for eval permissions

### DIFF
--- a/server/compose/service/module.go
+++ b/server/compose/service/module.go
@@ -1064,10 +1064,13 @@ func loadModuleField(ctx context.Context, s store.Storer, namespaceID, moduleID,
 		err = ModuleErrNotFound()
 	}
 
-	if err == nil && (namespaceID != res.NamespaceID || moduleID != res.ModuleID) {
-		// Make sure chart belongs to the right namespace
+	if err == nil && (moduleID != res.ModuleID) {
+		// Make sure  module-field belongs to the right module
 		return nil, ModuleErrNotFound()
 	}
+
+	// add namespace ID on the module-field
+	res.NamespaceID = namespaceID
 
 	return
 }

--- a/server/compose/types/module_field.go
+++ b/server/compose/types/module_field.go
@@ -19,7 +19,7 @@ type (
 	// Modules - CRM module definitions
 	ModuleField struct {
 		ID          uint64 `json:"fieldID,string"`
-		NamespaceID uint64 `json:"namspaceID,string"`
+        NamespaceID uint64 `json:"namespaceID,string"`
 		ModuleID    uint64 `json:"moduleID,string"`
 		Place       int    `json:"-"`
 


### PR DESCRIPTION
Ref: https://github.com/cortezaproject/corteza/issues/1861

This PR fixes the `ModuleErrNotFound` error when evaluating permissions on the module-field resource.
The issue is resolved by adding the` namespaceID` to the fetched module-field resource during permission evaluation.