### PR TITLE
Add a 'scope' attribute to <th> tags

### DIFF
--- a/client/web/compose/src/components/Admin/Module/UniqueValues.vue
+++ b/client/web/compose/src/components/Admin/Module/UniqueValues.vue
@@ -71,19 +71,19 @@
         >
           <thead>
             <tr class="text-primary">
-              <th>
+              <th scope="col">
                 {{ $t("field") }}
               </th>
-              <th>
+              <th scope="col">
                 {{ $t("type") }}
               </th>
-              <th style="width: 250px;">
+              <th scope="col" style="width: 250px;">
                 {{ $t("valueModifiers") }}
               </th>
-              <th style="width: 250px;">
+              <th scope="col" style="width: 250px;">
                 {{ $t("multiValues") }}
               </th>
-              <th style="width: 150px;" />
+              <th scope="col" style="width: 150px;" />
             </tr>
           </thead>
 

--- a/client/web/compose/src/components/PageBlocks/Navigation/Configurator.vue
+++ b/client/web/compose/src/components/PageBlocks/Navigation/Configurator.vue
@@ -97,28 +97,29 @@
               >
                 <thead class="text-primary">
                   <tr>
-                    <th style="width: auto;" />
+                    <th scope="col" style="width: auto;" />
 
-                    <th style="min-width: 200px;">
+                    <th scope="col" style="min-width: 200px;">
                       {{ $t("navigation.type") }}
                     </th>
 
-                    <th style="min-width: 200px;">
+                    <th scope="col" style="min-width: 200px;">
                       {{ $t("navigation.color") }}
                     </th>
 
-                    <th style="min-width: 200px;">
+                    <th scope="col" style="min-width: 200px;">
                       {{ $t("navigation.background") }}
                     </th>
 
                     <th
                       class="text-center"
+                      scope="col"
                       style="width: 50px; min-width: 50px;"
                     >
                       {{ $t("navigation.enabled") }}
                     </th>
 
-                    <th style="width: auto; min-width: 100px;" />
+                    <th scope="col" style="width: auto; min-width: 100px;" />
                   </tr>
                 </thead>
 

--- a/client/web/compose/src/components/PageBlocks/Navigation/NavTypes/Dropdown.vue
+++ b/client/web/compose/src/components/PageBlocks/Navigation/NavTypes/Dropdown.vue
@@ -43,17 +43,18 @@
       >
         <thead>
           <tr class="text-primary">
-            <th style="min-width: 200px;">
+            <th scope="col" style="min-width: 200px;">
               {{ $t("navigation.text") }}
             </th>
-            <th style="min-width: 200px;">
+            <th scope="col" style="min-width: 200px;">
               {{ $t("navigation.url") }}
             </th>
-            <th style="min-width: 200px;">
+            <th scope="col" style="min-width: 200px;">
               {{ $t('navigation.openIn') }}
             </th>
             <th
               class="text-center"
+              scope="col"
               style="width: 50px; min-width: 50px;"
             >
               {{ $t("navigation.delimiter") }}

--- a/client/web/compose/src/components/PageBlocks/TabsConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/TabsConfigurator.vue
@@ -122,9 +122,9 @@
       >
         <b-thead>
           <tr>
-            <th />
+            <th scope="col" />
 
-            <th class="d-flex align-items-center text-primary">
+            <th class="d-flex align-items-center text-primary" scope="col">
               {{ $t('tabs.table.columns.title.label') }}
               <c-hint
                 :tooltip="$t('interpolationFootnote', ['${record.values.fieldName}', '${recordID}', '${ownerID}', '${userID}'])"
@@ -134,11 +134,12 @@
 
             <th
               class="text-primary"
+              scope="col"
             >
               {{ $t('tabs.table.columns.block.label') }}
             </th>
 
-            <th />
+            <th scope="col" />
           </tr>
         </b-thead>
 

--- a/client/web/compose/src/views/Admin/Modules/Edit.vue
+++ b/client/web/compose/src/views/Admin/Modules/Edit.vue
@@ -229,9 +229,10 @@
                     >
                       <thead>
                         <tr>
-                          <th />
+                          <th scope="col" />
                           <th
                             class="text-primary"
+                            scope="col"
                           >
                             <div
                               class="d-flex align-items-center"
@@ -244,6 +245,7 @@
                           </th>
                           <th
                             class="text-primary"
+                            scope="col"
                           >
                             <div
                               class="d-flex align-items-center"
@@ -255,22 +257,22 @@
                             </div>
                           </th>
 
-                          <th class="text-primary">
+                          <th class="text-primary" scope="col">
                             {{ $t('general:label.type') }}
                           </th>
 
-                          <th />
-                          <th />
+                          <th scope="col" />
+                          <th scope="col" />
 
-                          <th class="text-primary text-center pr-3">
+                          <th class="text-primary text-center pr-3" scope="col">
                             {{ $t('general:label.required') }}
                           </th>
 
-                          <th class="text-primary text-center pl-2">
+                          <th class="text-primary text-center pl-2" scope="col">
                             {{ $t('general:label.multi') }}
                           </th>
 
-                          <th />
+                          <th scope="col" />
                         </tr>
                       </thead>
 
@@ -313,10 +315,11 @@
                     >
                       <thead>
                         <tr>
-                          <th />
+                          <th scope="col" />
 
                           <th
                             class="text-primary"
+                            scope="col"
                             style="min-width: 250px;"
                           >
                             {{ $t('general:label.name') }}
@@ -324,6 +327,7 @@
 
                           <th
                             class="text-primary"
+                            scope="col"
                             style="min-width: 250px;"
                           >
                             {{ $t('general.label.title') }}
@@ -332,6 +336,7 @@
                           <th
                             colspan="5"
                             class="text-primary"
+                            scope="col"
                             style="min-width: 250px;"
                           >
                             {{ $t('general:label.type') }}

--- a/client/web/compose/src/views/Admin/Pages/Edit.vue
+++ b/client/web/compose/src/views/Admin/Pages/Edit.vue
@@ -258,20 +258,22 @@
                 >
                   <b-thead>
                     <tr>
-                      <th style="width: 40px;" />
+                      <th scope="col" style="width: 40px;" />
                       <th
                         class="text-primary"
+                        scope="col"
                         style="min-width: 300px;"
                       >
                         {{ $t('page-layout.title') }}
                       </th>
                       <th
                         class="text-primary"
+                        scope="col"
                         style="min-width: 300px;"
                       >
                         {{ $t('page-layout.handle') }}
                       </th>
-                      <th style="min-width: 100px;" />
+                      <th scope="col" style="min-width: 100px;" />
                     </tr>
                   </b-thead>
 


### PR DESCRIPTION
# The following changes are implemented
Add a 'scope' attribute to <th> tags.

# Changes in the user interface:
Better support for screen readers. This increases the accessibility of tables to visually impaired users.

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [x] All new critical code is covered by tests
 - [ ] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch

# Reasoning
Associating `<table>` headers, i.e. `<th>` elements, with their `<td>` cells enables screen readers to announce the header prior to the data. This considerably increases the accessibility of tables to visually impaired users.

There are two ways of doing it:
* Adding a `scope` attribute to `<th>` headers.
* Adding an `id` attribute to `<th>` headers and a headers attribute to every `<td>` element.

It is recommended to add `scope` attributes to `<th>` headers whenever possible. Use `<th id="...">` and `<td headers="...">` only when `<th scope="...">` is not capable of associating cells to their headers. This happens for very complex tables which have headers splitting the data in multiple subtables. See [W3C WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/tables/tips/) for more information.