### PR TITLE
Enable privacy app, to conform w/ the new default

### DIFF
--- a/server/app/options/http_server.cue
+++ b/server/app/options/http_server.cue
@@ -116,7 +116,7 @@ HTTPServer: schema.#optionsGroup & {
 			env:          "HTTP_WEBAPP_BASE_DIR"
 		}
 		webappList: {
-			defaultValue: "admin,compose,workflow,reporter"
+			defaultValue: "admin,compose,workflow,reporter,privacy"
 			env:          "HTTP_WEBAPP_LIST"
 		}
 		sslTerminated: {

--- a/server/pkg/options/options.gen.go
+++ b/server/pkg/options/options.gen.go
@@ -347,7 +347,7 @@ func HttpServer() (o *HttpServerOpt) {
 		ApiBaseUrl:             "/",
 		WebappBaseUrl:          "/",
 		WebappBaseDir:          "./webapp/public",
-		WebappList:             "admin,compose,workflow,reporter",
+		WebappList:             "admin,compose,workflow,reporter,privacy",
 		SslTerminated:          isSecure(),
 		WebConsoleEnabled:      false,
 		WebConsoleUsername:     "admin",


### PR DESCRIPTION
# The following changes are implemented

Add the privacy app to the default enabled apps. See <https://forum.cortezaproject.org/t/privacy-namespace-issue/1911/6>.

# Changes in the user interface:

Does not redirect to the front page by default when clicking on the "privacy" app.

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
