### PR TITLE
Remove duplicated height in CSS - fixes #2027

### DIFF
--- a/server/assets/src/scss/main/18201131_bootsrapvue.scss
+++ b/server/assets/src/scss/main/18201131_bootsrapvue.scss
@@ -1064,7 +1064,6 @@ input[type="color"].form-control:disabled {
     background-color: $input-bg;
     background-clip: padding-box;
     border: $input-border-width solid $input-border-color;
-    height: $input-height;
 
     @if $enable-rounded {
       border-radius: $input-border-radius;


### PR DESCRIPTION
# The following changes are implemented
Remove duplicate `height: $input-height;` in CSS.

# Changes in the user interface:
none

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [ ] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
