### PR TITLE
Fix discovery mappings, indexing and allowed roles

### DIFF
--- a/extra/server-discovery/.env.example
+++ b/extra/server-discovery/.env.example
@@ -66,6 +66,11 @@
 # ES_PASSWORD=<no value>
 
 ###############################################################################
+# Path to the CA certificate file for the open search connection.
+# Type:    string
+# ES_CERT_FILE=<no value>
+
+###############################################################################
 # How often are indexes incremented. set value in seconds.
 # Type:    int
 # Default: 600

--- a/extra/server-discovery/.gitignore
+++ b/extra/server-discovery/.gitignore
@@ -13,3 +13,5 @@ profile.coverprofile
 /gin-bin
 /.vscode
 /federation/etc/.env*
+/certs
+

--- a/extra/server-discovery/pkg/es/es.go
+++ b/extra/server-discovery/pkg/es/es.go
@@ -2,8 +2,13 @@ package es
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+
 	"github.com/cortezaproject/corteza/extra/server-discovery/pkg/options"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
@@ -49,6 +54,33 @@ func (es *es) Client() (*elasticsearch.Client, error) {
 		config.Username = es.opt.Username
 		config.Password = es.opt.Password
 	}
+
+	// if the user provided a CA certificate file, we need to load it
+	// and set it in the TLS config
+	if es.opt.CertFile != "" {
+		rootCACert, err := os.ReadFile(es.opt.CertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file: %w", err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(rootCACert) {
+			return nil, fmt.Errorf("failed parse root certificate: %w", err)
+		}
+
+		config.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		}
+	} else if !es.opt.Secure {
+		config.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+
 	return elasticsearch.NewClient(config)
 }
 

--- a/extra/server-discovery/pkg/options/es.go
+++ b/extra/server-discovery/pkg/options/es.go
@@ -1,8 +1,9 @@
 package options
 
 import (
-	"github.com/cortezaproject/corteza/server/pkg/options"
 	"strings"
+
+	"github.com/cortezaproject/corteza/server/pkg/options"
 )
 
 type (
@@ -10,6 +11,7 @@ type (
 		Addresses            []string `env:"ES_ADDRESS"`
 		Username             string   `env:"ES_USERNAME"`
 		Password             string   `env:"ES_PASSWORD"`
+		CertFile             string   `env:"ES_CERT_FILE"`
 		Secure               bool     `env:"ES_SECURE"`
 		EnableRetryOnTimeout bool     `env:"ES_ENABLE_RETRY_ON_TIMEOUT"`
 		MaxRetries           int      `env:"ES_MAX_RETRIES"`
@@ -22,7 +24,8 @@ func ES() (o *EsOpt, err error) {
 	return o, func() error {
 		o.Username = options.EnvString("ES_USERNAME", "")
 		o.Password = options.EnvString("ES_PASSWORD", "")
-		o.Secure = options.EnvBool("ES_SECURE", false)
+		o.Secure = options.EnvBool("ES_SECURE", true)
+		o.CertFile = options.EnvString("ES_CERT_FILE", "")
 
 		o.EnableRetryOnTimeout = options.EnvBool("ES_ENABLE_RETRY_ON_TIMEOUT", true)
 		o.MaxRetries = options.EnvInt("ES_MAX_RETRIES", 5)

--- a/server/.env.example
+++ b/server/.env.example
@@ -33,7 +33,7 @@
 
 ###############################################################################
 # Allow insecure (invalid, expired TLS/SSL certificates) connections.
-#
+# 
 # [IMPORTANT]
 # ====
 # We strongly recommend keeping this value set to false except for local development or demos.
@@ -203,7 +203,7 @@
 
 ###############################################################################
 # Password for the web console endpoint. When running in dev environment, password is not required.
-#
+# 
 # Corteza intentionally sets default password to random chars to prevent security incidents.
 # Type:    string
 # Default: <no value>
@@ -290,7 +290,7 @@
 # Email sending
 #
 # Configure your local SMTP server or use one of the available providers.
-#
+# 
 # These values are copied to settings when the server starts and can be managed from the administration console.
 # We recommend you remove these values after they are copied to settings.
 # If server detects difference between these options and settings, it shows a warning in the log on server start.
@@ -430,7 +430,7 @@
 
 ###############################################################################
 # Password security allows you to disable constraints to which passwords must conform to.
-#
+# 
 # [CAUTION]
 # ====
 # Disabling password security can be useful for development environments as it removes the need for complex passwords.
@@ -442,12 +442,12 @@
 
 ###############################################################################
 # Algoritm to be use for JWT signature.
-#
+# 
 # Supported valus:
 #  - HS256, HS384, HS512
 #  - PS256, PS384, PS512,
 #  - RS256, RS384, RS512
-#
+# 
 # Provide shared secret string for HS256, HS384, HS512 and full private key or path to the file PS* and RS* algorithms.
 # Type:    string
 # Default: HS512
@@ -456,7 +456,7 @@
 ###############################################################################
 # Secret used for signing JWT tokens.
 # Value is used only when HS256, HS384 or HS512 algorithm is used.
-#
+# 
 # [IMPORTANT]
 # ====
 # If secret is not set, system auto-generates one from DB_DSN and HOSTNAME environment variables.
@@ -480,7 +480,7 @@
 
 ###############################################################################
 # Lifetime of the refresh token. Should be much longer than lifetime of the access token.
-#
+# 
 # Refresh tokens are used to exchange expired access tokens with new ones.
 # Type:    time.Duration
 # Default: 72h
@@ -488,7 +488,7 @@
 
 ###############################################################################
 # Redirect URL to be sent with OAuth2 authentication request to provider
-#
+# 
 # `provider` placeholder is replaced with the actual value when used.
 # Type:    string
 # Default: <no value>
@@ -496,7 +496,7 @@
 
 ###############################################################################
 # Secret used for securing cookies
-#
+# 
 # [IMPORTANT]
 # ====
 # If secret is not set, system auto-generates one from DB_DSN and HOSTNAME environment variables.
@@ -539,21 +539,21 @@
 
 ###############################################################################
 # Maximum time user is allowed to stay idle when logged in without "remember-me" option and before session is expired.
-#
+# 
 # Recomended value is between an hour and a day.
-#
+# 
 # [IMPORTANT]
 # ====
 # This affects only profile (/auth) pages. Using applications (admin, compose, ...) does not prolong the session.
 # ====
-#
+# 
 # Type:    time.Duration
 # Default: 24h
 # AUTH_SESSION_LIFETIME=24h
 
 ###############################################################################
 # Duration of the session in /auth lasts when user logs-in with "remember-me" option.
-#
+# 
 # If set to 0, "remember-me" option is removed.
 # Type:    time.Duration
 # Default: 8640h
@@ -580,7 +580,7 @@
 
 ###############################################################################
 # Secret used for securing CSRF protection
-#
+# 
 # [IMPORTANT]
 # ====
 # If secret is not set, system auto-generates one from DB_DSN and HOSTNAME environment variables.
@@ -610,19 +610,19 @@
 
 ###############################################################################
 # Handle for OAuth2 client used for automatic redirect from /auth/oauth2/go endpoint.
-#
+# 
 # This simplifies configuration for OAuth2 flow for Corteza Web applications as it removes
 # the need to suply redirection URL and client ID (oauth2/go endpoint does that internally)
-#
+# 
 # Type:    string
 # Default: corteza-webapp
 # AUTH_DEFAULT_CLIENT=corteza-webapp
 
 ###############################################################################
 # Path to js, css, images and template source files
-#
+# 
 # When corteza starts, if path exists it tries to load template files from it.
-#
+# 
 # When empty path is set (default value), embedded files are used.
 # Type:    string
 # Default: <no value>
@@ -631,7 +631,7 @@
 ###############################################################################
 # When enabled, corteza reloads template before every execution.
 # Enable this for debugging or when developing auth templates.
-#
+# 
 # Should be disabled in production where templates do not change between server restarts.
 # Type:    bool
 # Default: <no value>
@@ -640,7 +640,7 @@
 ###############################################################################
 # When set, Corteza creates one or more users with the configured values using provided email as a password.
 # It skips existing (email, handle). All new users are assigned to all bypass roles.
-#
+# 
 # When set in production, Corteza stops and reports an error
 # Type:    string
 # Default: <no value>
@@ -824,16 +824,16 @@
 ###############################################################################
 # List of compa delimited languages (language tags) to enable.
 # In case when an enabled language can not be loaded, error is logged.
-#
+# 
 # When loading language configurations (config.xml) from the configured path(s).
-#
+# 
 # Type:    string
 # Default: en
 # LOCALE_LANGUAGES=en
 
 ###############################################################################
 # 	One or more paths to locale config and translation files, separated by colon
-#
+# 
 # 	When with LOCALE_DEVELOPMENT_MODE=true, default value for path is ../../locale
 # Type:    string
 # Default: <no value>
@@ -843,7 +843,7 @@
 # Name of the query string parameter used to pass the language tag (it overrides Accept-Language header).
 # Set it to empty string to disable detection from the query string.
 # This parameter is ignored if only one language is enabled
-#
+# 
 # Type:    string
 # Default: lng
 # LOCALE_QUERY_STRING_PARAM=lng
@@ -874,9 +874,9 @@
 
 ###############################################################################
 # Disables json format for logging and enables more human-readable output with colors.
-#
+# 
 # Disable for production.
-#
+# 
 # Type:    bool
 # Default: <no value>
 # LOG_DEBUG=<no value>
@@ -884,11 +884,11 @@
 ###############################################################################
 # Minimum logging level. If set to "warn",
 # Levels warn, error, dpanic panic and fatal will be logged.
-#
+# 
 # Recommended value for production: warn
-#
+# 
 # Possible values: debug, info, warn, error, dpanic, panic, fatal
-#
+# 
 # Type:    string
 # Default: warn
 # LOG_LEVEL=warn
@@ -896,25 +896,25 @@
 ###############################################################################
 # Log filtering rules by level and name (log-level:log-namespace).
 # Please note that level (LOG_LEVEL) is applied before filter and it affects the final output!
-#
+# 
 # Leave unset for production.
-#
+# 
 # Example:
 # `warn+:* *:auth,workflow.*`
 # Log warnings, errors, panic, fatals. Everything from auth and workflow is logged.
-#
-#
+# 
+# 
 # See more examples and documentation here: https://github.com/moul/zapfilter
-#
+# 
 # Type:    string
 # Default: <no value>
 # LOG_FILTER=<no value>
 
 ###############################################################################
 # Set to true to see where the logging was called from.
-#
+# 
 # Disable for production.
-#
+# 
 # Type:    bool
 # Default: <no value>
 # LOG_INCLUDE_CALLER=<no value>
@@ -922,9 +922,9 @@
 ###############################################################################
 # Include stack-trace when logging at a specified level or below.
 # Disable for production.
-#
+# 
 # Possible values: debug, info, warn, error, dpanic, panic, fatal
-#
+# 
 # Type:    string
 # Default: dpanic
 # LOG_STACKTRACE_LEVEL=dpanic
@@ -1019,11 +1019,11 @@
 #
 # Provisioning allows you to configure a {PRODUCT_NAME} instance when deployed.
 # It occurs automatically after the {PRODUCT_NAME} server starts.
-#
+# 
 # [IMPORTANT]
 # ====
 # We recommend you to keep provisioning enabled as it simplifies version updates by updating the database and updating settings.
-#
+# 
 # If you're doing local development or some debugging, you can disable this.
 # ====
 #
@@ -1049,7 +1049,7 @@
 # ====
 # These parameters help in the development and testing process.
 # When you are deploying to production, these should be disabled to improve performance and reduce storage usage.
-#
+# 
 # You should configure external services such as Sentry or ELK to keep track of logs and error reports.
 # ====
 #
@@ -1155,7 +1155,7 @@
 # Delay system startup
 #
 # You can configure these options to defer API execution until another external (HTTP) service is up and running.
-#
+# 
 # [ TIP ]
 # ====
 # Delaying API execution can come in handy in complex setups where execution order is important.
@@ -1179,7 +1179,7 @@
 ###############################################################################
 # Space delimited list of hosts and/or URLs to probe.
 #     Host format: `host` or `host:443` (port will default to 80).
-#
+# 
 # [NOTE]
 # ====
 # Services are probed in parallel.

--- a/server/automation/automation/apigw_body_handler.gen.go
+++ b/server/automation/automation/apigw_body_handler.gen.go
@@ -121,7 +121,9 @@ type (
 	}
 
 	apigwBodyReadFileResults struct {
-		File io.Reader
+		File     io.Reader
+		FileName string
+		Exists   bool
 	}
 )
 
@@ -158,6 +160,16 @@ func (h apigwBodyHandler) ReadFile() *atypes.Function {
 				Name:  "file",
 				Types: []string{"Reader"},
 			},
+
+			{
+				Name:  "fileName",
+				Types: []string{"String"},
+			},
+
+			{
+				Name:  "exists",
+				Types: []string{"Boolean"},
+			},
 		},
 
 		Handler: func(ctx context.Context, in *expr.Vars) (out *expr.Vars, err error) {
@@ -188,6 +200,32 @@ func (h apigwBodyHandler) ReadFile() *atypes.Function {
 				if tval, err = h.reg.Type("Reader").Cast(results.File); err != nil {
 					return
 				} else if err = expr.Assign(out, "file", tval); err != nil {
+					return
+				}
+			}
+
+			{
+				// converting results.FileName (string) to String
+				var (
+					tval expr.TypedValue
+				)
+
+				if tval, err = h.reg.Type("String").Cast(results.FileName); err != nil {
+					return
+				} else if err = expr.Assign(out, "fileName", tval); err != nil {
+					return
+				}
+			}
+
+			{
+				// converting results.Exists (bool) to Boolean
+				var (
+					tval expr.TypedValue
+				)
+
+				if tval, err = h.reg.Type("Boolean").Cast(results.Exists); err != nil {
+					return
+				} else if err = expr.Assign(out, "exists", tval); err != nil {
 					return
 				}
 			}

--- a/server/automation/automation/apigw_body_handler.gen.go
+++ b/server/automation/automation/apigw_body_handler.gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cortezaproject/corteza/server/pkg/expr"
 	"github.com/cortezaproject/corteza/server/pkg/http"
 	"github.com/cortezaproject/corteza/server/pkg/wfexec"
+	"io"
 )
 
 var _ wfexec.ExecResponse
@@ -28,6 +29,7 @@ type (
 func (h apigwBodyHandler) register() {
 	h.reg.AddFunctions(
 		h.Read(),
+		h.ReadFile(),
 	)
 }
 
@@ -45,9 +47,10 @@ type (
 // Read function Read request body from integration gateway
 //
 // expects implementation of read function:
-// func (h apigwBodyHandler) read(ctx context.Context, args *apigwBodyReadArgs) (results *apigwBodyReadResults, err error) {
-//    return
-// }
+//
+//	func (h apigwBodyHandler) read(ctx context.Context, args *apigwBodyReadArgs) (results *apigwBodyReadResults, err error) {
+//	   return
+//	}
 func (h apigwBodyHandler) Read() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "apigwBodyRead",
@@ -99,6 +102,92 @@ func (h apigwBodyHandler) Read() *atypes.Function {
 				if tval, err = h.reg.Type("String").Cast(results.Body); err != nil {
 					return
 				} else if err = expr.Assign(out, "body", tval); err != nil {
+					return
+				}
+			}
+
+			return
+		},
+	}
+}
+
+type (
+	apigwBodyReadFileArgs struct {
+		hasRequest bool
+		Request    *http.Request
+
+		hasName bool
+		Name    string
+	}
+
+	apigwBodyReadFileResults struct {
+		File io.Reader
+	}
+)
+
+// ReadFile function Read file from integration gateway
+//
+// expects implementation of readFile function:
+//
+//	func (h apigwBodyHandler) readFile(ctx context.Context, args *apigwBodyReadFileArgs) (results *apigwBodyReadFileResults, err error) {
+//	   return
+//	}
+func (h apigwBodyHandler) ReadFile() *atypes.Function {
+	return &atypes.Function{
+		Ref:    "apigwBodyReadFile",
+		Kind:   "function",
+		Labels: map[string]string(nil),
+		Meta: &atypes.FunctionMeta{
+			Short: "Read file from integration gateway",
+		},
+
+		Parameters: []*atypes.Param{
+			{
+				Name:  "request",
+				Types: []string{"HttpRequest"}, Required: true,
+			},
+			{
+				Name:  "name",
+				Types: []string{"String"}, Required: true,
+			},
+		},
+
+		Results: []*atypes.Param{
+
+			{
+				Name:  "file",
+				Types: []string{"Reader"},
+			},
+		},
+
+		Handler: func(ctx context.Context, in *expr.Vars) (out *expr.Vars, err error) {
+			var (
+				args = &apigwBodyReadFileArgs{
+					hasRequest: in.Has("request"),
+					hasName:    in.Has("name"),
+				}
+			)
+
+			if err = in.Decode(args); err != nil {
+				return
+			}
+
+			var results *apigwBodyReadFileResults
+			if results, err = h.readFile(ctx, args); err != nil {
+				return
+			}
+
+			out = &expr.Vars{}
+
+			{
+				// converting results.File (io.Reader) to Reader
+				var (
+					tval expr.TypedValue
+				)
+
+				if tval, err = h.reg.Type("Reader").Cast(results.File); err != nil {
+					return
+				} else if err = expr.Assign(out, "file", tval); err != nil {
 					return
 				}
 			}

--- a/server/automation/automation/apigw_body_handler.go
+++ b/server/automation/automation/apigw_body_handler.go
@@ -2,7 +2,11 @@ package automation
 
 import (
 	"context"
+	"errors"
 	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
 )
 
 type (
@@ -36,8 +40,28 @@ func (h apigwBodyHandler) read(ctx context.Context, args *apigwBodyReadArgs) (re
 
 func (h apigwBodyHandler) readFile(ctx context.Context, args *apigwBodyReadFileArgs) (res *apigwBodyReadFileResults, err error) {
 	// @note the contents are already parsed; will probably need to rework behind the scenes bits
-	res = &apigwBodyReadFileResults{}
-	res.File, _, err = args.Request.FormFile(args.Name)
+	res = &apigwBodyReadFileResults{
+		Exists: true,
+	}
+
+	var fh *multipart.FileHeader
+	res.File, fh, err = args.Request.FormFile(args.Name)
+	if err != nil {
+		// In case the file is missing or empty, do this
+		// @todo do we want to just check if missing?
+		if errors.Is(err, http.ErrMissingFile) || strings.Contains(err.Error(), "EOF") {
+			res.Exists = false
+			err = nil
+		} else {
+			return
+		}
+	}
+
+	if !res.Exists {
+		return
+	}
+
+	res.FileName = fh.Filename
 
 	return
 }

--- a/server/automation/automation/apigw_body_handler.go
+++ b/server/automation/automation/apigw_body_handler.go
@@ -33,3 +33,11 @@ func (h apigwBodyHandler) read(ctx context.Context, args *apigwBodyReadArgs) (re
 
 	return
 }
+
+func (h apigwBodyHandler) readFile(ctx context.Context, args *apigwBodyReadFileArgs) (res *apigwBodyReadFileResults, err error) {
+	// @note the contents are already parsed; will probably need to rework behind the scenes bits
+	res = &apigwBodyReadFileResults{}
+	res.File, _, err = args.Request.FormFile(args.Name)
+
+	return
+}

--- a/server/automation/automation/apigw_body_handler.yaml
+++ b/server/automation/automation/apigw_body_handler.yaml
@@ -31,3 +31,7 @@ functions:
     results:
       file:
         wf: Reader
+      fileName:
+        wf: String
+      exists:
+        wf: Boolean

--- a/server/automation/automation/apigw_body_handler.yaml
+++ b/server/automation/automation/apigw_body_handler.yaml
@@ -2,6 +2,7 @@ name: apigwBody
 
 imports:
   - github.com/cortezaproject/corteza/server/pkg/http
+  - io
 
 functions:
   read:
@@ -15,3 +16,18 @@ functions:
     results:
       body:
         wf: String
+  readFile:
+    meta:
+      short: Read file from integration gateway
+    params:
+      request:
+        required: true
+        types:
+          - { wf: HttpRequest, go: '*http.Request' }
+      name:
+        required: true
+        types:
+          - { wf: String }
+    results:
+      file:
+        wf: Reader

--- a/server/automation/automation/corredor_handler.gen.go
+++ b/server/automation/automation/corredor_handler.gen.go
@@ -47,9 +47,10 @@ type (
 // Exec function Corredor automation script executor
 //
 // expects implementation of exec function:
-// func (h corredorHandler) exec(ctx context.Context, args *corredorExecArgs) (results *corredorExecResults, err error) {
-//    return
-// }
+//
+//	func (h corredorHandler) exec(ctx context.Context, args *corredorExecArgs) (results *corredorExecResults, err error) {
+//	   return
+//	}
 func (h corredorHandler) Exec() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "corredorExec",

--- a/server/automation/automation/email_handler.gen.go
+++ b/server/automation/automation/email_handler.gen.go
@@ -113,9 +113,10 @@ func (a emailSendArgs) GetPlain() (bool, string, io.Reader) {
 // Send function Email
 //
 // expects implementation of send function:
-// func (h emailHandler) send(ctx context.Context, args *emailSendArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) send(ctx context.Context, args *emailSendArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) Send() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailSend",
@@ -357,9 +358,10 @@ func (a emailMessageArgs) GetPlain() (bool, string, io.Reader) {
 // Message function Email builder
 //
 // expects implementation of message function:
-// func (h emailHandler) message(ctx context.Context, args *emailMessageArgs) (results *emailMessageResults, err error) {
-//    return
-// }
+//
+//	func (h emailHandler) message(ctx context.Context, args *emailMessageArgs) (results *emailMessageResults, err error) {
+//	   return
+//	}
 func (h emailHandler) Message() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailMessage",
@@ -563,9 +565,10 @@ type (
 // SendMessage function Email sender
 //
 // expects implementation of sendMessage function:
-// func (h emailHandler) sendMessage(ctx context.Context, args *emailSendMessageArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) sendMessage(ctx context.Context, args *emailSendMessageArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) SendMessage() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailSendMessage",
@@ -615,9 +618,10 @@ type (
 // SetSubject function Email subject
 //
 // expects implementation of setSubject function:
-// func (h emailHandler) setSubject(ctx context.Context, args *emailSetSubjectArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) setSubject(ctx context.Context, args *emailSetSubjectArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) SetSubject() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailSetSubject",
@@ -675,9 +679,10 @@ type (
 // SetHeaders function Email headers
 //
 // expects implementation of setHeaders function:
-// func (h emailHandler) setHeaders(ctx context.Context, args *emailSetHeadersArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) setHeaders(ctx context.Context, args *emailSetHeadersArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) SetHeaders() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailSetHeaders",
@@ -738,9 +743,10 @@ type (
 // SetHeader function Email header
 //
 // expects implementation of setHeader function:
-// func (h emailHandler) setHeader(ctx context.Context, args *emailSetHeaderArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) setHeader(ctx context.Context, args *emailSetHeaderArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) SetHeader() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailSetHeader",
@@ -813,9 +819,10 @@ type (
 // SetAddress function Email set address
 //
 // expects implementation of setAddress function:
-// func (h emailHandler) setAddress(ctx context.Context, args *emailSetAddressArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) setAddress(ctx context.Context, args *emailSetAddressArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) SetAddress() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailSetAddress",
@@ -896,9 +903,10 @@ type (
 // AddAddress function Email add address
 //
 // expects implementation of addAddress function:
-// func (h emailHandler) addAddress(ctx context.Context, args *emailAddAddressArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) addAddress(ctx context.Context, args *emailAddAddressArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) AddAddress() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailAddAddress",
@@ -982,9 +990,10 @@ func (a emailAttachArgs) GetContent() (bool, io.Reader, string) {
 // Attach function Email attachment
 //
 // expects implementation of attach function:
-// func (h emailHandler) attach(ctx context.Context, args *emailAttachArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) attach(ctx context.Context, args *emailAttachArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) Attach() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailAttach",
@@ -1064,9 +1073,10 @@ type (
 // Embed function Email embedded attachment
 //
 // expects implementation of embed function:
-// func (h emailHandler) embed(ctx context.Context, args *emailEmbedArgs) (err error) {
-//    return
-// }
+//
+//	func (h emailHandler) embed(ctx context.Context, args *emailEmbedArgs) (err error) {
+//	   return
+//	}
 func (h emailHandler) Embed() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "emailEmbed",

--- a/server/automation/automation/http_request_handler.gen.go
+++ b/server/automation/automation/http_request_handler.gen.go
@@ -93,9 +93,10 @@ func (a httpRequestSendArgs) GetBody() (bool, string, io.Reader, interface{}) {
 // Send function HTTP request
 //
 // expects implementation of send function:
-// func (h httpRequestHandler) send(ctx context.Context, args *httpRequestSendArgs) (results *httpRequestSendResults, err error) {
-//    return
-// }
+//
+//	func (h httpRequestHandler) send(ctx context.Context, args *httpRequestSendArgs) (results *httpRequestSendResults, err error) {
+//	   return
+//	}
 func (h httpRequestHandler) Send() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "httpRequestSend",

--- a/server/automation/automation/jsenv_handler.gen.go
+++ b/server/automation/automation/jsenv_handler.gen.go
@@ -57,9 +57,10 @@ func (a jsenvExecuteArgs) GetScope() (bool, interface{}, io.Reader) {
 // Execute function Process arbitrary data in jsenv
 //
 // expects implementation of execute function:
-// func (h jsenvHandler) execute(ctx context.Context, args *jsenvExecuteArgs) (results *jsenvExecuteResults, err error) {
-//    return
-// }
+//
+//	func (h jsenvHandler) execute(ctx context.Context, args *jsenvExecuteArgs) (results *jsenvExecuteResults, err error) {
+//	   return
+//	}
 func (h jsenvHandler) Execute() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "jsenvExecute",

--- a/server/automation/automation/jwt_handler.gen.go
+++ b/server/automation/automation/jwt_handler.gen.go
@@ -72,9 +72,10 @@ func (a jwtGenerateArgs) GetSecret() (bool, string, io.Reader) {
 // Generate function Generate JWT
 //
 // expects implementation of generate function:
-// func (h jwtHandler) generate(ctx context.Context, args *jwtGenerateArgs) (results *jwtGenerateResults, err error) {
-//    return
-// }
+//
+//	func (h jwtHandler) generate(ctx context.Context, args *jwtGenerateArgs) (results *jwtGenerateResults, err error) {
+//	   return
+//	}
 func (h jwtHandler) Generate() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "jwtGenerate",

--- a/server/automation/automation/log_handler.gen.go
+++ b/server/automation/automation/log_handler.gen.go
@@ -46,9 +46,10 @@ type (
 // Debug function Log debug message
 //
 // expects implementation of debug function:
-// func (h logHandler) debug(ctx context.Context, args *logDebugArgs) (err error) {
-//    return
-// }
+//
+//	func (h logHandler) debug(ctx context.Context, args *logDebugArgs) (err error) {
+//	   return
+//	}
 func (h logHandler) Debug() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "logDebug",
@@ -99,9 +100,10 @@ type (
 // Info function Log info message
 //
 // expects implementation of info function:
-// func (h logHandler) info(ctx context.Context, args *logInfoArgs) (err error) {
-//    return
-// }
+//
+//	func (h logHandler) info(ctx context.Context, args *logInfoArgs) (err error) {
+//	   return
+//	}
 func (h logHandler) Info() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "logInfo",
@@ -152,9 +154,10 @@ type (
 // Warn function Log warning message
 //
 // expects implementation of warn function:
-// func (h logHandler) warn(ctx context.Context, args *logWarnArgs) (err error) {
-//    return
-// }
+//
+//	func (h logHandler) warn(ctx context.Context, args *logWarnArgs) (err error) {
+//	   return
+//	}
 func (h logHandler) Warn() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "logWarn",
@@ -205,9 +208,10 @@ type (
 // Error function Log error message
 //
 // expects implementation of error function:
-// func (h logHandler) error(ctx context.Context, args *logErrorArgs) (err error) {
-//    return
-// }
+//
+//	func (h logHandler) error(ctx context.Context, args *logErrorArgs) (err error) {
+//	   return
+//	}
 func (h logHandler) Error() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "logError",

--- a/server/automation/automation/loop_handler.gen.go
+++ b/server/automation/automation/loop_handler.gen.go
@@ -56,9 +56,10 @@ type (
 // Sequence function Iterates over sequence of numbers
 //
 // expects implementation of sequence function:
-// func (h loopHandler) sequence(ctx context.Context, args *loopSequenceArgs) (results *loopSequenceResults, err error) {
-//    return
-// }
+//
+//	func (h loopHandler) sequence(ctx context.Context, args *loopSequenceArgs) (results *loopSequenceResults, err error) {
+//	   return
+//	}
 func (h loopHandler) Sequence() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "loopSequence",
@@ -129,9 +130,10 @@ type (
 // Do function Condition
 //
 // expects implementation of do function:
-// func (h loopHandler) do(ctx context.Context, args *loopDoArgs) (err error) {
-//    return
-// }
+//
+//	func (h loopHandler) do(ctx context.Context, args *loopDoArgs) (err error) {
+//	   return
+//	}
 func (h loopHandler) Do() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "loopDo",
@@ -183,9 +185,10 @@ type (
 // Each function Items
 //
 // expects implementation of each function:
-// func (h loopHandler) each(ctx context.Context, args *loopEachArgs) (results *loopEachResults, err error) {
-//    return
-// }
+//
+//	func (h loopHandler) each(ctx context.Context, args *loopEachArgs) (results *loopEachResults, err error) {
+//	   return
+//	}
 func (h loopHandler) Each() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "loopEach",
@@ -241,9 +244,10 @@ type (
 // Lines function Stream lines
 //
 // expects implementation of lines function:
-// func (h loopHandler) lines(ctx context.Context, args *loopLinesArgs) (results *loopLinesResults, err error) {
-//    return
-// }
+//
+//	func (h loopHandler) lines(ctx context.Context, args *loopLinesArgs) (results *loopLinesResults, err error) {
+//	   return
+//	}
 func (h loopHandler) Lines() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "loopLines",

--- a/server/automation/automation/oauth2_handler.gen.go
+++ b/server/automation/automation/oauth2_handler.gen.go
@@ -55,9 +55,10 @@ type (
 // Authenticate function Authentication: OAUTH2
 //
 // expects implementation of authenticate function:
-// func (h oauth2Handler) authenticate(ctx context.Context, args *oauth2AuthenticateArgs) (results *oauth2AuthenticateResults, err error) {
-//    return
-// }
+//
+//	func (h oauth2Handler) authenticate(ctx context.Context, args *oauth2AuthenticateArgs) (results *oauth2AuthenticateResults, err error) {
+//	   return
+//	}
 func (h oauth2Handler) Authenticate() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "oauth2Authenticate",

--- a/server/automation/automation/queue_handler.gen.go
+++ b/server/automation/automation/queue_handler.gen.go
@@ -50,9 +50,10 @@ func (a queueWriteArgs) GetPayload() (bool, string, io.Reader) {
 // Write function Queue message send
 //
 // expects implementation of write function:
-// func (h queueHandler) write(ctx context.Context, args *queueWriteArgs) (err error) {
-//    return
-// }
+//
+//	func (h queueHandler) write(ctx context.Context, args *queueWriteArgs) (err error) {
+//	   return
+//	}
 func (h queueHandler) Write() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "queueWrite",

--- a/server/automation/service/access_control_actions.gen.go
+++ b/server/automation/service/access_control_actions.gen.go
@@ -52,7 +52,6 @@ var (
 // setRule updates accessControlActionProps's rule
 //
 // This function is auto-generated.
-//
 func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlActionProps {
 	p.rule = rule
 	return p
@@ -61,7 +60,6 @@ func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlAction
 // Serialize converts accessControlActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -80,7 +78,6 @@ func (p accessControlActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -129,7 +126,6 @@ func (p accessControlActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *accessControlAction) String() string {
 	var props = &accessControlActionProps{}
 
@@ -157,7 +153,6 @@ func (e *accessControlAction) ToAction() *actionlog.Action {
 // AccessControlActionGrant returns "automation:access_control.grant" action
 //
 // This function is auto-generated.
-//
 func AccessControlActionGrant(props ...*accessControlActionProps) *accessControlAction {
 	a := &accessControlAction{
 		timestamp: time.Now(),
@@ -180,9 +175,7 @@ func AccessControlActionGrant(props ...*accessControlActionProps) *accessControl
 
 // AccessControlErrGeneric returns "automation:access_control.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -216,9 +209,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 // AccessControlErrNotAllowedToSetPermissions returns "automation:access_control.notAllowedToSetPermissions" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -256,7 +247,6 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc accessControl) recordAction(ctx context.Context, props *accessControlActionProps, actionFn func(...*accessControlActionProps) *accessControlAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/automation/service/session_actions.gen.go
+++ b/server/automation/service/session_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setSession updates sessionActionProps's session
 //
 // This function is auto-generated.
-//
 func (p *sessionActionProps) setSession(session *types.Session) *sessionActionProps {
 	p.session = session
 	return p
@@ -64,7 +63,6 @@ func (p *sessionActionProps) setSession(session *types.Session) *sessionActionPr
 // setNew updates sessionActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *sessionActionProps) setNew(new *types.Session) *sessionActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *sessionActionProps) setNew(new *types.Session) *sessionActionProps {
 // setUpdate updates sessionActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *sessionActionProps) setUpdate(update *types.Session) *sessionActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *sessionActionProps) setUpdate(update *types.Session) *sessionActionProp
 // setFilter updates sessionActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *sessionActionProps) setFilter(filter *types.SessionFilter) *sessionActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *sessionActionProps) setFilter(filter *types.SessionFilter) *sessionActi
 // Serialize converts sessionActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p sessionActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -115,7 +110,6 @@ func (p sessionActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p sessionActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -191,7 +185,6 @@ func (p sessionActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *sessionAction) String() string {
 	var props = &sessionActionProps{}
 
@@ -219,7 +212,6 @@ func (e *sessionAction) ToAction() *actionlog.Action {
 // SessionActionSearch returns "automation:session.search" action
 //
 // This function is auto-generated.
-//
 func SessionActionSearch(props ...*sessionActionProps) *sessionAction {
 	a := &sessionAction{
 		timestamp: time.Now(),
@@ -239,7 +231,6 @@ func SessionActionSearch(props ...*sessionActionProps) *sessionAction {
 // SessionActionLookup returns "automation:session.lookup" action
 //
 // This function is auto-generated.
-//
 func SessionActionLookup(props ...*sessionActionProps) *sessionAction {
 	a := &sessionAction{
 		timestamp: time.Now(),
@@ -259,7 +250,6 @@ func SessionActionLookup(props ...*sessionActionProps) *sessionAction {
 // SessionActionCreate returns "automation:session.create" action
 //
 // This function is auto-generated.
-//
 func SessionActionCreate(props ...*sessionActionProps) *sessionAction {
 	a := &sessionAction{
 		timestamp: time.Now(),
@@ -279,7 +269,6 @@ func SessionActionCreate(props ...*sessionActionProps) *sessionAction {
 // SessionActionUpdate returns "automation:session.update" action
 //
 // This function is auto-generated.
-//
 func SessionActionUpdate(props ...*sessionActionProps) *sessionAction {
 	a := &sessionAction{
 		timestamp: time.Now(),
@@ -299,7 +288,6 @@ func SessionActionUpdate(props ...*sessionActionProps) *sessionAction {
 // SessionActionDelete returns "automation:session.delete" action
 //
 // This function is auto-generated.
-//
 func SessionActionDelete(props ...*sessionActionProps) *sessionAction {
 	a := &sessionAction{
 		timestamp: time.Now(),
@@ -319,7 +307,6 @@ func SessionActionDelete(props ...*sessionActionProps) *sessionAction {
 // SessionActionUndelete returns "automation:session.undelete" action
 //
 // This function is auto-generated.
-//
 func SessionActionUndelete(props ...*sessionActionProps) *sessionAction {
 	a := &sessionAction{
 		timestamp: time.Now(),
@@ -342,9 +329,7 @@ func SessionActionUndelete(props ...*sessionActionProps) *sessionAction {
 
 // SessionErrGeneric returns "automation:session.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrGeneric(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -378,9 +363,7 @@ func SessionErrGeneric(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrNotFound returns "automation:session.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrNotFound(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -412,9 +395,7 @@ func SessionErrNotFound(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrInvalidID returns "automation:session.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrInvalidID(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -446,9 +427,7 @@ func SessionErrInvalidID(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrStaleData returns "automation:session.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrStaleData(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -480,9 +459,7 @@ func SessionErrStaleData(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrNotAllowedToRead returns "automation:session.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrNotAllowedToRead(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -516,9 +493,7 @@ func SessionErrNotAllowedToRead(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrNotAllowedToSearch returns "automation:session.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrNotAllowedToSearch(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -552,9 +527,7 @@ func SessionErrNotAllowedToSearch(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrNotAllowedToDelete returns "automation:session.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrNotAllowedToDelete(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -588,9 +561,7 @@ func SessionErrNotAllowedToDelete(mm ...*sessionActionProps) *errors.Error {
 
 // SessionErrNotAllowedToManage returns "automation:session.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SessionErrNotAllowedToManage(mm ...*sessionActionProps) *errors.Error {
 	var p = &sessionActionProps{}
 	if len(mm) > 0 {
@@ -630,7 +601,6 @@ func SessionErrNotAllowedToManage(mm ...*sessionActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc session) recordAction(ctx context.Context, props *sessionActionProps, actionFn func(...*sessionActionProps) *sessionAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/automation/service/trigger_actions.gen.go
+++ b/server/automation/service/trigger_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setTrigger updates triggerActionProps's trigger
 //
 // This function is auto-generated.
-//
 func (p *triggerActionProps) setTrigger(trigger *types.Trigger) *triggerActionProps {
 	p.trigger = trigger
 	return p
@@ -64,7 +63,6 @@ func (p *triggerActionProps) setTrigger(trigger *types.Trigger) *triggerActionPr
 // setNew updates triggerActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *triggerActionProps) setNew(new *types.Trigger) *triggerActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *triggerActionProps) setNew(new *types.Trigger) *triggerActionProps {
 // setUpdate updates triggerActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *triggerActionProps) setUpdate(update *types.Trigger) *triggerActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *triggerActionProps) setUpdate(update *types.Trigger) *triggerActionProp
 // setFilter updates triggerActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *triggerActionProps) setFilter(filter *types.TriggerFilter) *triggerActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *triggerActionProps) setFilter(filter *types.TriggerFilter) *triggerActi
 // Serialize converts triggerActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p triggerActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -115,7 +110,6 @@ func (p triggerActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p triggerActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -191,7 +185,6 @@ func (p triggerActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *triggerAction) String() string {
 	var props = &triggerActionProps{}
 
@@ -219,7 +212,6 @@ func (e *triggerAction) ToAction() *actionlog.Action {
 // TriggerActionSearch returns "automation:trigger.search" action
 //
 // This function is auto-generated.
-//
 func TriggerActionSearch(props ...*triggerActionProps) *triggerAction {
 	a := &triggerAction{
 		timestamp: time.Now(),
@@ -239,7 +231,6 @@ func TriggerActionSearch(props ...*triggerActionProps) *triggerAction {
 // TriggerActionLookup returns "automation:trigger.lookup" action
 //
 // This function is auto-generated.
-//
 func TriggerActionLookup(props ...*triggerActionProps) *triggerAction {
 	a := &triggerAction{
 		timestamp: time.Now(),
@@ -259,7 +250,6 @@ func TriggerActionLookup(props ...*triggerActionProps) *triggerAction {
 // TriggerActionCreate returns "automation:trigger.create" action
 //
 // This function is auto-generated.
-//
 func TriggerActionCreate(props ...*triggerActionProps) *triggerAction {
 	a := &triggerAction{
 		timestamp: time.Now(),
@@ -279,7 +269,6 @@ func TriggerActionCreate(props ...*triggerActionProps) *triggerAction {
 // TriggerActionUpdate returns "automation:trigger.update" action
 //
 // This function is auto-generated.
-//
 func TriggerActionUpdate(props ...*triggerActionProps) *triggerAction {
 	a := &triggerAction{
 		timestamp: time.Now(),
@@ -299,7 +288,6 @@ func TriggerActionUpdate(props ...*triggerActionProps) *triggerAction {
 // TriggerActionDelete returns "automation:trigger.delete" action
 //
 // This function is auto-generated.
-//
 func TriggerActionDelete(props ...*triggerActionProps) *triggerAction {
 	a := &triggerAction{
 		timestamp: time.Now(),
@@ -319,7 +307,6 @@ func TriggerActionDelete(props ...*triggerActionProps) *triggerAction {
 // TriggerActionUndelete returns "automation:trigger.undelete" action
 //
 // This function is auto-generated.
-//
 func TriggerActionUndelete(props ...*triggerActionProps) *triggerAction {
 	a := &triggerAction{
 		timestamp: time.Now(),
@@ -342,9 +329,7 @@ func TriggerActionUndelete(props ...*triggerActionProps) *triggerAction {
 
 // TriggerErrGeneric returns "automation:trigger.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrGeneric(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -378,9 +363,7 @@ func TriggerErrGeneric(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotFound returns "automation:trigger.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotFound(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -412,9 +395,7 @@ func TriggerErrNotFound(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrInvalidID returns "automation:trigger.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrInvalidID(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -446,9 +427,7 @@ func TriggerErrInvalidID(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrStaleData returns "automation:trigger.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrStaleData(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -480,9 +459,7 @@ func TriggerErrStaleData(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotAllowedToRead returns "automation:trigger.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotAllowedToRead(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -516,9 +493,7 @@ func TriggerErrNotAllowedToRead(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotAllowedToSearch returns "automation:trigger.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotAllowedToSearch(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -552,9 +527,7 @@ func TriggerErrNotAllowedToSearch(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotAllowedToCreate returns "automation:trigger.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotAllowedToCreate(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -588,9 +561,7 @@ func TriggerErrNotAllowedToCreate(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotAllowedToUpdate returns "automation:trigger.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotAllowedToUpdate(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -624,9 +595,7 @@ func TriggerErrNotAllowedToUpdate(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotAllowedToDelete returns "automation:trigger.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotAllowedToDelete(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -660,9 +629,7 @@ func TriggerErrNotAllowedToDelete(mm ...*triggerActionProps) *errors.Error {
 
 // TriggerErrNotAllowedToUndelete returns "automation:trigger.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TriggerErrNotAllowedToUndelete(mm ...*triggerActionProps) *errors.Error {
 	var p = &triggerActionProps{}
 	if len(mm) > 0 {
@@ -702,7 +669,6 @@ func TriggerErrNotAllowedToUndelete(mm ...*triggerActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc trigger) recordAction(ctx context.Context, props *triggerActionProps, actionFn func(...*triggerActionProps) *triggerAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/automation/service/workflow_actions.gen.go
+++ b/server/automation/service/workflow_actions.gen.go
@@ -56,7 +56,6 @@ var (
 // setWorkflow updates workflowActionProps's workflow
 //
 // This function is auto-generated.
-//
 func (p *workflowActionProps) setWorkflow(workflow *types.Workflow) *workflowActionProps {
 	p.workflow = workflow
 	return p
@@ -65,7 +64,6 @@ func (p *workflowActionProps) setWorkflow(workflow *types.Workflow) *workflowAct
 // setNew updates workflowActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *workflowActionProps) setNew(new *types.Workflow) *workflowActionProps {
 	p.new = new
 	return p
@@ -74,7 +72,6 @@ func (p *workflowActionProps) setNew(new *types.Workflow) *workflowActionProps {
 // setUpdate updates workflowActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *workflowActionProps) setUpdate(update *types.Workflow) *workflowActionProps {
 	p.update = update
 	return p
@@ -83,7 +80,6 @@ func (p *workflowActionProps) setUpdate(update *types.Workflow) *workflowActionP
 // setTrigger updates workflowActionProps's trigger
 //
 // This function is auto-generated.
-//
 func (p *workflowActionProps) setTrigger(trigger *types.Trigger) *workflowActionProps {
 	p.trigger = trigger
 	return p
@@ -92,7 +88,6 @@ func (p *workflowActionProps) setTrigger(trigger *types.Trigger) *workflowAction
 // setFilter updates workflowActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *workflowActionProps) setFilter(filter *types.WorkflowFilter) *workflowActionProps {
 	p.filter = filter
 	return p
@@ -101,7 +96,6 @@ func (p *workflowActionProps) setFilter(filter *types.WorkflowFilter) *workflowA
 // Serialize converts workflowActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p workflowActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -134,7 +128,6 @@ func (p workflowActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p workflowActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -234,7 +227,6 @@ func (p workflowActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *workflowAction) String() string {
 	var props = &workflowActionProps{}
 
@@ -262,7 +254,6 @@ func (e *workflowAction) ToAction() *actionlog.Action {
 // WorkflowActionSearch returns "automation:workflow.search" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionSearch(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -282,7 +273,6 @@ func WorkflowActionSearch(props ...*workflowActionProps) *workflowAction {
 // WorkflowActionLookup returns "automation:workflow.lookup" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionLookup(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -302,7 +292,6 @@ func WorkflowActionLookup(props ...*workflowActionProps) *workflowAction {
 // WorkflowActionCreate returns "automation:workflow.create" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionCreate(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -322,7 +311,6 @@ func WorkflowActionCreate(props ...*workflowActionProps) *workflowAction {
 // WorkflowActionUpdate returns "automation:workflow.update" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionUpdate(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -342,7 +330,6 @@ func WorkflowActionUpdate(props ...*workflowActionProps) *workflowAction {
 // WorkflowActionDelete returns "automation:workflow.delete" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionDelete(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -362,7 +349,6 @@ func WorkflowActionDelete(props ...*workflowActionProps) *workflowAction {
 // WorkflowActionUndelete returns "automation:workflow.undelete" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionUndelete(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -382,7 +368,6 @@ func WorkflowActionUndelete(props ...*workflowActionProps) *workflowAction {
 // WorkflowActionExecute returns "automation:workflow.execute" action
 //
 // This function is auto-generated.
-//
 func WorkflowActionExecute(props ...*workflowActionProps) *workflowAction {
 	a := &workflowAction{
 		timestamp: time.Now(),
@@ -405,9 +390,7 @@ func WorkflowActionExecute(props ...*workflowActionProps) *workflowAction {
 
 // WorkflowErrGeneric returns "automation:workflow.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrGeneric(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -441,9 +424,7 @@ func WorkflowErrGeneric(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotFound returns "automation:workflow.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotFound(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -475,9 +456,7 @@ func WorkflowErrNotFound(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrInvalidID returns "automation:workflow.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrInvalidID(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -509,9 +488,7 @@ func WorkflowErrInvalidID(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrDisabled returns "automation:workflow.disabled" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrDisabled(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -543,9 +520,7 @@ func WorkflowErrDisabled(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrInvalidHandle returns "automation:workflow.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrInvalidHandle(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -577,9 +552,7 @@ func WorkflowErrInvalidHandle(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrMissingName returns "automation:workflow.missingName" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrMissingName(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -611,9 +584,7 @@ func WorkflowErrMissingName(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrStaleData returns "automation:workflow.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrStaleData(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -645,9 +616,7 @@ func WorkflowErrStaleData(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToRead returns "automation:workflow.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToRead(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -681,9 +650,7 @@ func WorkflowErrNotAllowedToRead(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToSearch returns "automation:workflow.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToSearch(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -717,9 +684,7 @@ func WorkflowErrNotAllowedToSearch(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToCreate returns "automation:workflow.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToCreate(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -753,9 +718,7 @@ func WorkflowErrNotAllowedToCreate(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToUpdate returns "automation:workflow.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToUpdate(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -789,9 +752,7 @@ func WorkflowErrNotAllowedToUpdate(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToDelete returns "automation:workflow.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToDelete(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -825,9 +786,7 @@ func WorkflowErrNotAllowedToDelete(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToUndelete returns "automation:workflow.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToUndelete(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -861,9 +820,7 @@ func WorkflowErrNotAllowedToUndelete(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToExecute returns "automation:workflow.notAllowedToExecute" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToExecute(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -897,9 +854,7 @@ func WorkflowErrNotAllowedToExecute(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrUnknownWorkflowStep returns "automation:workflow.unknownWorkflowStep" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrUnknownWorkflowStep(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -933,9 +888,7 @@ func WorkflowErrUnknownWorkflowStep(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrHandleNotUnique returns "automation:workflow.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrHandleNotUnique(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -969,9 +922,7 @@ func WorkflowErrHandleNotUnique(mm ...*workflowActionProps) *errors.Error {
 
 // WorkflowErrNotAllowedToExecuteCorredorStep returns "automation:workflow.notAllowedToExecuteCorredorStep" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrNotAllowedToExecuteCorredorStep(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -1005,9 +956,7 @@ func WorkflowErrNotAllowedToExecuteCorredorStep(mm ...*workflowActionProps) *err
 
 // WorkflowErrMaximumCallStackSizeExceeded returns "automation:workflow.maximumCallStackSizeExceeded" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func WorkflowErrMaximumCallStackSizeExceeded(mm ...*workflowActionProps) *errors.Error {
 	var p = &workflowActionProps{}
 	if len(mm) > 0 {
@@ -1047,7 +996,6 @@ func WorkflowErrMaximumCallStackSizeExceeded(mm ...*workflowActionProps) *errors
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc workflow) recordAction(ctx context.Context, props *workflowActionProps, actionFn func(...*workflowActionProps) *workflowAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/automation/attachment_handler.gen.go
+++ b/server/compose/automation/attachment_handler.gen.go
@@ -50,9 +50,10 @@ type (
 // Lookup function Attachment lookup
 //
 // expects implementation of lookup function:
-// func (h attachmentHandler) lookup(ctx context.Context, args *attachmentLookupArgs) (results *attachmentLookupResults, err error) {
-//    return
-// }
+//
+//	func (h attachmentHandler) lookup(ctx context.Context, args *attachmentLookupArgs) (results *attachmentLookupResults, err error) {
+//	   return
+//	}
 func (h attachmentHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "attachmentLookup",
@@ -144,9 +145,10 @@ func (a attachmentCreateArgs) GetContent() (bool, string, io.Reader, []byte) {
 // Create function Create file and attach it to a resource
 //
 // expects implementation of create function:
-// func (h attachmentHandler) create(ctx context.Context, args *attachmentCreateArgs) (results *attachmentCreateResults, err error) {
-//    return
-// }
+//
+//	func (h attachmentHandler) create(ctx context.Context, args *attachmentCreateArgs) (results *attachmentCreateResults, err error) {
+//	   return
+//	}
 func (h attachmentHandler) Create() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "attachmentCreate",
@@ -245,9 +247,10 @@ type (
 // Delete function Delete attachment
 //
 // expects implementation of delete function:
-// func (h attachmentHandler) delete(ctx context.Context, args *attachmentDeleteArgs) (err error) {
-//    return
-// }
+//
+//	func (h attachmentHandler) delete(ctx context.Context, args *attachmentDeleteArgs) (err error) {
+//	   return
+//	}
 func (h attachmentHandler) Delete() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "attachmentDelete",
@@ -300,9 +303,10 @@ func (a attachmentOpenOriginalArgs) GetAttachment() (bool, uint64, *types.Attach
 // OpenOriginal function Open original attachment
 //
 // expects implementation of openOriginal function:
-// func (h attachmentHandler) openOriginal(ctx context.Context, args *attachmentOpenOriginalArgs) (results *attachmentOpenOriginalResults, err error) {
-//    return
-// }
+//
+//	func (h attachmentHandler) openOriginal(ctx context.Context, args *attachmentOpenOriginalArgs) (results *attachmentOpenOriginalResults, err error) {
+//	   return
+//	}
 func (h attachmentHandler) OpenOriginal() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "attachmentOpenOriginal",
@@ -394,9 +398,10 @@ func (a attachmentOpenPreviewArgs) GetAttachment() (bool, uint64, *types.Attachm
 // OpenPreview function Open attachment preview
 //
 // expects implementation of openPreview function:
-// func (h attachmentHandler) openPreview(ctx context.Context, args *attachmentOpenPreviewArgs) (results *attachmentOpenPreviewResults, err error) {
-//    return
-// }
+//
+//	func (h attachmentHandler) openPreview(ctx context.Context, args *attachmentOpenPreviewArgs) (results *attachmentOpenPreviewResults, err error) {
+//	   return
+//	}
 func (h attachmentHandler) OpenPreview() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "attachmentOpenPreview",

--- a/server/compose/automation/expr_types.gen.go
+++ b/server/compose/automation/expr_types.gen.go
@@ -78,7 +78,6 @@ func (t *Attachment) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access Attachment's underlying value (*types.Attachment)
 // and it's fields
-//
 func (t *Attachment) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -279,7 +278,6 @@ func (t *ComposeModule) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access ComposeModule's underlying value (*types.Module)
 // and it's fields
-//
 func (t *ComposeModule) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -474,7 +472,6 @@ func (t *ComposeNamespace) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access ComposeNamespace's underlying value (*types.Namespace)
 // and it's fields
-//
 func (t *ComposeNamespace) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()

--- a/server/compose/automation/modules_handler.gen.go
+++ b/server/compose/automation/modules_handler.gen.go
@@ -62,9 +62,10 @@ func (a modulesLookupArgs) GetNamespace() (bool, uint64, string, *types.Namespac
 // Lookup function Compose module lookup
 //
 // expects implementation of lookup function:
-// func (h modulesHandler) lookup(ctx context.Context, args *modulesLookupArgs) (results *modulesLookupResults, err error) {
-//    return
-// }
+//
+//	func (h modulesHandler) lookup(ctx context.Context, args *modulesLookupArgs) (results *modulesLookupResults, err error) {
+//	   return
+//	}
 func (h modulesHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeModulesLookup",

--- a/server/compose/automation/namespaces_handler.gen.go
+++ b/server/compose/automation/namespaces_handler.gen.go
@@ -52,9 +52,10 @@ func (a namespacesLookupArgs) GetNamespace() (bool, uint64, string, *types.Names
 // Lookup function Compose namespace lookup
 //
 // expects implementation of lookup function:
-// func (h namespacesHandler) lookup(ctx context.Context, args *namespacesLookupArgs) (results *namespacesLookupResults, err error) {
-//    return
-// }
+//
+//	func (h namespacesHandler) lookup(ctx context.Context, args *namespacesLookupArgs) (results *namespacesLookupResults, err error) {
+//	   return
+//	}
 func (h namespacesHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "composeNamespacesLookup",

--- a/server/compose/automation/records_handler.gen.go
+++ b/server/compose/automation/records_handler.gen.go
@@ -10,7 +10,6 @@ package automation
 
 import (
 	"context"
-
 	atypes "github.com/cortezaproject/corteza/server/automation/types"
 	"github.com/cortezaproject/corteza/server/compose/types"
 	"github.com/cortezaproject/corteza/server/pkg/expr"
@@ -508,7 +507,7 @@ func (a recordsFirstArgs) GetNamespace() (bool, uint64, string, *types.Namespace
 	return a.hasNamespace, a.namespaceID, a.namespaceHandle, a.namespaceRes
 }
 
-// First function Compose record lookup (first created)
+// First function Compose record lookup (oldest)
 //
 // expects implementation of first function:
 //
@@ -638,7 +637,7 @@ func (a recordsLastArgs) GetNamespace() (bool, uint64, string, *types.Namespace)
 	return a.hasNamespace, a.namespaceID, a.namespaceHandle, a.namespaceRes
 }
 
-// Last function Compose record lookup (last created)
+// Last function Compose record lookup (newest)
 //
 // expects implementation of last function:
 //

--- a/server/compose/service/access_control_actions.gen.go
+++ b/server/compose/service/access_control_actions.gen.go
@@ -52,7 +52,6 @@ var (
 // setRule updates accessControlActionProps's rule
 //
 // This function is auto-generated.
-//
 func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlActionProps {
 	p.rule = rule
 	return p
@@ -61,7 +60,6 @@ func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlAction
 // Serialize converts accessControlActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -80,7 +78,6 @@ func (p accessControlActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -129,7 +126,6 @@ func (p accessControlActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *accessControlAction) String() string {
 	var props = &accessControlActionProps{}
 
@@ -157,7 +153,6 @@ func (e *accessControlAction) ToAction() *actionlog.Action {
 // AccessControlActionGrant returns "compose:access_control.grant" action
 //
 // This function is auto-generated.
-//
 func AccessControlActionGrant(props ...*accessControlActionProps) *accessControlAction {
 	a := &accessControlAction{
 		timestamp: time.Now(),
@@ -180,9 +175,7 @@ func AccessControlActionGrant(props ...*accessControlActionProps) *accessControl
 
 // AccessControlErrGeneric returns "compose:access_control.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -216,9 +209,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 // AccessControlErrNotAllowedToSetPermissions returns "compose:access_control.notAllowedToSetPermissions" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -256,7 +247,6 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc accessControl) recordAction(ctx context.Context, props *accessControlActionProps, actionFn func(...*accessControlActionProps) *accessControlAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/service/attachment_actions.gen.go
+++ b/server/compose/service/attachment_actions.gen.go
@@ -61,7 +61,6 @@ var (
 // setSize updates attachmentActionProps's size
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setSize(size int64) *attachmentActionProps {
 	p.size = size
 	return p
@@ -70,7 +69,6 @@ func (p *attachmentActionProps) setSize(size int64) *attachmentActionProps {
 // setName updates attachmentActionProps's name
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setName(name string) *attachmentActionProps {
 	p.name = name
 	return p
@@ -79,7 +77,6 @@ func (p *attachmentActionProps) setName(name string) *attachmentActionProps {
 // setMimetype updates attachmentActionProps's mimetype
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setMimetype(mimetype string) *attachmentActionProps {
 	p.mimetype = mimetype
 	return p
@@ -88,7 +85,6 @@ func (p *attachmentActionProps) setMimetype(mimetype string) *attachmentActionPr
 // setUrl updates attachmentActionProps's url
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setUrl(url string) *attachmentActionProps {
 	p.url = url
 	return p
@@ -97,7 +93,6 @@ func (p *attachmentActionProps) setUrl(url string) *attachmentActionProps {
 // setAttachment updates attachmentActionProps's attachment
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setAttachment(attachment *types.Attachment) *attachmentActionProps {
 	p.attachment = attachment
 	return p
@@ -106,7 +101,6 @@ func (p *attachmentActionProps) setAttachment(attachment *types.Attachment) *att
 // setFilter updates attachmentActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setFilter(filter *types.AttachmentFilter) *attachmentActionProps {
 	p.filter = filter
 	return p
@@ -115,7 +109,6 @@ func (p *attachmentActionProps) setFilter(filter *types.AttachmentFilter) *attac
 // setNamespace updates attachmentActionProps's namespace
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setNamespace(namespace *types.Namespace) *attachmentActionProps {
 	p.namespace = namespace
 	return p
@@ -124,7 +117,6 @@ func (p *attachmentActionProps) setNamespace(namespace *types.Namespace) *attach
 // setRecord updates attachmentActionProps's record
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setRecord(record *types.Record) *attachmentActionProps {
 	p.record = record
 	return p
@@ -133,7 +125,6 @@ func (p *attachmentActionProps) setRecord(record *types.Record) *attachmentActio
 // setPage updates attachmentActionProps's page
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setPage(page *types.Page) *attachmentActionProps {
 	p.page = page
 	return p
@@ -142,7 +133,6 @@ func (p *attachmentActionProps) setPage(page *types.Page) *attachmentActionProps
 // setModule updates attachmentActionProps's module
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setModule(module *types.Module) *attachmentActionProps {
 	p.module = module
 	return p
@@ -151,7 +141,6 @@ func (p *attachmentActionProps) setModule(module *types.Module) *attachmentActio
 // Serialize converts attachmentActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p attachmentActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -203,7 +192,6 @@ func (p attachmentActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p attachmentActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -344,7 +332,6 @@ func (p attachmentActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *attachmentAction) String() string {
 	var props = &attachmentActionProps{}
 
@@ -372,7 +359,6 @@ func (e *attachmentAction) ToAction() *actionlog.Action {
 // AttachmentActionSearch returns "compose:attachment.search" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionSearch(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -392,7 +378,6 @@ func AttachmentActionSearch(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionLookup returns "compose:attachment.lookup" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionLookup(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -412,7 +397,6 @@ func AttachmentActionLookup(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionCreate returns "compose:attachment.create" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionCreate(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -432,7 +416,6 @@ func AttachmentActionCreate(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionDelete returns "compose:attachment.delete" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionDelete(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -455,9 +438,7 @@ func AttachmentActionDelete(props ...*attachmentActionProps) *attachmentAction {
 
 // AttachmentErrGeneric returns "compose:attachment.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrGeneric(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -491,9 +472,7 @@ func AttachmentErrGeneric(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotFound returns "compose:attachment.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -525,9 +504,7 @@ func AttachmentErrNotFound(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNamespaceNotFound returns "compose:attachment.namespaceNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNamespaceNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -559,9 +536,7 @@ func AttachmentErrNamespaceNotFound(mm ...*attachmentActionProps) *errors.Error 
 
 // AttachmentErrModuleNotFound returns "compose:attachment.moduleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrModuleNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -593,9 +568,7 @@ func AttachmentErrModuleNotFound(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrPageNotFound returns "compose:attachment.pageNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrPageNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -627,9 +600,7 @@ func AttachmentErrPageNotFound(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrRecordNotFound returns "compose:attachment.recordNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrRecordNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -661,9 +632,7 @@ func AttachmentErrRecordNotFound(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrInvalidID returns "compose:attachment.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -695,9 +664,7 @@ func AttachmentErrInvalidID(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrInvalidNamespaceID returns "compose:attachment.invalidNamespaceID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidNamespaceID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -729,9 +696,7 @@ func AttachmentErrInvalidNamespaceID(mm ...*attachmentActionProps) *errors.Error
 
 // AttachmentErrInvalidModuleID returns "compose:attachment.invalidModuleID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidModuleID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -763,9 +728,7 @@ func AttachmentErrInvalidModuleID(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrInvalidModuleField returns "compose:attachment.invalidModuleField" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidModuleField(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -797,9 +760,7 @@ func AttachmentErrInvalidModuleField(mm ...*attachmentActionProps) *errors.Error
 
 // AttachmentErrInvalidPageID returns "compose:attachment.invalidPageID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidPageID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -831,9 +792,7 @@ func AttachmentErrInvalidPageID(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrInvalidRecordID returns "compose:attachment.invalidRecordID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidRecordID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -865,9 +824,7 @@ func AttachmentErrInvalidRecordID(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrTooLarge returns "compose:attachment.tooLarge" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrTooLarge(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -901,9 +858,7 @@ func AttachmentErrTooLarge(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotAllowedToUploadThisType returns "compose:attachment.notAllowedToUploadThisType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToUploadThisType(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -937,9 +892,7 @@ func AttachmentErrNotAllowedToUploadThisType(mm ...*attachmentActionProps) *erro
 
 // AttachmentErrNotAllowedToListAttachments returns "compose:attachment.notAllowedToListAttachments" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToListAttachments(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -973,9 +926,7 @@ func AttachmentErrNotAllowedToListAttachments(mm ...*attachmentActionProps) *err
 
 // AttachmentErrNotAllowedToCreate returns "compose:attachment.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreate(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1009,9 +960,7 @@ func AttachmentErrNotAllowedToCreate(mm ...*attachmentActionProps) *errors.Error
 
 // AttachmentErrNotAllowedToCreateEmptyAttachment returns "compose:attachment.notAllowedToCreateEmptyAttachment" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreateEmptyAttachment(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1045,9 +994,7 @@ func AttachmentErrNotAllowedToCreateEmptyAttachment(mm ...*attachmentActionProps
 
 // AttachmentErrFailedToExtractMimeType returns "compose:attachment.failedToExtractMimeType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToExtractMimeType(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1079,9 +1026,7 @@ func AttachmentErrFailedToExtractMimeType(mm ...*attachmentActionProps) *errors.
 
 // AttachmentErrFailedToStoreFile returns "compose:attachment.failedToStoreFile" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToStoreFile(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1113,9 +1058,7 @@ func AttachmentErrFailedToStoreFile(mm ...*attachmentActionProps) *errors.Error 
 
 // AttachmentErrFailedToProcessImage returns "compose:attachment.failedToProcessImage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToProcessImage(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1147,9 +1090,7 @@ func AttachmentErrFailedToProcessImage(mm ...*attachmentActionProps) *errors.Err
 
 // AttachmentErrNotAllowedToRead returns "compose:attachment.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToRead(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1183,9 +1124,7 @@ func AttachmentErrNotAllowedToRead(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotAllowedToSearch returns "compose:attachment.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToSearch(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1219,9 +1158,7 @@ func AttachmentErrNotAllowedToSearch(mm ...*attachmentActionProps) *errors.Error
 
 // AttachmentErrNotAllowedToReadNamespace returns "compose:attachment.notAllowedToReadNamespace" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToReadNamespace(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1255,9 +1192,7 @@ func AttachmentErrNotAllowedToReadNamespace(mm ...*attachmentActionProps) *error
 
 // AttachmentErrNotAllowedToReadPage returns "compose:attachment.notAllowedToReadPage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToReadPage(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1291,9 +1226,7 @@ func AttachmentErrNotAllowedToReadPage(mm ...*attachmentActionProps) *errors.Err
 
 // AttachmentErrNotAllowedToReadRecord returns "compose:attachment.notAllowedToReadRecord" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToReadRecord(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1327,9 +1260,7 @@ func AttachmentErrNotAllowedToReadRecord(mm ...*attachmentActionProps) *errors.E
 
 // AttachmentErrNotAllowedToUpdatePage returns "compose:attachment.notAllowedToUpdatePage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToUpdatePage(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1363,9 +1294,7 @@ func AttachmentErrNotAllowedToUpdatePage(mm ...*attachmentActionProps) *errors.E
 
 // AttachmentErrNotAllowedToCreateRecords returns "compose:attachment.notAllowedToCreateRecords" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreateRecords(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1399,9 +1328,7 @@ func AttachmentErrNotAllowedToCreateRecords(mm ...*attachmentActionProps) *error
 
 // AttachmentErrNotAllowedToUpdateRecord returns "compose:attachment.notAllowedToUpdateRecord" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToUpdateRecord(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1435,9 +1362,7 @@ func AttachmentErrNotAllowedToUpdateRecord(mm ...*attachmentActionProps) *errors
 
 // AttachmentErrNotAllowedToUpdateNamespace returns "compose:attachment.notAllowedToUpdateNamespace" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToUpdateNamespace(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -1477,7 +1402,6 @@ func AttachmentErrNotAllowedToUpdateNamespace(mm ...*attachmentActionProps) *err
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc attachment) recordAction(ctx context.Context, props *attachmentActionProps, actionFn func(...*attachmentActionProps) *attachmentAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/service/chart_actions.gen.go
+++ b/server/compose/service/chart_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setChart updates chartActionProps's chart
 //
 // This function is auto-generated.
-//
 func (p *chartActionProps) setChart(chart *types.Chart) *chartActionProps {
 	p.chart = chart
 	return p
@@ -64,7 +63,6 @@ func (p *chartActionProps) setChart(chart *types.Chart) *chartActionProps {
 // setChanged updates chartActionProps's changed
 //
 // This function is auto-generated.
-//
 func (p *chartActionProps) setChanged(changed *types.Chart) *chartActionProps {
 	p.changed = changed
 	return p
@@ -73,7 +71,6 @@ func (p *chartActionProps) setChanged(changed *types.Chart) *chartActionProps {
 // setFilter updates chartActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *chartActionProps) setFilter(filter *types.ChartFilter) *chartActionProps {
 	p.filter = filter
 	return p
@@ -82,7 +79,6 @@ func (p *chartActionProps) setFilter(filter *types.ChartFilter) *chartActionProp
 // setNamespace updates chartActionProps's namespace
 //
 // This function is auto-generated.
-//
 func (p *chartActionProps) setNamespace(namespace *types.Namespace) *chartActionProps {
 	p.namespace = namespace
 	return p
@@ -91,7 +87,6 @@ func (p *chartActionProps) setNamespace(namespace *types.Namespace) *chartAction
 // Serialize converts chartActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p chartActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -129,7 +124,6 @@ func (p chartActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p chartActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -234,7 +228,6 @@ func (p chartActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *chartAction) String() string {
 	var props = &chartActionProps{}
 
@@ -262,7 +255,6 @@ func (e *chartAction) ToAction() *actionlog.Action {
 // ChartActionSearch returns "compose:chart.search" action
 //
 // This function is auto-generated.
-//
 func ChartActionSearch(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -282,7 +274,6 @@ func ChartActionSearch(props ...*chartActionProps) *chartAction {
 // ChartActionLookup returns "compose:chart.lookup" action
 //
 // This function is auto-generated.
-//
 func ChartActionLookup(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -302,7 +293,6 @@ func ChartActionLookup(props ...*chartActionProps) *chartAction {
 // ChartActionCreate returns "compose:chart.create" action
 //
 // This function is auto-generated.
-//
 func ChartActionCreate(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -322,7 +312,6 @@ func ChartActionCreate(props ...*chartActionProps) *chartAction {
 // ChartActionUpdate returns "compose:chart.update" action
 //
 // This function is auto-generated.
-//
 func ChartActionUpdate(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -342,7 +331,6 @@ func ChartActionUpdate(props ...*chartActionProps) *chartAction {
 // ChartActionDelete returns "compose:chart.delete" action
 //
 // This function is auto-generated.
-//
 func ChartActionDelete(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -362,7 +350,6 @@ func ChartActionDelete(props ...*chartActionProps) *chartAction {
 // ChartActionUndelete returns "compose:chart.undelete" action
 //
 // This function is auto-generated.
-//
 func ChartActionUndelete(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -382,7 +369,6 @@ func ChartActionUndelete(props ...*chartActionProps) *chartAction {
 // ChartActionReorder returns "compose:chart.reorder" action
 //
 // This function is auto-generated.
-//
 func ChartActionReorder(props ...*chartActionProps) *chartAction {
 	a := &chartAction{
 		timestamp: time.Now(),
@@ -405,9 +391,7 @@ func ChartActionReorder(props ...*chartActionProps) *chartAction {
 
 // ChartErrGeneric returns "compose:chart.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrGeneric(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -441,9 +425,7 @@ func ChartErrGeneric(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotFound returns "compose:chart.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotFound(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -475,9 +457,7 @@ func ChartErrNotFound(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNamespaceNotFound returns "compose:chart.namespaceNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNamespaceNotFound(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -509,9 +489,7 @@ func ChartErrNamespaceNotFound(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrModuleNotFound returns "compose:chart.moduleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrModuleNotFound(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -543,9 +521,7 @@ func ChartErrModuleNotFound(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrInvalidID returns "compose:chart.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrInvalidID(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -577,9 +553,7 @@ func ChartErrInvalidID(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrInvalidHandle returns "compose:chart.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrInvalidHandle(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -611,9 +585,7 @@ func ChartErrInvalidHandle(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrHandleNotUnique returns "compose:chart.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrHandleNotUnique(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -647,9 +619,7 @@ func ChartErrHandleNotUnique(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrStaleData returns "compose:chart.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrStaleData(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -681,9 +651,7 @@ func ChartErrStaleData(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrInvalidNamespaceID returns "compose:chart.invalidNamespaceID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrInvalidNamespaceID(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -715,9 +683,7 @@ func ChartErrInvalidNamespaceID(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToRead returns "compose:chart.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToRead(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -751,9 +717,7 @@ func ChartErrNotAllowedToRead(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToSearch returns "compose:chart.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToSearch(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -787,9 +751,7 @@ func ChartErrNotAllowedToSearch(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToReadNamespace returns "compose:chart.notAllowedToReadNamespace" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToReadNamespace(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -823,9 +785,7 @@ func ChartErrNotAllowedToReadNamespace(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToCreate returns "compose:chart.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToCreate(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -859,9 +819,7 @@ func ChartErrNotAllowedToCreate(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToUpdate returns "compose:chart.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToUpdate(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -895,9 +853,7 @@ func ChartErrNotAllowedToUpdate(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToDelete returns "compose:chart.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToDelete(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -931,9 +887,7 @@ func ChartErrNotAllowedToDelete(mm ...*chartActionProps) *errors.Error {
 
 // ChartErrNotAllowedToUndelete returns "compose:chart.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ChartErrNotAllowedToUndelete(mm ...*chartActionProps) *errors.Error {
 	var p = &chartActionProps{}
 	if len(mm) > 0 {
@@ -973,7 +927,6 @@ func ChartErrNotAllowedToUndelete(mm ...*chartActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc chart) recordAction(ctx context.Context, props *chartActionProps, actionFn func(...*chartActionProps) *chartAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/service/namespace_actions.gen.go
+++ b/server/compose/service/namespace_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setNamespace updates namespaceActionProps's namespace
 //
 // This function is auto-generated.
-//
 func (p *namespaceActionProps) setNamespace(namespace *types.Namespace) *namespaceActionProps {
 	p.namespace = namespace
 	return p
@@ -64,7 +63,6 @@ func (p *namespaceActionProps) setNamespace(namespace *types.Namespace) *namespa
 // setChanged updates namespaceActionProps's changed
 //
 // This function is auto-generated.
-//
 func (p *namespaceActionProps) setChanged(changed *types.Namespace) *namespaceActionProps {
 	p.changed = changed
 	return p
@@ -73,7 +71,6 @@ func (p *namespaceActionProps) setChanged(changed *types.Namespace) *namespaceAc
 // setArchiveFormat updates namespaceActionProps's archiveFormat
 //
 // This function is auto-generated.
-//
 func (p *namespaceActionProps) setArchiveFormat(archiveFormat string) *namespaceActionProps {
 	p.archiveFormat = archiveFormat
 	return p
@@ -82,7 +79,6 @@ func (p *namespaceActionProps) setArchiveFormat(archiveFormat string) *namespace
 // setFilter updates namespaceActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *namespaceActionProps) setFilter(filter *types.NamespaceFilter) *namespaceActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *namespaceActionProps) setFilter(filter *types.NamespaceFilter) *namespa
 // Serialize converts namespaceActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p namespaceActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -124,7 +119,6 @@ func (p namespaceActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p namespaceActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -212,7 +206,6 @@ func (p namespaceActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *namespaceAction) String() string {
 	var props = &namespaceActionProps{}
 
@@ -240,7 +233,6 @@ func (e *namespaceAction) ToAction() *actionlog.Action {
 // NamespaceActionSearch returns "compose:namespace.search" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionSearch(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -260,7 +252,6 @@ func NamespaceActionSearch(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionLookup returns "compose:namespace.lookup" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionLookup(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -280,7 +271,6 @@ func NamespaceActionLookup(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionCreate returns "compose:namespace.create" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionCreate(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -300,7 +290,6 @@ func NamespaceActionCreate(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionUpdate returns "compose:namespace.update" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionUpdate(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -320,7 +309,6 @@ func NamespaceActionUpdate(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionClone returns "compose:namespace.clone" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionClone(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -340,7 +328,6 @@ func NamespaceActionClone(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionExport returns "compose:namespace.export" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionExport(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -360,7 +347,6 @@ func NamespaceActionExport(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionImportInit returns "compose:namespace.importInit" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionImportInit(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -380,7 +366,6 @@ func NamespaceActionImportInit(props ...*namespaceActionProps) *namespaceAction 
 // NamespaceActionImportRun returns "compose:namespace.importRun" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionImportRun(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -400,7 +385,6 @@ func NamespaceActionImportRun(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionDelete returns "compose:namespace.delete" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionDelete(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -420,7 +404,6 @@ func NamespaceActionDelete(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionUndelete returns "compose:namespace.undelete" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionUndelete(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -440,7 +423,6 @@ func NamespaceActionUndelete(props ...*namespaceActionProps) *namespaceAction {
 // NamespaceActionReorder returns "compose:namespace.reorder" action
 //
 // This function is auto-generated.
-//
 func NamespaceActionReorder(props ...*namespaceActionProps) *namespaceAction {
 	a := &namespaceAction{
 		timestamp: time.Now(),
@@ -463,9 +445,7 @@ func NamespaceActionReorder(props ...*namespaceActionProps) *namespaceAction {
 
 // NamespaceErrGeneric returns "compose:namespace.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrGeneric(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -499,9 +479,7 @@ func NamespaceErrGeneric(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotFound returns "compose:namespace.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotFound(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -533,9 +511,7 @@ func NamespaceErrNotFound(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrInvalidID returns "compose:namespace.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrInvalidID(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -567,9 +543,7 @@ func NamespaceErrInvalidID(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrInvalidHandle returns "compose:namespace.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrInvalidHandle(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -601,9 +575,7 @@ func NamespaceErrInvalidHandle(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrHandleNotUnique returns "compose:namespace.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrHandleNotUnique(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -637,9 +609,7 @@ func NamespaceErrHandleNotUnique(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrStaleData returns "compose:namespace.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrStaleData(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -671,9 +641,7 @@ func NamespaceErrStaleData(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrUnsupportedExportFormat returns "compose:namespace.unsupportedExportFormat" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrUnsupportedExportFormat(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -707,9 +675,7 @@ func NamespaceErrUnsupportedExportFormat(mm ...*namespaceActionProps) *errors.Er
 
 // NamespaceErrUnsupportedImportFormat returns "compose:namespace.unsupportedImportFormat" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrUnsupportedImportFormat(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -743,9 +709,7 @@ func NamespaceErrUnsupportedImportFormat(mm ...*namespaceActionProps) *errors.Er
 
 // NamespaceErrImportMissingNamespace returns "compose:namespace.importMissingNamespace" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrImportMissingNamespace(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -779,9 +743,7 @@ func NamespaceErrImportMissingNamespace(mm ...*namespaceActionProps) *errors.Err
 
 // NamespaceErrImportSessionNotFound returns "compose:namespace.importSessionNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrImportSessionNotFound(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -815,9 +777,7 @@ func NamespaceErrImportSessionNotFound(mm ...*namespaceActionProps) *errors.Erro
 
 // NamespaceErrCloneMultiple returns "compose:namespace.cloneMultiple" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrCloneMultiple(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -851,9 +811,7 @@ func NamespaceErrCloneMultiple(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotAllowedToRead returns "compose:namespace.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotAllowedToRead(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -887,9 +845,7 @@ func NamespaceErrNotAllowedToRead(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotAllowedToSearch returns "compose:namespace.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotAllowedToSearch(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -923,9 +879,7 @@ func NamespaceErrNotAllowedToSearch(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotAllowedToCreate returns "compose:namespace.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotAllowedToCreate(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -959,9 +913,7 @@ func NamespaceErrNotAllowedToCreate(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotAllowedToUpdate returns "compose:namespace.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotAllowedToUpdate(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -995,9 +947,7 @@ func NamespaceErrNotAllowedToUpdate(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotAllowedToDelete returns "compose:namespace.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotAllowedToDelete(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -1031,9 +981,7 @@ func NamespaceErrNotAllowedToDelete(mm ...*namespaceActionProps) *errors.Error {
 
 // NamespaceErrNotAllowedToUndelete returns "compose:namespace.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NamespaceErrNotAllowedToUndelete(mm ...*namespaceActionProps) *errors.Error {
 	var p = &namespaceActionProps{}
 	if len(mm) > 0 {
@@ -1073,7 +1021,6 @@ func NamespaceErrNotAllowedToUndelete(mm ...*namespaceActionProps) *errors.Error
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc namespace) recordAction(ctx context.Context, props *namespaceActionProps, actionFn func(...*namespaceActionProps) *namespaceAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/service/notifications_actions.gen.go
+++ b/server/compose/service/notifications_actions.gen.go
@@ -56,7 +56,6 @@ var (
 // setMail updates notificationActionProps's mail
 //
 // This function is auto-generated.
-//
 func (p *notificationActionProps) setMail(mail *types.EmailNotification) *notificationActionProps {
 	p.mail = mail
 	return p
@@ -65,7 +64,6 @@ func (p *notificationActionProps) setMail(mail *types.EmailNotification) *notifi
 // setRecipient updates notificationActionProps's recipient
 //
 // This function is auto-generated.
-//
 func (p *notificationActionProps) setRecipient(recipient string) *notificationActionProps {
 	p.recipient = recipient
 	return p
@@ -74,7 +72,6 @@ func (p *notificationActionProps) setRecipient(recipient string) *notificationAc
 // setAttachmentURL updates notificationActionProps's attachmentURL
 //
 // This function is auto-generated.
-//
 func (p *notificationActionProps) setAttachmentURL(attachmentURL string) *notificationActionProps {
 	p.attachmentURL = attachmentURL
 	return p
@@ -83,7 +80,6 @@ func (p *notificationActionProps) setAttachmentURL(attachmentURL string) *notifi
 // setAttachmentSize updates notificationActionProps's attachmentSize
 //
 // This function is auto-generated.
-//
 func (p *notificationActionProps) setAttachmentSize(attachmentSize int64) *notificationActionProps {
 	p.attachmentSize = attachmentSize
 	return p
@@ -92,7 +88,6 @@ func (p *notificationActionProps) setAttachmentSize(attachmentSize int64) *notif
 // setAttachmentType updates notificationActionProps's attachmentType
 //
 // This function is auto-generated.
-//
 func (p *notificationActionProps) setAttachmentType(attachmentType string) *notificationActionProps {
 	p.attachmentType = attachmentType
 	return p
@@ -101,7 +96,6 @@ func (p *notificationActionProps) setAttachmentType(attachmentType string) *noti
 // Serialize converts notificationActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p notificationActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -127,7 +121,6 @@ func (p notificationActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p notificationActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -186,7 +179,6 @@ func (p notificationActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *notificationAction) String() string {
 	var props = &notificationActionProps{}
 
@@ -214,7 +206,6 @@ func (e *notificationAction) ToAction() *actionlog.Action {
 // NotificationActionSend returns "compose:notification.send" action
 //
 // This function is auto-generated.
-//
 func NotificationActionSend(props ...*notificationActionProps) *notificationAction {
 	a := &notificationAction{
 		timestamp: time.Now(),
@@ -234,7 +225,6 @@ func NotificationActionSend(props ...*notificationActionProps) *notificationActi
 // NotificationActionAttachmentDownload returns "compose:notification.attachmentDownload" action
 //
 // This function is auto-generated.
-//
 func NotificationActionAttachmentDownload(props ...*notificationActionProps) *notificationAction {
 	a := &notificationAction{
 		timestamp: time.Now(),
@@ -257,9 +247,7 @@ func NotificationActionAttachmentDownload(props ...*notificationActionProps) *no
 
 // NotificationErrGeneric returns "compose:notification.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NotificationErrGeneric(mm ...*notificationActionProps) *errors.Error {
 	var p = &notificationActionProps{}
 	if len(mm) > 0 {
@@ -293,9 +281,7 @@ func NotificationErrGeneric(mm ...*notificationActionProps) *errors.Error {
 
 // NotificationErrFailedToLoadUser returns "compose:notification.failedToLoadUser" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NotificationErrFailedToLoadUser(mm ...*notificationActionProps) *errors.Error {
 	var p = &notificationActionProps{}
 	if len(mm) > 0 {
@@ -327,9 +313,7 @@ func NotificationErrFailedToLoadUser(mm ...*notificationActionProps) *errors.Err
 
 // NotificationErrInvalidReceipientFormat returns "compose:notification.invalidReceipientFormat" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NotificationErrInvalidReceipientFormat(mm ...*notificationActionProps) *errors.Error {
 	var p = &notificationActionProps{}
 	if len(mm) > 0 {
@@ -361,9 +345,7 @@ func NotificationErrInvalidReceipientFormat(mm ...*notificationActionProps) *err
 
 // NotificationErrNoRecipients returns "compose:notification.noRecipients" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NotificationErrNoRecipients(mm ...*notificationActionProps) *errors.Error {
 	var p = &notificationActionProps{}
 	if len(mm) > 0 {
@@ -395,9 +377,7 @@ func NotificationErrNoRecipients(mm ...*notificationActionProps) *errors.Error {
 
 // NotificationErrFailedToDownloadAttachment returns "compose:notification.failedToDownloadAttachment" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NotificationErrFailedToDownloadAttachment(mm ...*notificationActionProps) *errors.Error {
 	var p = &notificationActionProps{}
 	if len(mm) > 0 {
@@ -435,7 +415,6 @@ func NotificationErrFailedToDownloadAttachment(mm ...*notificationActionProps) *
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc notification) recordAction(ctx context.Context, props *notificationActionProps, actionFn func(...*notificationActionProps) *notificationAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/service/page_actions.gen.go
+++ b/server/compose/service/page_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setPage updates pageActionProps's page
 //
 // This function is auto-generated.
-//
 func (p *pageActionProps) setPage(page *types.Page) *pageActionProps {
 	p.page = page
 	return p
@@ -64,7 +63,6 @@ func (p *pageActionProps) setPage(page *types.Page) *pageActionProps {
 // setChanged updates pageActionProps's changed
 //
 // This function is auto-generated.
-//
 func (p *pageActionProps) setChanged(changed *types.Page) *pageActionProps {
 	p.changed = changed
 	return p
@@ -73,7 +71,6 @@ func (p *pageActionProps) setChanged(changed *types.Page) *pageActionProps {
 // setFilter updates pageActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *pageActionProps) setFilter(filter *types.PageFilter) *pageActionProps {
 	p.filter = filter
 	return p
@@ -82,7 +79,6 @@ func (p *pageActionProps) setFilter(filter *types.PageFilter) *pageActionProps {
 // setNamespace updates pageActionProps's namespace
 //
 // This function is auto-generated.
-//
 func (p *pageActionProps) setNamespace(namespace *types.Namespace) *pageActionProps {
 	p.namespace = namespace
 	return p
@@ -91,7 +87,6 @@ func (p *pageActionProps) setNamespace(namespace *types.Namespace) *pageActionPr
 // Serialize converts pageActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p pageActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -136,7 +131,6 @@ func (p pageActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p pageActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -255,7 +249,6 @@ func (p pageActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *pageAction) String() string {
 	var props = &pageActionProps{}
 
@@ -283,7 +276,6 @@ func (e *pageAction) ToAction() *actionlog.Action {
 // PageActionSearch returns "compose:page.search" action
 //
 // This function is auto-generated.
-//
 func PageActionSearch(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -303,7 +295,6 @@ func PageActionSearch(props ...*pageActionProps) *pageAction {
 // PageActionLookup returns "compose:page.lookup" action
 //
 // This function is auto-generated.
-//
 func PageActionLookup(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -323,7 +314,6 @@ func PageActionLookup(props ...*pageActionProps) *pageAction {
 // PageActionCreate returns "compose:page.create" action
 //
 // This function is auto-generated.
-//
 func PageActionCreate(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -343,7 +333,6 @@ func PageActionCreate(props ...*pageActionProps) *pageAction {
 // PageActionUpdate returns "compose:page.update" action
 //
 // This function is auto-generated.
-//
 func PageActionUpdate(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -363,7 +352,6 @@ func PageActionUpdate(props ...*pageActionProps) *pageAction {
 // PageActionDelete returns "compose:page.delete" action
 //
 // This function is auto-generated.
-//
 func PageActionDelete(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -383,7 +371,6 @@ func PageActionDelete(props ...*pageActionProps) *pageAction {
 // PageActionUndelete returns "compose:page.undelete" action
 //
 // This function is auto-generated.
-//
 func PageActionUndelete(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -403,7 +390,6 @@ func PageActionUndelete(props ...*pageActionProps) *pageAction {
 // PageActionReorder returns "compose:page.reorder" action
 //
 // This function is auto-generated.
-//
 func PageActionReorder(props ...*pageActionProps) *pageAction {
 	a := &pageAction{
 		timestamp: time.Now(),
@@ -426,9 +412,7 @@ func PageActionReorder(props ...*pageActionProps) *pageAction {
 
 // PageErrGeneric returns "compose:page.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrGeneric(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -462,9 +446,7 @@ func PageErrGeneric(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotFound returns "compose:page.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotFound(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -496,9 +478,7 @@ func PageErrNotFound(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNamespaceNotFound returns "compose:page.namespaceNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNamespaceNotFound(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -530,9 +510,7 @@ func PageErrNamespaceNotFound(mm ...*pageActionProps) *errors.Error {
 
 // PageErrModuleNotFound returns "compose:page.moduleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrModuleNotFound(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -564,9 +542,7 @@ func PageErrModuleNotFound(mm ...*pageActionProps) *errors.Error {
 
 // PageErrInvalidID returns "compose:page.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrInvalidID(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -598,9 +574,7 @@ func PageErrInvalidID(mm ...*pageActionProps) *errors.Error {
 
 // PageErrInvalidHandle returns "compose:page.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrInvalidHandle(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -632,9 +606,7 @@ func PageErrInvalidHandle(mm ...*pageActionProps) *errors.Error {
 
 // PageErrHandleNotUnique returns "compose:page.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrHandleNotUnique(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -668,9 +640,7 @@ func PageErrHandleNotUnique(mm ...*pageActionProps) *errors.Error {
 
 // PageErrStaleData returns "compose:page.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrStaleData(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -702,9 +672,7 @@ func PageErrStaleData(mm ...*pageActionProps) *errors.Error {
 
 // PageErrInvalidNamespaceID returns "compose:page.invalidNamespaceID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrInvalidNamespaceID(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -736,9 +704,7 @@ func PageErrInvalidNamespaceID(mm ...*pageActionProps) *errors.Error {
 
 // PageErrDeleteAbortedForPageWithSubpages returns "compose:page.deleteAbortedForPageWithSubpages" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrDeleteAbortedForPageWithSubpages(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -770,9 +736,7 @@ func PageErrDeleteAbortedForPageWithSubpages(mm ...*pageActionProps) *errors.Err
 
 // PageErrUnknownDeleteStrategy returns "compose:page.unknownDeleteStrategy" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrUnknownDeleteStrategy(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -804,9 +768,7 @@ func PageErrUnknownDeleteStrategy(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToRead returns "compose:page.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToRead(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -840,9 +802,7 @@ func PageErrNotAllowedToRead(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToSearch returns "compose:page.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToSearch(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -876,9 +836,7 @@ func PageErrNotAllowedToSearch(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToReadNamespace returns "compose:page.notAllowedToReadNamespace" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToReadNamespace(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -912,9 +870,7 @@ func PageErrNotAllowedToReadNamespace(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToListPages returns "compose:page.notAllowedToListPages" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToListPages(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -948,9 +904,7 @@ func PageErrNotAllowedToListPages(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToCreate returns "compose:page.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToCreate(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -984,9 +938,7 @@ func PageErrNotAllowedToCreate(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToUpdate returns "compose:page.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToUpdate(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -1020,9 +972,7 @@ func PageErrNotAllowedToUpdate(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToDelete returns "compose:page.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToDelete(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -1056,9 +1006,7 @@ func PageErrNotAllowedToDelete(mm ...*pageActionProps) *errors.Error {
 
 // PageErrNotAllowedToUndelete returns "compose:page.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageErrNotAllowedToUndelete(mm ...*pageActionProps) *errors.Error {
 	var p = &pageActionProps{}
 	if len(mm) > 0 {
@@ -1098,7 +1046,6 @@ func PageErrNotAllowedToUndelete(mm ...*pageActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc page) recordAction(ctx context.Context, props *pageActionProps, actionFn func(...*pageActionProps) *pageAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/compose/service/page_layout_actions.gen.go
+++ b/server/compose/service/page_layout_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setPageLayout updates pageLayoutActionProps's pageLayout
 //
 // This function is auto-generated.
-//
 func (p *pageLayoutActionProps) setPageLayout(pageLayout *types.PageLayout) *pageLayoutActionProps {
 	p.pageLayout = pageLayout
 	return p
@@ -64,7 +63,6 @@ func (p *pageLayoutActionProps) setPageLayout(pageLayout *types.PageLayout) *pag
 // setChanged updates pageLayoutActionProps's changed
 //
 // This function is auto-generated.
-//
 func (p *pageLayoutActionProps) setChanged(changed *types.PageLayout) *pageLayoutActionProps {
 	p.changed = changed
 	return p
@@ -73,7 +71,6 @@ func (p *pageLayoutActionProps) setChanged(changed *types.PageLayout) *pageLayou
 // setFilter updates pageLayoutActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *pageLayoutActionProps) setFilter(filter *types.PageLayoutFilter) *pageLayoutActionProps {
 	p.filter = filter
 	return p
@@ -82,7 +79,6 @@ func (p *pageLayoutActionProps) setFilter(filter *types.PageLayoutFilter) *pageL
 // setNamespace updates pageLayoutActionProps's namespace
 //
 // This function is auto-generated.
-//
 func (p *pageLayoutActionProps) setNamespace(namespace *types.Namespace) *pageLayoutActionProps {
 	p.namespace = namespace
 	return p
@@ -91,7 +87,6 @@ func (p *pageLayoutActionProps) setNamespace(namespace *types.Namespace) *pageLa
 // Serialize converts pageLayoutActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p pageLayoutActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -126,7 +121,6 @@ func (p pageLayoutActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p pageLayoutActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -225,7 +219,6 @@ func (p pageLayoutActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *pageLayoutAction) String() string {
 	var props = &pageLayoutActionProps{}
 
@@ -253,7 +246,6 @@ func (e *pageLayoutAction) ToAction() *actionlog.Action {
 // PageLayoutActionSearch returns "compose:page-layout.search" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionSearch(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -273,7 +265,6 @@ func PageLayoutActionSearch(props ...*pageLayoutActionProps) *pageLayoutAction {
 // PageLayoutActionLookup returns "compose:page-layout.lookup" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionLookup(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -293,7 +284,6 @@ func PageLayoutActionLookup(props ...*pageLayoutActionProps) *pageLayoutAction {
 // PageLayoutActionCreate returns "compose:page-layout.create" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionCreate(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -313,7 +303,6 @@ func PageLayoutActionCreate(props ...*pageLayoutActionProps) *pageLayoutAction {
 // PageLayoutActionUpdate returns "compose:page-layout.update" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionUpdate(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -333,7 +322,6 @@ func PageLayoutActionUpdate(props ...*pageLayoutActionProps) *pageLayoutAction {
 // PageLayoutActionReorder returns "compose:page-layout.reorder" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionReorder(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -353,7 +341,6 @@ func PageLayoutActionReorder(props ...*pageLayoutActionProps) *pageLayoutAction 
 // PageLayoutActionDelete returns "compose:page-layout.delete" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionDelete(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -373,7 +360,6 @@ func PageLayoutActionDelete(props ...*pageLayoutActionProps) *pageLayoutAction {
 // PageLayoutActionUndelete returns "compose:page-layout.undelete" action
 //
 // This function is auto-generated.
-//
 func PageLayoutActionUndelete(props ...*pageLayoutActionProps) *pageLayoutAction {
 	a := &pageLayoutAction{
 		timestamp: time.Now(),
@@ -396,9 +382,7 @@ func PageLayoutActionUndelete(props ...*pageLayoutActionProps) *pageLayoutAction
 
 // PageLayoutErrGeneric returns "compose:page-layout.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrGeneric(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -432,9 +416,7 @@ func PageLayoutErrGeneric(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrNotFound returns "compose:page-layout.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotFound(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -466,9 +448,7 @@ func PageLayoutErrNotFound(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrNamespaceNotFound returns "compose:page-layout.namespaceNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNamespaceNotFound(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -500,9 +480,7 @@ func PageLayoutErrNamespaceNotFound(mm ...*pageLayoutActionProps) *errors.Error 
 
 // PageLayoutErrModuleNotFound returns "compose:page-layout.moduleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrModuleNotFound(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -534,9 +512,7 @@ func PageLayoutErrModuleNotFound(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrInvalidID returns "compose:page-layout.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrInvalidID(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -568,9 +544,7 @@ func PageLayoutErrInvalidID(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrInvalidHandle returns "compose:page-layout.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrInvalidHandle(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -602,9 +576,7 @@ func PageLayoutErrInvalidHandle(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrHandleNotUnique returns "compose:page-layout.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrHandleNotUnique(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -638,9 +610,7 @@ func PageLayoutErrHandleNotUnique(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrStaleData returns "compose:page-layout.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrStaleData(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -672,9 +642,7 @@ func PageLayoutErrStaleData(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrInvalidNamespaceID returns "compose:page-layout.invalidNamespaceID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrInvalidNamespaceID(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -706,9 +674,7 @@ func PageLayoutErrInvalidNamespaceID(mm ...*pageLayoutActionProps) *errors.Error
 
 // PageLayoutErrNotAllowedToRead returns "compose:page-layout.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToRead(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -742,9 +708,7 @@ func PageLayoutErrNotAllowedToRead(mm ...*pageLayoutActionProps) *errors.Error {
 
 // PageLayoutErrNotAllowedToSearch returns "compose:page-layout.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToSearch(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -778,9 +742,7 @@ func PageLayoutErrNotAllowedToSearch(mm ...*pageLayoutActionProps) *errors.Error
 
 // PageLayoutErrNotAllowedToListPageLayouts returns "compose:page-layout.notAllowedToListPageLayouts" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToListPageLayouts(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -814,9 +776,7 @@ func PageLayoutErrNotAllowedToListPageLayouts(mm ...*pageLayoutActionProps) *err
 
 // PageLayoutErrNotAllowedToCreate returns "compose:page-layout.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToCreate(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -850,9 +810,7 @@ func PageLayoutErrNotAllowedToCreate(mm ...*pageLayoutActionProps) *errors.Error
 
 // PageLayoutErrNotAllowedToUpdate returns "compose:page-layout.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToUpdate(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -886,9 +844,7 @@ func PageLayoutErrNotAllowedToUpdate(mm ...*pageLayoutActionProps) *errors.Error
 
 // PageLayoutErrNotAllowedToDelete returns "compose:page-layout.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToDelete(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -922,9 +878,7 @@ func PageLayoutErrNotAllowedToDelete(mm ...*pageLayoutActionProps) *errors.Error
 
 // PageLayoutErrNotAllowedToUndelete returns "compose:page-layout.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func PageLayoutErrNotAllowedToUndelete(mm ...*pageLayoutActionProps) *errors.Error {
 	var p = &pageLayoutActionProps{}
 	if len(mm) > 0 {
@@ -964,7 +918,6 @@ func PageLayoutErrNotAllowedToUndelete(mm ...*pageLayoutActionProps) *errors.Err
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc pageLayout) recordAction(ctx context.Context, props *pageLayoutActionProps, actionFn func(...*pageLayoutActionProps) *pageLayoutAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/discovery/rest/internal/documents/compose.go
+++ b/server/discovery/rest/internal/documents/compose.go
@@ -3,6 +3,7 @@ package documents
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	cmpService "github.com/cortezaproject/corteza/server/compose/service"
 	cmpTypes "github.com/cortezaproject/corteza/server/compose/types"
@@ -168,7 +169,12 @@ func (d composeResources) Namespaces(ctx context.Context, limit uint, cur string
 				},
 			}
 
-			doc.Security.AllowedRoles, doc.Security.DeniedRoles = d.rbac.SignificantRoles(ns, "read")
+			allowedRoles, deniedRoles := d.rbac.SignificantRoles(ns, "read")
+
+			doc.Security = append(doc.Security, docSecurity{
+				AllowedRoles: stringifyUints64(allowedRoles),
+				DeniedRoles:  stringifyUints64(deniedRoles),
+			})
 
 			rsp.Documents[i].Source = doc
 		}
@@ -255,7 +261,12 @@ func (d composeResources) Modules(ctx context.Context, namespaceID uint64, limit
 				},
 			}
 
-			doc.Security.AllowedRoles, doc.Security.DeniedRoles = d.rbac.SignificantRoles(mod, "read")
+			allowedRoles, deniedRoles := d.rbac.SignificantRoles(mod, "read")
+
+			doc.Security = append(doc.Security, docSecurity{
+				AllowedRoles: stringifyUints64(allowedRoles),
+				DeniedRoles:  stringifyUints64(deniedRoles),
+			})
 
 			rsp.Documents[i].Source = doc
 		}
@@ -378,7 +389,12 @@ func (d composeResources) Records(ctx context.Context, namespaceID, moduleID uin
 			// Values and value labels
 			doc.Values, doc.ValueLabels = d.recordValues(ctx, rec, mod.Fields)
 
-			doc.Security.AllowedRoles, doc.Security.DeniedRoles = d.rbac.SignificantRoles(rec, "read")
+			allowedRoles, deniedRoles := d.rbac.SignificantRoles(rec, "read")
+
+			doc.Security = append(doc.Security, docSecurity{
+				AllowedRoles: stringifyUints64(allowedRoles),
+				DeniedRoles:  stringifyUints64(deniedRoles),
+			})
 
 			rsp.Documents[i].Source = doc
 		}
@@ -483,4 +499,12 @@ func (d composeResources) getUserInfo(ctx context.Context, ID uint64, users map[
 		}
 		return u, users, err
 	}
+}
+
+func stringifyUints64(uints []uint64) []string {
+	strings := make([]string, len(uints))
+	for i, num := range uints {
+		strings[i] = strconv.FormatUint(num, 10)
+	}
+	return strings
 }

--- a/server/discovery/rest/internal/documents/documents.go
+++ b/server/discovery/rest/internal/documents/documents.go
@@ -1,9 +1,10 @@
 package documents
 
 import (
+	"time"
+
 	"github.com/cortezaproject/corteza/server/pkg/filter"
 	sysTypes "github.com/cortezaproject/corteza/server/system/types"
-	"time"
 )
 
 type (
@@ -47,7 +48,7 @@ type (
 		Updated      *docPartialChange `json:"updated,omitempty"`
 		Created      *docPartialChange `json:"created,omitempty"`
 		Deleted      *docPartialChange `json:"deleted,omitempty"`
-		Security     docSecurity       `json:"security"`
+		Security     []docSecurity     `json:"security"`
 	}
 
 	docComposeNamespace struct {
@@ -62,7 +63,7 @@ type (
 		Updated  *docPartialChange `json:"updated,omitempty"`
 		Created  *docPartialChange `json:"created,omitempty"`
 		Deleted  *docPartialChange `json:"deleted,omitempty"`
-		Security docSecurity       `json:"security"`
+		Security []docSecurity     `json:"security"`
 
 		// Aggregation update
 		Namespace docPartialComposeNamespace `json:"namespace"`
@@ -90,7 +91,7 @@ type (
 		Updated      *docPartialChange               `json:"updated,omitempty"`
 		Created      *docPartialChange               `json:"created,omitempty"`
 		Deleted      *docPartialChange               `json:"deleted,omitempty"`
-		Security     docSecurity                     `json:"security"`
+		Security     []docSecurity                   `json:"security"`
 
 		// Aggregation update
 		Namespace docPartialComposeNamespace `json:"namespace"`
@@ -118,7 +119,7 @@ type (
 		Updated      *docPartialChange        `json:"updated,omitempty"`
 		Created      *docPartialChange        `json:"created,omitempty"`
 		Deleted      *docPartialChange        `json:"deleted,omitempty"`
-		Security     docSecurity              `json:"security"`
+		Security     []docSecurity            `json:"security"`
 
 		// Aggregation update
 		Namespace docPartialComposeNamespace `json:"namespace"`
@@ -127,10 +128,10 @@ type (
 
 	docSecurity struct {
 		// list of roles that are allowed to read the resource
-		AllowedRoles []uint64 `json:"allowedRoles"`
+		AllowedRoles []string `json:"allowedRoles"`
 
 		// list of roles that are disallowed to read the resource
-		DeniedRoles []uint64 `json:"deniedRoles"`
+		DeniedRoles []string `json:"deniedRoles"`
 	}
 )
 

--- a/server/discovery/rest/internal/documents/system.go
+++ b/server/discovery/rest/internal/documents/system.go
@@ -92,7 +92,12 @@ func (d systemResources) Users(ctx context.Context, limit uint, cur string, user
 				doc.Url = fmt.Sprintf("%s/admin/system/user/edit/%d", d.opt.CortezaDomain, u.ID)
 			}
 
-			doc.Security.AllowedRoles, doc.Security.DeniedRoles = d.rbac.SignificantRoles(u, "read")
+			allowedRoles, deniedRoles := d.rbac.SignificantRoles(u, "read")
+
+			doc.Security = append(doc.Security, docSecurity{
+				AllowedRoles: stringifyUints64(allowedRoles),
+				DeniedRoles:  stringifyUints64(deniedRoles),
+			})
 
 			rsp.Documents[i].ID = u.ID
 			rsp.Documents[i].Source = doc

--- a/server/discovery/rest/internal/feed/resource.go
+++ b/server/discovery/rest/internal/feed/resource.go
@@ -2,12 +2,13 @@ package feed
 
 import (
 	"context"
+	"time"
+
 	"github.com/cortezaproject/corteza/server/discovery/service"
 	"github.com/cortezaproject/corteza/server/discovery/types"
 	"github.com/cortezaproject/corteza/server/pkg/errors"
 	"github.com/cortezaproject/corteza/server/pkg/filter"
 	"github.com/cortezaproject/corteza/server/pkg/options"
-	"time"
 
 	"github.com/cortezaproject/corteza/server/pkg/rbac"
 )
@@ -55,6 +56,13 @@ func (a resourceActivity) ResourceActivities(ctx context.Context, limit uint, cu
 		if from.After(*to) {
 			return errors.Internal("invalid from timestamp, it must be before to timestamp")
 		}
+
+		// Ensure both 'from' and 'to' are in UTC
+		utcFrom := from.UTC()
+		utcTo := to.UTC()
+
+		from = &utcFrom
+		to = &utcTo
 
 		f.FromTimestamp = from
 		f.ToTimestamp = to

--- a/server/discovery/rest/internal/mapping/mapping.go
+++ b/server/discovery/rest/internal/mapping/mapping.go
@@ -39,7 +39,6 @@ func change() *property {
 
 func security() *property {
 	return &property{
-		Type: "nested",
 		Properties: map[string]*property{
 			"allowedRoles": {Type: "long"},
 			"deniedRoles":  {Type: "long"},

--- a/server/federation/service/access_control_actions.gen.go
+++ b/server/federation/service/access_control_actions.gen.go
@@ -52,7 +52,6 @@ var (
 // setRule updates accessControlActionProps's rule
 //
 // This function is auto-generated.
-//
 func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlActionProps {
 	p.rule = rule
 	return p
@@ -61,7 +60,6 @@ func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlAction
 // Serialize converts accessControlActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -80,7 +78,6 @@ func (p accessControlActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -129,7 +126,6 @@ func (p accessControlActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *accessControlAction) String() string {
 	var props = &accessControlActionProps{}
 
@@ -157,7 +153,6 @@ func (e *accessControlAction) ToAction() *actionlog.Action {
 // AccessControlActionGrant returns "federation:access_control.grant" action
 //
 // This function is auto-generated.
-//
 func AccessControlActionGrant(props ...*accessControlActionProps) *accessControlAction {
 	a := &accessControlAction{
 		timestamp: time.Now(),
@@ -180,9 +175,7 @@ func AccessControlActionGrant(props ...*accessControlActionProps) *accessControl
 
 // AccessControlErrGeneric returns "federation:access_control.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -216,9 +209,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 // AccessControlErrNotAllowedToSetPermissions returns "federation:access_control.notAllowedToSetPermissions" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -256,7 +247,6 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc accessControl) recordAction(ctx context.Context, props *accessControlActionProps, actionFn func(...*accessControlActionProps) *accessControlAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/federation/service/exposed_module_actions.gen.go
+++ b/server/federation/service/exposed_module_actions.gen.go
@@ -57,7 +57,6 @@ var (
 // setModule updates exposedModuleActionProps's module
 //
 // This function is auto-generated.
-//
 func (p *exposedModuleActionProps) setModule(module *types.ExposedModule) *exposedModuleActionProps {
 	p.module = module
 	return p
@@ -66,7 +65,6 @@ func (p *exposedModuleActionProps) setModule(module *types.ExposedModule) *expos
 // setUpdate updates exposedModuleActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *exposedModuleActionProps) setUpdate(update *types.ExposedModule) *exposedModuleActionProps {
 	p.update = update
 	return p
@@ -75,7 +73,6 @@ func (p *exposedModuleActionProps) setUpdate(update *types.ExposedModule) *expos
 // setCreate updates exposedModuleActionProps's create
 //
 // This function is auto-generated.
-//
 func (p *exposedModuleActionProps) setCreate(create *types.ExposedModule) *exposedModuleActionProps {
 	p.create = create
 	return p
@@ -84,7 +81,6 @@ func (p *exposedModuleActionProps) setCreate(create *types.ExposedModule) *expos
 // setDelete updates exposedModuleActionProps's delete
 //
 // This function is auto-generated.
-//
 func (p *exposedModuleActionProps) setDelete(delete *types.ExposedModule) *exposedModuleActionProps {
 	p.delete = delete
 	return p
@@ -93,7 +89,6 @@ func (p *exposedModuleActionProps) setDelete(delete *types.ExposedModule) *expos
 // setFilter updates exposedModuleActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *exposedModuleActionProps) setFilter(filter *types.ExposedModuleFilter) *exposedModuleActionProps {
 	p.filter = filter
 	return p
@@ -102,7 +97,6 @@ func (p *exposedModuleActionProps) setFilter(filter *types.ExposedModuleFilter) 
 // setNode updates exposedModuleActionProps's node
 //
 // This function is auto-generated.
-//
 func (p *exposedModuleActionProps) setNode(node *types.Node) *exposedModuleActionProps {
 	p.node = node
 	return p
@@ -111,7 +105,6 @@ func (p *exposedModuleActionProps) setNode(node *types.Node) *exposedModuleActio
 // Serialize converts exposedModuleActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p exposedModuleActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -157,7 +150,6 @@ func (p exposedModuleActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p exposedModuleActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -290,7 +282,6 @@ func (p exposedModuleActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *exposedModuleAction) String() string {
 	var props = &exposedModuleActionProps{}
 
@@ -318,7 +309,6 @@ func (e *exposedModuleAction) ToAction() *actionlog.Action {
 // ExposedModuleActionSearch returns "federation:exposed_module.search" action
 //
 // This function is auto-generated.
-//
 func ExposedModuleActionSearch(props ...*exposedModuleActionProps) *exposedModuleAction {
 	a := &exposedModuleAction{
 		timestamp: time.Now(),
@@ -338,7 +328,6 @@ func ExposedModuleActionSearch(props ...*exposedModuleActionProps) *exposedModul
 // ExposedModuleActionLookup returns "federation:exposed_module.lookup" action
 //
 // This function is auto-generated.
-//
 func ExposedModuleActionLookup(props ...*exposedModuleActionProps) *exposedModuleAction {
 	a := &exposedModuleAction{
 		timestamp: time.Now(),
@@ -358,7 +347,6 @@ func ExposedModuleActionLookup(props ...*exposedModuleActionProps) *exposedModul
 // ExposedModuleActionCreate returns "federation:exposed_module.create" action
 //
 // This function is auto-generated.
-//
 func ExposedModuleActionCreate(props ...*exposedModuleActionProps) *exposedModuleAction {
 	a := &exposedModuleAction{
 		timestamp: time.Now(),
@@ -378,7 +366,6 @@ func ExposedModuleActionCreate(props ...*exposedModuleActionProps) *exposedModul
 // ExposedModuleActionUpdate returns "federation:exposed_module.update" action
 //
 // This function is auto-generated.
-//
 func ExposedModuleActionUpdate(props ...*exposedModuleActionProps) *exposedModuleAction {
 	a := &exposedModuleAction{
 		timestamp: time.Now(),
@@ -398,7 +385,6 @@ func ExposedModuleActionUpdate(props ...*exposedModuleActionProps) *exposedModul
 // ExposedModuleActionDelete returns "federation:exposed_module.delete" action
 //
 // This function is auto-generated.
-//
 func ExposedModuleActionDelete(props ...*exposedModuleActionProps) *exposedModuleAction {
 	a := &exposedModuleAction{
 		timestamp: time.Now(),
@@ -418,7 +404,6 @@ func ExposedModuleActionDelete(props ...*exposedModuleActionProps) *exposedModul
 // ExposedModuleActionUndelete returns "federation:exposed_module.undelete" action
 //
 // This function is auto-generated.
-//
 func ExposedModuleActionUndelete(props ...*exposedModuleActionProps) *exposedModuleAction {
 	a := &exposedModuleAction{
 		timestamp: time.Now(),
@@ -441,9 +426,7 @@ func ExposedModuleActionUndelete(props ...*exposedModuleActionProps) *exposedMod
 
 // ExposedModuleErrGeneric returns "federation:exposed_module.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrGeneric(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -477,9 +460,7 @@ func ExposedModuleErrGeneric(mm ...*exposedModuleActionProps) *errors.Error {
 
 // ExposedModuleErrNotFound returns "federation:exposed_module.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrNotFound(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -511,9 +492,7 @@ func ExposedModuleErrNotFound(mm ...*exposedModuleActionProps) *errors.Error {
 
 // ExposedModuleErrInvalidID returns "federation:exposed_module.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrInvalidID(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -545,9 +524,7 @@ func ExposedModuleErrInvalidID(mm ...*exposedModuleActionProps) *errors.Error {
 
 // ExposedModuleErrStaleData returns "federation:exposed_module.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrStaleData(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -579,9 +556,7 @@ func ExposedModuleErrStaleData(mm ...*exposedModuleActionProps) *errors.Error {
 
 // ExposedModuleErrNotUnique returns "federation:exposed_module.notUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrNotUnique(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -615,9 +590,7 @@ func ExposedModuleErrNotUnique(mm ...*exposedModuleActionProps) *errors.Error {
 
 // ExposedModuleErrNodeNotFound returns "federation:exposed_module.nodeNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrNodeNotFound(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -649,9 +622,7 @@ func ExposedModuleErrNodeNotFound(mm ...*exposedModuleActionProps) *errors.Error
 
 // ExposedModuleErrComposeModuleNotFound returns "federation:exposed_module.composeModuleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrComposeModuleNotFound(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -683,9 +654,7 @@ func ExposedModuleErrComposeModuleNotFound(mm ...*exposedModuleActionProps) *err
 
 // ExposedModuleErrComposeNamespaceNotFound returns "federation:exposed_module.composeNamespaceNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrComposeNamespaceNotFound(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -717,9 +686,7 @@ func ExposedModuleErrComposeNamespaceNotFound(mm ...*exposedModuleActionProps) *
 
 // ExposedModuleErrRequestParametersInvalid returns "federation:exposed_module.requestParametersInvalid" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrRequestParametersInvalid(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -751,9 +718,7 @@ func ExposedModuleErrRequestParametersInvalid(mm ...*exposedModuleActionProps) *
 
 // ExposedModuleErrNotAllowedToCreate returns "federation:exposed_module.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrNotAllowedToCreate(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -787,9 +752,7 @@ func ExposedModuleErrNotAllowedToCreate(mm ...*exposedModuleActionProps) *errors
 
 // ExposedModuleErrNotAllowedToManage returns "federation:exposed_module.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ExposedModuleErrNotAllowedToManage(mm ...*exposedModuleActionProps) *errors.Error {
 	var p = &exposedModuleActionProps{}
 	if len(mm) > 0 {
@@ -829,7 +792,6 @@ func ExposedModuleErrNotAllowedToManage(mm ...*exposedModuleActionProps) *errors
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc exposedModule) recordAction(ctx context.Context, props *exposedModuleActionProps, actionFn func(...*exposedModuleActionProps) *exposedModuleAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/federation/service/module_mapping_actions.gen.go
+++ b/server/federation/service/module_mapping_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setCreated updates moduleMappingActionProps's created
 //
 // This function is auto-generated.
-//
 func (p *moduleMappingActionProps) setCreated(created *types.ModuleMapping) *moduleMappingActionProps {
 	p.created = created
 	return p
@@ -64,7 +63,6 @@ func (p *moduleMappingActionProps) setCreated(created *types.ModuleMapping) *mod
 // setMapping updates moduleMappingActionProps's mapping
 //
 // This function is auto-generated.
-//
 func (p *moduleMappingActionProps) setMapping(mapping *types.ModuleMapping) *moduleMappingActionProps {
 	p.mapping = mapping
 	return p
@@ -73,7 +71,6 @@ func (p *moduleMappingActionProps) setMapping(mapping *types.ModuleMapping) *mod
 // setChanged updates moduleMappingActionProps's changed
 //
 // This function is auto-generated.
-//
 func (p *moduleMappingActionProps) setChanged(changed *types.ModuleMapping) *moduleMappingActionProps {
 	p.changed = changed
 	return p
@@ -82,7 +79,6 @@ func (p *moduleMappingActionProps) setChanged(changed *types.ModuleMapping) *mod
 // setFilter updates moduleMappingActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *moduleMappingActionProps) setFilter(filter *types.ModuleMappingFilter) *moduleMappingActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *moduleMappingActionProps) setFilter(filter *types.ModuleMappingFilter) 
 // Serialize converts moduleMappingActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p moduleMappingActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -121,7 +116,6 @@ func (p moduleMappingActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p moduleMappingActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -210,7 +204,6 @@ func (p moduleMappingActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *moduleMappingAction) String() string {
 	var props = &moduleMappingActionProps{}
 
@@ -238,7 +231,6 @@ func (e *moduleMappingAction) ToAction() *actionlog.Action {
 // ModuleMappingActionSearch returns "federation:module_mapping.search" action
 //
 // This function is auto-generated.
-//
 func ModuleMappingActionSearch(props ...*moduleMappingActionProps) *moduleMappingAction {
 	a := &moduleMappingAction{
 		timestamp: time.Now(),
@@ -258,7 +250,6 @@ func ModuleMappingActionSearch(props ...*moduleMappingActionProps) *moduleMappin
 // ModuleMappingActionLookup returns "federation:module_mapping.lookup" action
 //
 // This function is auto-generated.
-//
 func ModuleMappingActionLookup(props ...*moduleMappingActionProps) *moduleMappingAction {
 	a := &moduleMappingAction{
 		timestamp: time.Now(),
@@ -278,7 +269,6 @@ func ModuleMappingActionLookup(props ...*moduleMappingActionProps) *moduleMappin
 // ModuleMappingActionCreate returns "federation:module_mapping.create" action
 //
 // This function is auto-generated.
-//
 func ModuleMappingActionCreate(props ...*moduleMappingActionProps) *moduleMappingAction {
 	a := &moduleMappingAction{
 		timestamp: time.Now(),
@@ -298,7 +288,6 @@ func ModuleMappingActionCreate(props ...*moduleMappingActionProps) *moduleMappin
 // ModuleMappingActionUpdate returns "federation:module_mapping.update" action
 //
 // This function is auto-generated.
-//
 func ModuleMappingActionUpdate(props ...*moduleMappingActionProps) *moduleMappingAction {
 	a := &moduleMappingAction{
 		timestamp: time.Now(),
@@ -318,7 +307,6 @@ func ModuleMappingActionUpdate(props ...*moduleMappingActionProps) *moduleMappin
 // ModuleMappingActionDelete returns "federation:module_mapping.delete" action
 //
 // This function is auto-generated.
-//
 func ModuleMappingActionDelete(props ...*moduleMappingActionProps) *moduleMappingAction {
 	a := &moduleMappingAction{
 		timestamp: time.Now(),
@@ -341,9 +329,7 @@ func ModuleMappingActionDelete(props ...*moduleMappingActionProps) *moduleMappin
 
 // ModuleMappingErrGeneric returns "federation:module_mapping.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrGeneric(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -377,9 +363,7 @@ func ModuleMappingErrGeneric(mm ...*moduleMappingActionProps) *errors.Error {
 
 // ModuleMappingErrNotFound returns "federation:module_mapping.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -411,9 +395,7 @@ func ModuleMappingErrNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 
 // ModuleMappingErrComposeModuleNotFound returns "federation:module_mapping.composeModuleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrComposeModuleNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -445,9 +427,7 @@ func ModuleMappingErrComposeModuleNotFound(mm ...*moduleMappingActionProps) *err
 
 // ModuleMappingErrComposeNamespaceNotFound returns "federation:module_mapping.composeNamespaceNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrComposeNamespaceNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -479,9 +459,7 @@ func ModuleMappingErrComposeNamespaceNotFound(mm ...*moduleMappingActionProps) *
 
 // ModuleMappingErrFederationModuleNotFound returns "federation:module_mapping.federationModuleNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrFederationModuleNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -513,9 +491,7 @@ func ModuleMappingErrFederationModuleNotFound(mm ...*moduleMappingActionProps) *
 
 // ModuleMappingErrNodeNotFound returns "federation:module_mapping.nodeNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrNodeNotFound(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -547,9 +523,7 @@ func ModuleMappingErrNodeNotFound(mm ...*moduleMappingActionProps) *errors.Error
 
 // ModuleMappingErrModuleMappingExists returns "federation:module_mapping.moduleMappingExists" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrModuleMappingExists(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -581,9 +555,7 @@ func ModuleMappingErrModuleMappingExists(mm ...*moduleMappingActionProps) *error
 
 // ModuleMappingErrNotAllowedToMap returns "federation:module_mapping.notAllowedToMap" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ModuleMappingErrNotAllowedToMap(mm ...*moduleMappingActionProps) *errors.Error {
 	var p = &moduleMappingActionProps{}
 	if len(mm) > 0 {
@@ -623,7 +595,6 @@ func ModuleMappingErrNotAllowedToMap(mm ...*moduleMappingActionProps) *errors.Er
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc moduleMapping) recordAction(ctx context.Context, props *moduleMappingActionProps, actionFn func(...*moduleMappingActionProps) *moduleMappingAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/federation/service/node_actions.gen.go
+++ b/server/federation/service/node_actions.gen.go
@@ -54,7 +54,6 @@ var (
 // setNode updates nodeActionProps's node
 //
 // This function is auto-generated.
-//
 func (p *nodeActionProps) setNode(node *types.Node) *nodeActionProps {
 	p.node = node
 	return p
@@ -63,7 +62,6 @@ func (p *nodeActionProps) setNode(node *types.Node) *nodeActionProps {
 // setPairingURI updates nodeActionProps's pairingURI
 //
 // This function is auto-generated.
-//
 func (p *nodeActionProps) setPairingURI(pairingURI string) *nodeActionProps {
 	p.pairingURI = pairingURI
 	return p
@@ -72,7 +70,6 @@ func (p *nodeActionProps) setPairingURI(pairingURI string) *nodeActionProps {
 // setFilter updates nodeActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *nodeActionProps) setFilter(filter *types.NodeFilter) *nodeActionProps {
 	p.filter = filter
 	return p
@@ -81,7 +78,6 @@ func (p *nodeActionProps) setFilter(filter *types.NodeFilter) *nodeActionProps {
 // Serialize converts nodeActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p nodeActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -105,7 +101,6 @@ func (p nodeActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p nodeActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -169,7 +164,6 @@ func (p nodeActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *nodeAction) String() string {
 	var props = &nodeActionProps{}
 
@@ -197,7 +191,6 @@ func (e *nodeAction) ToAction() *actionlog.Action {
 // NodeActionSearch returns "federation:node.search" action
 //
 // This function is auto-generated.
-//
 func NodeActionSearch(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -217,7 +210,6 @@ func NodeActionSearch(props ...*nodeActionProps) *nodeAction {
 // NodeActionLookup returns "federation:node.lookup" action
 //
 // This function is auto-generated.
-//
 func NodeActionLookup(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -237,7 +229,6 @@ func NodeActionLookup(props ...*nodeActionProps) *nodeAction {
 // NodeActionCreate returns "federation:node.create" action
 //
 // This function is auto-generated.
-//
 func NodeActionCreate(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -257,7 +248,6 @@ func NodeActionCreate(props ...*nodeActionProps) *nodeAction {
 // NodeActionCreateFromPairingURI returns "federation:node.createFromPairingURI" action
 //
 // This function is auto-generated.
-//
 func NodeActionCreateFromPairingURI(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -277,7 +267,6 @@ func NodeActionCreateFromPairingURI(props ...*nodeActionProps) *nodeAction {
 // NodeActionRecreateFromPairingURI returns "federation:node.recreateFromPairingURI" action
 //
 // This function is auto-generated.
-//
 func NodeActionRecreateFromPairingURI(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -297,7 +286,6 @@ func NodeActionRecreateFromPairingURI(props ...*nodeActionProps) *nodeAction {
 // NodeActionUpdate returns "federation:node.update" action
 //
 // This function is auto-generated.
-//
 func NodeActionUpdate(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -317,7 +305,6 @@ func NodeActionUpdate(props ...*nodeActionProps) *nodeAction {
 // NodeActionDelete returns "federation:node.delete" action
 //
 // This function is auto-generated.
-//
 func NodeActionDelete(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -337,7 +324,6 @@ func NodeActionDelete(props ...*nodeActionProps) *nodeAction {
 // NodeActionUndelete returns "federation:node.undelete" action
 //
 // This function is auto-generated.
-//
 func NodeActionUndelete(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -357,7 +343,6 @@ func NodeActionUndelete(props ...*nodeActionProps) *nodeAction {
 // NodeActionOttRegenerated returns "federation:node.ottRegenerated" action
 //
 // This function is auto-generated.
-//
 func NodeActionOttRegenerated(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -377,7 +362,6 @@ func NodeActionOttRegenerated(props ...*nodeActionProps) *nodeAction {
 // NodeActionPair returns "federation:node.pair" action
 //
 // This function is auto-generated.
-//
 func NodeActionPair(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -397,7 +381,6 @@ func NodeActionPair(props ...*nodeActionProps) *nodeAction {
 // NodeActionHandshakeInit returns "federation:node.handshakeInit" action
 //
 // This function is auto-generated.
-//
 func NodeActionHandshakeInit(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -417,7 +400,6 @@ func NodeActionHandshakeInit(props ...*nodeActionProps) *nodeAction {
 // NodeActionHandshakeConfirm returns "federation:node.handshakeConfirm" action
 //
 // This function is auto-generated.
-//
 func NodeActionHandshakeConfirm(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -437,7 +419,6 @@ func NodeActionHandshakeConfirm(props ...*nodeActionProps) *nodeAction {
 // NodeActionHandshakeComplete returns "federation:node.handshakeComplete" action
 //
 // This function is auto-generated.
-//
 func NodeActionHandshakeComplete(props ...*nodeActionProps) *nodeAction {
 	a := &nodeAction{
 		timestamp: time.Now(),
@@ -460,9 +441,7 @@ func NodeActionHandshakeComplete(props ...*nodeActionProps) *nodeAction {
 
 // NodeErrGeneric returns "federation:node.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrGeneric(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -496,9 +475,7 @@ func NodeErrGeneric(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrNotFound returns "federation:node.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrNotFound(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -530,9 +507,7 @@ func NodeErrNotFound(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrInvalidID returns "federation:node.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrInvalidID(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -564,9 +539,7 @@ func NodeErrInvalidID(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrPairingURIInvalid returns "federation:node.pairingURIInvalid" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrPairingURIInvalid(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -598,9 +571,7 @@ func NodeErrPairingURIInvalid(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrPairingURITokenInvalid returns "federation:node.pairingURITokenInvalid" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrPairingURITokenInvalid(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -632,9 +603,7 @@ func NodeErrPairingURITokenInvalid(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrPairingURISourceIDInvalid returns "federation:node.pairingURISourceIDInvalid" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrPairingURISourceIDInvalid(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -666,9 +635,7 @@ func NodeErrPairingURISourceIDInvalid(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrPairingTokenInvalid returns "federation:node.pairingTokenInvalid" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrPairingTokenInvalid(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -700,9 +667,7 @@ func NodeErrPairingTokenInvalid(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrNotAllowedToCreate returns "federation:node.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrNotAllowedToCreate(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -736,9 +701,7 @@ func NodeErrNotAllowedToCreate(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrNotAllowedToSearch returns "federation:node.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrNotAllowedToSearch(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -772,9 +735,7 @@ func NodeErrNotAllowedToSearch(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrNotAllowedToManage returns "federation:node.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrNotAllowedToManage(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -808,9 +769,7 @@ func NodeErrNotAllowedToManage(mm ...*nodeActionProps) *errors.Error {
 
 // NodeErrNotAllowedToPair returns "federation:node.notAllowedToPair" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeErrNotAllowedToPair(mm ...*nodeActionProps) *errors.Error {
 	var p = &nodeActionProps{}
 	if len(mm) > 0 {
@@ -850,7 +809,6 @@ func NodeErrNotAllowedToPair(mm ...*nodeActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc node) recordAction(ctx context.Context, props *nodeActionProps, actionFn func(...*nodeActionProps) *nodeAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/federation/service/node_sync_actions.gen.go
+++ b/server/federation/service/node_sync_actions.gen.go
@@ -53,7 +53,6 @@ var (
 // setNodeSync updates nodeSyncActionProps's nodeSync
 //
 // This function is auto-generated.
-//
 func (p *nodeSyncActionProps) setNodeSync(nodeSync *types.NodeSync) *nodeSyncActionProps {
 	p.nodeSync = nodeSync
 	return p
@@ -62,7 +61,6 @@ func (p *nodeSyncActionProps) setNodeSync(nodeSync *types.NodeSync) *nodeSyncAct
 // setNodeSyncFilter updates nodeSyncActionProps's nodeSyncFilter
 //
 // This function is auto-generated.
-//
 func (p *nodeSyncActionProps) setNodeSyncFilter(nodeSyncFilter *types.NodeSyncFilter) *nodeSyncActionProps {
 	p.nodeSyncFilter = nodeSyncFilter
 	return p
@@ -71,7 +69,6 @@ func (p *nodeSyncActionProps) setNodeSyncFilter(nodeSyncFilter *types.NodeSyncFi
 // Serialize converts nodeSyncActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p nodeSyncActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -93,7 +90,6 @@ func (p nodeSyncActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p nodeSyncActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -154,7 +150,6 @@ func (p nodeSyncActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *nodeSyncAction) String() string {
 	var props = &nodeSyncActionProps{}
 
@@ -182,7 +177,6 @@ func (e *nodeSyncAction) ToAction() *actionlog.Action {
 // NodeSyncActionLookup returns "federation:node_sync.lookup" action
 //
 // This function is auto-generated.
-//
 func NodeSyncActionLookup(props ...*nodeSyncActionProps) *nodeSyncAction {
 	a := &nodeSyncAction{
 		timestamp: time.Now(),
@@ -202,7 +196,6 @@ func NodeSyncActionLookup(props ...*nodeSyncActionProps) *nodeSyncAction {
 // NodeSyncActionCreate returns "federation:node_sync.create" action
 //
 // This function is auto-generated.
-//
 func NodeSyncActionCreate(props ...*nodeSyncActionProps) *nodeSyncAction {
 	a := &nodeSyncAction{
 		timestamp: time.Now(),
@@ -225,9 +218,7 @@ func NodeSyncActionCreate(props ...*nodeSyncActionProps) *nodeSyncAction {
 
 // NodeSyncErrGeneric returns "federation:node_sync.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeSyncErrGeneric(mm ...*nodeSyncActionProps) *errors.Error {
 	var p = &nodeSyncActionProps{}
 	if len(mm) > 0 {
@@ -261,9 +252,7 @@ func NodeSyncErrGeneric(mm ...*nodeSyncActionProps) *errors.Error {
 
 // NodeSyncErrNotFound returns "federation:node_sync.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeSyncErrNotFound(mm ...*nodeSyncActionProps) *errors.Error {
 	var p = &nodeSyncActionProps{}
 	if len(mm) > 0 {
@@ -295,9 +284,7 @@ func NodeSyncErrNotFound(mm ...*nodeSyncActionProps) *errors.Error {
 
 // NodeSyncErrNodeNotFound returns "federation:node_sync.nodeNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func NodeSyncErrNodeNotFound(mm ...*nodeSyncActionProps) *errors.Error {
 	var p = &nodeSyncActionProps{}
 	if len(mm) > 0 {
@@ -335,7 +322,6 @@ func NodeSyncErrNodeNotFound(mm ...*nodeSyncActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc nodeSync) recordAction(ctx context.Context, props *nodeSyncActionProps, actionFn func(...*nodeSyncActionProps) *nodeSyncAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/federation/service/shared_module_actions.gen.go
+++ b/server/federation/service/shared_module_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setModule updates sharedModuleActionProps's module
 //
 // This function is auto-generated.
-//
 func (p *sharedModuleActionProps) setModule(module *types.SharedModule) *sharedModuleActionProps {
 	p.module = module
 	return p
@@ -64,7 +63,6 @@ func (p *sharedModuleActionProps) setModule(module *types.SharedModule) *sharedM
 // setChanged updates sharedModuleActionProps's changed
 //
 // This function is auto-generated.
-//
 func (p *sharedModuleActionProps) setChanged(changed *types.SharedModule) *sharedModuleActionProps {
 	p.changed = changed
 	return p
@@ -73,7 +71,6 @@ func (p *sharedModuleActionProps) setChanged(changed *types.SharedModule) *share
 // setFilter updates sharedModuleActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *sharedModuleActionProps) setFilter(filter *types.SharedModuleFilter) *sharedModuleActionProps {
 	p.filter = filter
 	return p
@@ -82,7 +79,6 @@ func (p *sharedModuleActionProps) setFilter(filter *types.SharedModuleFilter) *s
 // setNode updates sharedModuleActionProps's node
 //
 // This function is auto-generated.
-//
 func (p *sharedModuleActionProps) setNode(node *types.Node) *sharedModuleActionProps {
 	p.node = node
 	return p
@@ -91,7 +87,6 @@ func (p *sharedModuleActionProps) setNode(node *types.Node) *sharedModuleActionP
 // Serialize converts sharedModuleActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p sharedModuleActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -119,7 +114,6 @@ func (p sharedModuleActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p sharedModuleActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -204,7 +198,6 @@ func (p sharedModuleActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *sharedModuleAction) String() string {
 	var props = &sharedModuleActionProps{}
 
@@ -232,7 +225,6 @@ func (e *sharedModuleAction) ToAction() *actionlog.Action {
 // SharedModuleActionSearch returns "federation:shared_module.search" action
 //
 // This function is auto-generated.
-//
 func SharedModuleActionSearch(props ...*sharedModuleActionProps) *sharedModuleAction {
 	a := &sharedModuleAction{
 		timestamp: time.Now(),
@@ -252,7 +244,6 @@ func SharedModuleActionSearch(props ...*sharedModuleActionProps) *sharedModuleAc
 // SharedModuleActionLookup returns "federation:shared_module.lookup" action
 //
 // This function is auto-generated.
-//
 func SharedModuleActionLookup(props ...*sharedModuleActionProps) *sharedModuleAction {
 	a := &sharedModuleAction{
 		timestamp: time.Now(),
@@ -272,7 +263,6 @@ func SharedModuleActionLookup(props ...*sharedModuleActionProps) *sharedModuleAc
 // SharedModuleActionCreate returns "federation:shared_module.create" action
 //
 // This function is auto-generated.
-//
 func SharedModuleActionCreate(props ...*sharedModuleActionProps) *sharedModuleAction {
 	a := &sharedModuleAction{
 		timestamp: time.Now(),
@@ -292,7 +282,6 @@ func SharedModuleActionCreate(props ...*sharedModuleActionProps) *sharedModuleAc
 // SharedModuleActionUpdate returns "federation:shared_module.update" action
 //
 // This function is auto-generated.
-//
 func SharedModuleActionUpdate(props ...*sharedModuleActionProps) *sharedModuleAction {
 	a := &sharedModuleAction{
 		timestamp: time.Now(),
@@ -312,7 +301,6 @@ func SharedModuleActionUpdate(props ...*sharedModuleActionProps) *sharedModuleAc
 // SharedModuleActionDelete returns "federation:shared_module.delete" action
 //
 // This function is auto-generated.
-//
 func SharedModuleActionDelete(props ...*sharedModuleActionProps) *sharedModuleAction {
 	a := &sharedModuleAction{
 		timestamp: time.Now(),
@@ -332,7 +320,6 @@ func SharedModuleActionDelete(props ...*sharedModuleActionProps) *sharedModuleAc
 // SharedModuleActionUndelete returns "federation:shared_module.undelete" action
 //
 // This function is auto-generated.
-//
 func SharedModuleActionUndelete(props ...*sharedModuleActionProps) *sharedModuleAction {
 	a := &sharedModuleAction{
 		timestamp: time.Now(),
@@ -355,9 +342,7 @@ func SharedModuleActionUndelete(props ...*sharedModuleActionProps) *sharedModule
 
 // SharedModuleErrGeneric returns "federation:shared_module.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrGeneric(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -391,9 +376,7 @@ func SharedModuleErrGeneric(mm ...*sharedModuleActionProps) *errors.Error {
 
 // SharedModuleErrNotFound returns "federation:shared_module.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrNotFound(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -425,9 +408,7 @@ func SharedModuleErrNotFound(mm ...*sharedModuleActionProps) *errors.Error {
 
 // SharedModuleErrInvalidID returns "federation:shared_module.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrInvalidID(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -459,9 +440,7 @@ func SharedModuleErrInvalidID(mm ...*sharedModuleActionProps) *errors.Error {
 
 // SharedModuleErrStaleData returns "federation:shared_module.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrStaleData(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -493,9 +472,7 @@ func SharedModuleErrStaleData(mm ...*sharedModuleActionProps) *errors.Error {
 
 // SharedModuleErrFederationSyncStructureChanged returns "federation:shared_module.federationSyncStructureChanged" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrFederationSyncStructureChanged(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -529,9 +506,7 @@ func SharedModuleErrFederationSyncStructureChanged(mm ...*sharedModuleActionProp
 
 // SharedModuleErrNotUnique returns "federation:shared_module.notUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrNotUnique(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -565,9 +540,7 @@ func SharedModuleErrNotUnique(mm ...*sharedModuleActionProps) *errors.Error {
 
 // SharedModuleErrNodeNotFound returns "federation:shared_module.nodeNotFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrNodeNotFound(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -599,9 +572,7 @@ func SharedModuleErrNodeNotFound(mm ...*sharedModuleActionProps) *errors.Error {
 
 // SharedModuleErrNotAllowedToCreate returns "federation:shared_module.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrNotAllowedToCreate(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -635,9 +606,7 @@ func SharedModuleErrNotAllowedToCreate(mm ...*sharedModuleActionProps) *errors.E
 
 // SharedModuleErrNotAllowedToManage returns "federation:shared_module.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrNotAllowedToManage(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -671,9 +640,7 @@ func SharedModuleErrNotAllowedToManage(mm ...*sharedModuleActionProps) *errors.E
 
 // SharedModuleErrNotAllowedToMap returns "federation:shared_module.notAllowedToMap" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SharedModuleErrNotAllowedToMap(mm ...*sharedModuleActionProps) *errors.Error {
 	var p = &sharedModuleActionProps{}
 	if len(mm) > 0 {
@@ -713,7 +680,6 @@ func SharedModuleErrNotAllowedToMap(mm ...*sharedModuleActionProps) *errors.Erro
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc sharedModule) recordAction(ctx context.Context, props *sharedModuleActionProps, actionFn func(...*sharedModuleActionProps) *sharedModuleAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/pkg/expr/expr_types.gen.go
+++ b/server/pkg/expr/expr_types.gen.go
@@ -525,7 +525,6 @@ func (t *HttpRequest) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access HttpRequest's underlying value (*http.Request)
 // and it's fields
-//
 func (t *HttpRequest) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()

--- a/server/pkg/http/request.go
+++ b/server/pkg/http/request.go
@@ -27,6 +27,8 @@ type (
 	}
 )
 
+const maxMemory = 1 << 30 // 1GB
+
 func NewRequest(r *http.Request) (rr *Request, err error) {
 	rr = &Request{
 		Request: r,
@@ -34,7 +36,29 @@ func NewRequest(r *http.Request) (rr *Request, err error) {
 
 	contentType := r.Header.Get("Content-Type")
 	if strings.HasPrefix(contentType, "multipart/form-data") {
+		// @todo consider increasing the limit; should be plenty for now
+		var body []byte
+		body, err = io.ReadAll(io.LimitReader(r.Body, maxMemory))
+		if err != nil {
+			return
+		}
+		r.Body.Close()
+
+		// Save a copy of the body
+		bCopy := make([]byte, len(body))
+		copy(bCopy, body)
+
+		// Restore the body so we can parse it
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		// Pull files (this consumes the body)
 		err = getFilesAsReaders(r)
+		if err != nil {
+			return
+		}
+
+		// Restore & parse
+		rr.Body, err = NewBufferedReader(bytes.NewBuffer(bCopy))
 		if err != nil {
 			return
 		}

--- a/server/pkg/http/request.go
+++ b/server/pkg/http/request.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type (
@@ -27,13 +28,24 @@ type (
 )
 
 func NewRequest(r *http.Request) (rr *Request, err error) {
-	rs, err := NewBufferedReader(r.Body)
-
-	if err != nil {
-		return
+	rr = &Request{
+		Request: r,
 	}
 
-	rr = &Request{r, rs}
+	contentType := r.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "multipart/form-data") {
+		err = getFilesAsReaders(r)
+		if err != nil {
+			return
+		}
+	} else {
+		// @todo support for others when needed?
+		rr.Body, err = NewBufferedReader(r.Body)
+		if err != nil {
+			return
+		}
+	}
+
 	return
 }
 
@@ -116,4 +128,17 @@ func (bb *Request) MarshalJSON() ([]byte, error) {
 		RemoteAddr:    bb.RemoteAddr,
 		RequestURI:    bb.RequestURI,
 	})
+}
+
+func getFilesAsReaders(r *http.Request) (err error) {
+	err = r.ParseMultipartForm(32 << 20)
+	if err != nil {
+		return fmt.Errorf("error parsing multipart form: %w", err)
+	}
+
+	if r.MultipartForm == nil {
+		return fmt.Errorf("no multipart form found")
+	}
+
+	return nil
 }

--- a/server/pkg/rbac/ruleset_utils.go
+++ b/server/pkg/rbac/ruleset_utils.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"github.com/cortezaproject/corteza/server/pkg/auth"
 	"github.com/cortezaproject/corteza/server/pkg/slice"
 )
 
@@ -162,6 +163,15 @@ func (set RuleSet) sigRoles(res string, op string) (aRR, dRR []uint64) {
 		if chk {
 			dRR = append(dRR, r)
 		}
+	}
+
+	// add bypass roles
+	for _, r := range auth.BypassRoles() {
+		if r == nil {
+			continue
+		}
+
+		aRR = append(aRR, r.ID)
 	}
 
 	return

--- a/server/store/adapters/rdbms/filter.go
+++ b/server/store/adapters/rdbms/filter.go
@@ -282,7 +282,7 @@ func DefaultFilters() (f *extendedFilters) {
 		// query = query.OrderBy("id DESC")
 
 		if f.FromTimestamp != nil {
-			ee = append(ee, goqu.C("ts").Gte(f.ToTimestamp))
+			ee = append(ee, goqu.C("ts").Gte(f.FromTimestamp))
 		}
 
 		if f.ToTimestamp != nil {

--- a/server/system/automation/actionlog_handler.gen.go
+++ b/server/system/automation/actionlog_handler.gen.go
@@ -69,9 +69,10 @@ type (
 // Search function Action log search
 //
 // expects implementation of search function:
-// func (h actionlogHandler) search(ctx context.Context, args *actionlogSearchArgs) (results *actionlogSearchResults, err error) {
-//    return
-// }
+//
+//	func (h actionlogHandler) search(ctx context.Context, args *actionlogSearchArgs) (results *actionlogSearchResults, err error) {
+//	   return
+//	}
 func (h actionlogHandler) Search() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "actionlogSearch",
@@ -210,9 +211,10 @@ type (
 // Each function Action log
 //
 // expects implementation of each function:
-// func (h actionlogHandler) each(ctx context.Context, args *actionlogEachArgs) (results *actionlogEachResults, err error) {
-//    return
-// }
+//
+//	func (h actionlogHandler) each(ctx context.Context, args *actionlogEachArgs) (results *actionlogEachResults, err error) {
+//	   return
+//	}
 func (h actionlogHandler) Each() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "actionlogEach",
@@ -313,9 +315,10 @@ type (
 // Record function Record action into action log
 //
 // expects implementation of record function:
-// func (h actionlogHandler) record(ctx context.Context, args *actionlogRecordArgs) (err error) {
-//    return
-// }
+//
+//	func (h actionlogHandler) record(ctx context.Context, args *actionlogRecordArgs) (err error) {
+//	   return
+//	}
 func (h actionlogHandler) Record() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "actionlogRecord",

--- a/server/system/automation/expr_types.gen.go
+++ b/server/system/automation/expr_types.gen.go
@@ -178,7 +178,6 @@ func (t *QueueMessage) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access QueueMessage's underlying value (*types.QueueMessage)
 // and it's fields
-//
 func (t *QueueMessage) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -417,7 +416,6 @@ func (t *RenderedDocument) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access RenderedDocument's underlying value (*renderedDocument)
 // and it's fields
-//
 func (t *RenderedDocument) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -572,7 +570,6 @@ func (t *Role) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access Role's underlying value (*types.Role)
 // and it's fields
-//
 func (t *Role) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -767,7 +764,6 @@ func (t *Template) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access Template's underlying value (*types.Template)
 // and it's fields
-//
 func (t *Template) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -1026,7 +1022,6 @@ func (t *TemplateMeta) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access TemplateMeta's underlying value (types.TemplateMeta)
 // and it's fields
-//
 func (t *TemplateMeta) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
@@ -1161,7 +1156,6 @@ func (t *User) AssignFieldValue(key string, val TypedValue) error {
 //
 // It allows gval lib to access User's underlying value (*types.User)
 // and it's fields
-//
 func (t *User) SelectGVal(ctx context.Context, k string) (interface{}, error) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()

--- a/server/system/automation/rbac_handler.gen.go
+++ b/server/system/automation/rbac_handler.gen.go
@@ -58,9 +58,10 @@ func (a rbacAllowArgs) GetRole() (bool, uint64, string, *types.Role) {
 // Allow function RBAC: Allow operation on resource to a role
 //
 // expects implementation of allow function:
-// func (h rbacHandler) allow(ctx context.Context, args *rbacAllowArgs) (err error) {
-//    return
-// }
+//
+//	func (h rbacHandler) allow(ctx context.Context, args *rbacAllowArgs) (err error) {
+//	   return
+//	}
 func (h rbacHandler) Allow() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rbacAllow",
@@ -139,9 +140,10 @@ func (a rbacDenyArgs) GetRole() (bool, uint64, string, *types.Role) {
 // Deny function RBAC: Deny operation on resource to a role
 //
 // expects implementation of deny function:
-// func (h rbacHandler) deny(ctx context.Context, args *rbacDenyArgs) (err error) {
-//    return
-// }
+//
+//	func (h rbacHandler) deny(ctx context.Context, args *rbacDenyArgs) (err error) {
+//	   return
+//	}
 func (h rbacHandler) Deny() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rbacDeny",
@@ -220,9 +222,10 @@ func (a rbacInheritArgs) GetRole() (bool, uint64, string, *types.Role) {
 // Inherit function RBAC: Remove allow/deny operation of a role from resource
 //
 // expects implementation of inherit function:
-// func (h rbacHandler) inherit(ctx context.Context, args *rbacInheritArgs) (err error) {
-//    return
-// }
+//
+//	func (h rbacHandler) inherit(ctx context.Context, args *rbacInheritArgs) (err error) {
+//	   return
+//	}
 func (h rbacHandler) Inherit() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rbacInherit",
@@ -298,9 +301,10 @@ type (
 // Check function RBAC: Can user perform an operation on a resource
 //
 // expects implementation of check function:
-// func (h rbacHandler) check(ctx context.Context, args *rbacCheckArgs) (results *rbacCheckResults, err error) {
-//    return
-// }
+//
+//	func (h rbacHandler) check(ctx context.Context, args *rbacCheckArgs) (results *rbacCheckResults, err error) {
+//	   return
+//	}
 func (h rbacHandler) Check() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rbacCheck",

--- a/server/system/automation/roles_handler.gen.go
+++ b/server/system/automation/roles_handler.gen.go
@@ -64,9 +64,10 @@ func (a rolesLookupArgs) GetLookup() (bool, uint64, string, *types.Role) {
 // Lookup function Role lookup
 //
 // expects implementation of lookup function:
-// func (h rolesHandler) lookup(ctx context.Context, args *rolesLookupArgs) (results *rolesLookupResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) lookup(ctx context.Context, args *rolesLookupArgs) (results *rolesLookupResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesLookup",
@@ -163,9 +164,10 @@ func (a rolesSearchMembersArgs) GetLookup() (bool, uint64, string, *types.Role) 
 // SearchMembers function Role members search
 //
 // expects implementation of searchMembers function:
-// func (h rolesHandler) searchMembers(ctx context.Context, args *rolesSearchMembersArgs) (results *rolesSearchMembersResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) searchMembers(ctx context.Context, args *rolesSearchMembersArgs) (results *rolesSearchMembersResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) SearchMembers() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesSearchMembers",
@@ -288,9 +290,10 @@ func (a rolesEachMemberArgs) GetLookup() (bool, uint64, string, *types.Role) {
 // EachMember function Iterate over role members
 //
 // expects implementation of eachMember function:
-// func (h rolesHandler) eachMember(ctx context.Context, args *rolesEachMemberArgs) (results *rolesEachMemberResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) eachMember(ctx context.Context, args *rolesEachMemberArgs) (results *rolesEachMemberResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) EachMember() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesEachMember",
@@ -377,9 +380,10 @@ func (a rolesAddMemberArgs) GetUser() (bool, uint64, string, string, *types.User
 // AddMember function Role membership add
 //
 // expects implementation of addMember function:
-// func (h rolesHandler) addMember(ctx context.Context, args *rolesAddMemberArgs) (err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) addMember(ctx context.Context, args *rolesAddMemberArgs) (err error) {
+//	   return
+//	}
 func (h rolesHandler) AddMember() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesAddMember",
@@ -473,9 +477,10 @@ func (a rolesRemoveMemberArgs) GetUser() (bool, uint64, string, string, *types.U
 // RemoveMember function Role membership remove
 //
 // expects implementation of removeMember function:
-// func (h rolesHandler) removeMember(ctx context.Context, args *rolesRemoveMemberArgs) (err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) removeMember(ctx context.Context, args *rolesRemoveMemberArgs) (err error) {
+//	   return
+//	}
 func (h rolesHandler) RemoveMember() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesRemoveMember",
@@ -589,9 +594,10 @@ type (
 // Search function Roles search
 //
 // expects implementation of search function:
-// func (h rolesHandler) search(ctx context.Context, args *rolesSearchArgs) (results *rolesSearchResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) search(ctx context.Context, args *rolesSearchArgs) (results *rolesSearchResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) Search() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesSearch",
@@ -781,9 +787,10 @@ type (
 // Each function Roles
 //
 // expects implementation of each function:
-// func (h rolesHandler) each(ctx context.Context, args *rolesEachArgs) (results *rolesEachResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) each(ctx context.Context, args *rolesEachArgs) (results *rolesEachResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) Each() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesEach",
@@ -898,9 +905,10 @@ type (
 // Create function Role creator
 //
 // expects implementation of create function:
-// func (h rolesHandler) create(ctx context.Context, args *rolesCreateArgs) (results *rolesCreateResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) create(ctx context.Context, args *rolesCreateArgs) (results *rolesCreateResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) Create() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesCreate",
@@ -975,9 +983,10 @@ type (
 // Update function Role update
 //
 // expects implementation of update function:
-// func (h rolesHandler) update(ctx context.Context, args *rolesUpdateArgs) (results *rolesUpdateResults, err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) update(ctx context.Context, args *rolesUpdateArgs) (results *rolesUpdateResults, err error) {
+//	   return
+//	}
 func (h rolesHandler) Update() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesUpdate",
@@ -1055,9 +1064,10 @@ func (a rolesDeleteArgs) GetLookup() (bool, uint64, string, *types.Role) {
 // Delete function Role delete
 //
 // expects implementation of delete function:
-// func (h rolesHandler) delete(ctx context.Context, args *rolesDeleteArgs) (err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) delete(ctx context.Context, args *rolesDeleteArgs) (err error) {
+//	   return
+//	}
 func (h rolesHandler) Delete() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesDelete",
@@ -1120,9 +1130,10 @@ func (a rolesRecoverArgs) GetLookup() (bool, uint64, string, *types.Role) {
 // Recover function Role recover
 //
 // expects implementation of recover function:
-// func (h rolesHandler) recover(ctx context.Context, args *rolesRecoverArgs) (err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) recover(ctx context.Context, args *rolesRecoverArgs) (err error) {
+//	   return
+//	}
 func (h rolesHandler) Recover() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesRecover",
@@ -1185,9 +1196,10 @@ func (a rolesArchiveArgs) GetLookup() (bool, uint64, string, *types.Role) {
 // Archive function Role archive
 //
 // expects implementation of archive function:
-// func (h rolesHandler) archive(ctx context.Context, args *rolesArchiveArgs) (err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) archive(ctx context.Context, args *rolesArchiveArgs) (err error) {
+//	   return
+//	}
 func (h rolesHandler) Archive() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesArchive",
@@ -1250,9 +1262,10 @@ func (a rolesUnarchiveArgs) GetLookup() (bool, uint64, string, *types.Role) {
 // Unarchive function Role unarchive
 //
 // expects implementation of unarchive function:
-// func (h rolesHandler) unarchive(ctx context.Context, args *rolesUnarchiveArgs) (err error) {
-//    return
-// }
+//
+//	func (h rolesHandler) unarchive(ctx context.Context, args *rolesUnarchiveArgs) (err error) {
+//	   return
+//	}
 func (h rolesHandler) Unarchive() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "rolesUnarchive",

--- a/server/system/automation/templates_handler.gen.go
+++ b/server/system/automation/templates_handler.gen.go
@@ -59,9 +59,10 @@ func (a templatesLookupArgs) GetLookup() (bool, uint64, string, *types.Template)
 // Lookup function Template lookup
 //
 // expects implementation of lookup function:
-// func (h templatesHandler) lookup(ctx context.Context, args *templatesLookupArgs) (results *templatesLookupResults, err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) lookup(ctx context.Context, args *templatesLookupArgs) (results *templatesLookupResults, err error) {
+//	   return
+//	}
 func (h templatesHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesLookup",
@@ -178,9 +179,10 @@ type (
 // Search function Templates search
 //
 // expects implementation of search function:
-// func (h templatesHandler) search(ctx context.Context, args *templatesSearchArgs) (results *templatesSearchResults, err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) search(ctx context.Context, args *templatesSearchArgs) (results *templatesSearchResults, err error) {
+//	   return
+//	}
 func (h templatesHandler) Search() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesSearch",
@@ -354,9 +356,10 @@ type (
 // Each function Templates
 //
 // expects implementation of each function:
-// func (h templatesHandler) each(ctx context.Context, args *templatesEachArgs) (results *templatesEachResults, err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) each(ctx context.Context, args *templatesEachArgs) (results *templatesEachResults, err error) {
+//	   return
+//	}
 func (h templatesHandler) Each() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesEach",
@@ -461,9 +464,10 @@ type (
 // Create function Template create
 //
 // expects implementation of create function:
-// func (h templatesHandler) create(ctx context.Context, args *templatesCreateArgs) (results *templatesCreateResults, err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) create(ctx context.Context, args *templatesCreateArgs) (results *templatesCreateResults, err error) {
+//	   return
+//	}
 func (h templatesHandler) Create() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesCreate",
@@ -538,9 +542,10 @@ type (
 // Update function Template update
 //
 // expects implementation of update function:
-// func (h templatesHandler) update(ctx context.Context, args *templatesUpdateArgs) (results *templatesUpdateResults, err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) update(ctx context.Context, args *templatesUpdateArgs) (results *templatesUpdateResults, err error) {
+//	   return
+//	}
 func (h templatesHandler) Update() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesUpdate",
@@ -618,9 +623,10 @@ func (a templatesDeleteArgs) GetLookup() (bool, uint64, string, *types.Template)
 // Delete function Template delete
 //
 // expects implementation of delete function:
-// func (h templatesHandler) delete(ctx context.Context, args *templatesDeleteArgs) (err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) delete(ctx context.Context, args *templatesDeleteArgs) (err error) {
+//	   return
+//	}
 func (h templatesHandler) Delete() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesDelete",
@@ -683,9 +689,10 @@ func (a templatesRecoverArgs) GetLookup() (bool, uint64, string, *types.Template
 // Recover function Template recover
 //
 // expects implementation of recover function:
-// func (h templatesHandler) recover(ctx context.Context, args *templatesRecoverArgs) (err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) recover(ctx context.Context, args *templatesRecoverArgs) (err error) {
+//	   return
+//	}
 func (h templatesHandler) Recover() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesRecover",
@@ -764,9 +771,10 @@ func (a templatesRenderArgs) GetLookup() (bool, uint64, string, *types.Template)
 // Render function Template render
 //
 // expects implementation of render function:
-// func (h templatesHandler) render(ctx context.Context, args *templatesRenderArgs) (results *templatesRenderResults, err error) {
-//    return
-// }
+//
+//	func (h templatesHandler) render(ctx context.Context, args *templatesRenderArgs) (results *templatesRenderResults, err error) {
+//	   return
+//	}
 func (h templatesHandler) Render() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "templatesRender",

--- a/server/system/automation/users_handler.gen.go
+++ b/server/system/automation/users_handler.gen.go
@@ -63,9 +63,10 @@ func (a usersLookupArgs) GetLookup() (bool, uint64, string, string, *types.User)
 // Lookup function User lookup
 //
 // expects implementation of lookup function:
-// func (h usersHandler) lookup(ctx context.Context, args *usersLookupArgs) (results *usersLookupResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) lookup(ctx context.Context, args *usersLookupArgs) (results *usersLookupResults, err error) {
+//	   return
+//	}
 func (h usersHandler) Lookup() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersLookup",
@@ -165,9 +166,10 @@ func (a usersSearchMembershipArgs) GetLookup() (bool, uint64, string, string, *t
 // SearchMembership function User role search
 //
 // expects implementation of searchMembership function:
-// func (h usersHandler) searchMembership(ctx context.Context, args *usersSearchMembershipArgs) (results *usersSearchMembershipResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) searchMembership(ctx context.Context, args *usersSearchMembershipArgs) (results *usersSearchMembershipResults, err error) {
+//	   return
+//	}
 func (h usersHandler) SearchMembership() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersSearchMembership",
@@ -302,9 +304,10 @@ func (a usersCheckMembershipArgs) GetRole() (bool, uint64, string, *types.Role) 
 // CheckMembership function User membership check
 //
 // expects implementation of checkMembership function:
-// func (h usersHandler) checkMembership(ctx context.Context, args *usersCheckMembershipArgs) (results *usersCheckMembershipResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) checkMembership(ctx context.Context, args *usersCheckMembershipArgs) (results *usersCheckMembershipResults, err error) {
+//	   return
+//	}
 func (h usersHandler) CheckMembership() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersCheckMembership",
@@ -444,9 +447,10 @@ type (
 // Search function User search
 //
 // expects implementation of search function:
-// func (h usersHandler) search(ctx context.Context, args *usersSearchArgs) (results *usersSearchResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) search(ctx context.Context, args *usersSearchArgs) (results *usersSearchResults, err error) {
+//	   return
+//	}
 func (h usersHandler) Search() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersSearch",
@@ -628,9 +632,10 @@ type (
 // Each function Users
 //
 // expects implementation of each function:
-// func (h usersHandler) each(ctx context.Context, args *usersEachArgs) (results *usersEachResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) each(ctx context.Context, args *usersEachArgs) (results *usersEachResults, err error) {
+//	   return
+//	}
 func (h usersHandler) Each() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersEach",
@@ -740,9 +745,10 @@ type (
 // Create function User create
 //
 // expects implementation of create function:
-// func (h usersHandler) create(ctx context.Context, args *usersCreateArgs) (results *usersCreateResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) create(ctx context.Context, args *usersCreateArgs) (results *usersCreateResults, err error) {
+//	   return
+//	}
 func (h usersHandler) Create() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersCreate",
@@ -817,9 +823,10 @@ type (
 // Update function User update
 //
 // expects implementation of update function:
-// func (h usersHandler) update(ctx context.Context, args *usersUpdateArgs) (results *usersUpdateResults, err error) {
-//    return
-// }
+//
+//	func (h usersHandler) update(ctx context.Context, args *usersUpdateArgs) (results *usersUpdateResults, err error) {
+//	   return
+//	}
 func (h usersHandler) Update() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersUpdate",
@@ -898,9 +905,10 @@ func (a usersDeleteArgs) GetLookup() (bool, uint64, string, string, *types.User)
 // Delete function User delete
 //
 // expects implementation of delete function:
-// func (h usersHandler) delete(ctx context.Context, args *usersDeleteArgs) (err error) {
-//    return
-// }
+//
+//	func (h usersHandler) delete(ctx context.Context, args *usersDeleteArgs) (err error) {
+//	   return
+//	}
 func (h usersHandler) Delete() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersDelete",
@@ -966,9 +974,10 @@ func (a usersRecoverArgs) GetLookup() (bool, uint64, string, string, *types.User
 // Recover function User recover
 //
 // expects implementation of recover function:
-// func (h usersHandler) recover(ctx context.Context, args *usersRecoverArgs) (err error) {
-//    return
-// }
+//
+//	func (h usersHandler) recover(ctx context.Context, args *usersRecoverArgs) (err error) {
+//	   return
+//	}
 func (h usersHandler) Recover() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersRecover",
@@ -1034,9 +1043,10 @@ func (a usersSuspendArgs) GetLookup() (bool, uint64, string, string, *types.User
 // Suspend function User suspend
 //
 // expects implementation of suspend function:
-// func (h usersHandler) suspend(ctx context.Context, args *usersSuspendArgs) (err error) {
-//    return
-// }
+//
+//	func (h usersHandler) suspend(ctx context.Context, args *usersSuspendArgs) (err error) {
+//	   return
+//	}
 func (h usersHandler) Suspend() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersSuspend",
@@ -1102,9 +1112,10 @@ func (a usersUnsuspendArgs) GetLookup() (bool, uint64, string, string, *types.Us
 // Unsuspend function User unsuspend
 //
 // expects implementation of unsuspend function:
-// func (h usersHandler) unsuspend(ctx context.Context, args *usersUnsuspendArgs) (err error) {
-//    return
-// }
+//
+//	func (h usersHandler) unsuspend(ctx context.Context, args *usersUnsuspendArgs) (err error) {
+//	   return
+//	}
 func (h usersHandler) Unsuspend() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "usersUnsuspend",

--- a/server/system/automation/valuestore_handler.gen.go
+++ b/server/system/automation/valuestore_handler.gen.go
@@ -44,9 +44,10 @@ type (
 // Env function Get ENV variable
 //
 // expects implementation of env function:
-// func (h valuestoreHandler) env(ctx context.Context, args *valuestoreEnvArgs) (results *valuestoreEnvResults, err error) {
-//    return
-// }
+//
+//	func (h valuestoreHandler) env(ctx context.Context, args *valuestoreEnvArgs) (results *valuestoreEnvResults, err error) {
+//	   return
+//	}
 func (h valuestoreHandler) Env() *atypes.Function {
 	return &atypes.Function{
 		Ref:    "valuestoreEnv",

--- a/server/system/service/access_control_actions.gen.go
+++ b/server/system/service/access_control_actions.gen.go
@@ -52,7 +52,6 @@ var (
 // setRule updates accessControlActionProps's rule
 //
 // This function is auto-generated.
-//
 func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlActionProps {
 	p.rule = rule
 	return p
@@ -61,7 +60,6 @@ func (p *accessControlActionProps) setRule(rule *rbac.Rule) *accessControlAction
 // Serialize converts accessControlActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -80,7 +78,6 @@ func (p accessControlActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p accessControlActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -129,7 +126,6 @@ func (p accessControlActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *accessControlAction) String() string {
 	var props = &accessControlActionProps{}
 
@@ -157,7 +153,6 @@ func (e *accessControlAction) ToAction() *actionlog.Action {
 // AccessControlActionGrant returns "system:access_control.grant" action
 //
 // This function is auto-generated.
-//
 func AccessControlActionGrant(props ...*accessControlActionProps) *accessControlAction {
 	a := &accessControlAction{
 		timestamp: time.Now(),
@@ -180,9 +175,7 @@ func AccessControlActionGrant(props ...*accessControlActionProps) *accessControl
 
 // AccessControlErrGeneric returns "system:access_control.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -216,9 +209,7 @@ func AccessControlErrGeneric(mm ...*accessControlActionProps) *errors.Error {
 
 // AccessControlErrNotAllowedToSetPermissions returns "system:access_control.notAllowedToSetPermissions" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps) *errors.Error {
 	var p = &accessControlActionProps{}
 	if len(mm) > 0 {
@@ -256,7 +247,6 @@ func AccessControlErrNotAllowedToSetPermissions(mm ...*accessControlActionProps)
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc accessControl) recordAction(ctx context.Context, props *accessControlActionProps, actionFn func(...*accessControlActionProps) *accessControlAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/apigw_filter_actions.gen.go
+++ b/server/system/service/apigw_filter_actions.gen.go
@@ -53,7 +53,6 @@ var (
 // setFilter updates apigwFilterActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *apigwFilterActionProps) setFilter(filter *types.ApigwFilter) *apigwFilterActionProps {
 	p.filter = filter
 	return p
@@ -62,7 +61,6 @@ func (p *apigwFilterActionProps) setFilter(filter *types.ApigwFilter) *apigwFilt
 // setSearch updates apigwFilterActionProps's search
 //
 // This function is auto-generated.
-//
 func (p *apigwFilterActionProps) setSearch(search *types.ApigwFilterFilter) *apigwFilterActionProps {
 	p.search = search
 	return p
@@ -71,7 +69,6 @@ func (p *apigwFilterActionProps) setSearch(search *types.ApigwFilterFilter) *api
 // Serialize converts apigwFilterActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p apigwFilterActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -91,7 +88,6 @@ func (p apigwFilterActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p apigwFilterActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -148,7 +144,6 @@ func (p apigwFilterActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *apigwFilterAction) String() string {
 	var props = &apigwFilterActionProps{}
 
@@ -176,7 +171,6 @@ func (e *apigwFilterAction) ToAction() *actionlog.Action {
 // ApigwFilterActionSearch returns "system:filter.search" action
 //
 // This function is auto-generated.
-//
 func ApigwFilterActionSearch(props ...*apigwFilterActionProps) *apigwFilterAction {
 	a := &apigwFilterAction{
 		timestamp: time.Now(),
@@ -196,7 +190,6 @@ func ApigwFilterActionSearch(props ...*apigwFilterActionProps) *apigwFilterActio
 // ApigwFilterActionLookup returns "system:filter.lookup" action
 //
 // This function is auto-generated.
-//
 func ApigwFilterActionLookup(props ...*apigwFilterActionProps) *apigwFilterAction {
 	a := &apigwFilterAction{
 		timestamp: time.Now(),
@@ -216,7 +209,6 @@ func ApigwFilterActionLookup(props ...*apigwFilterActionProps) *apigwFilterActio
 // ApigwFilterActionCreate returns "system:filter.create" action
 //
 // This function is auto-generated.
-//
 func ApigwFilterActionCreate(props ...*apigwFilterActionProps) *apigwFilterAction {
 	a := &apigwFilterAction{
 		timestamp: time.Now(),
@@ -236,7 +228,6 @@ func ApigwFilterActionCreate(props ...*apigwFilterActionProps) *apigwFilterActio
 // ApigwFilterActionUpdate returns "system:filter.update" action
 //
 // This function is auto-generated.
-//
 func ApigwFilterActionUpdate(props ...*apigwFilterActionProps) *apigwFilterAction {
 	a := &apigwFilterAction{
 		timestamp: time.Now(),
@@ -256,7 +247,6 @@ func ApigwFilterActionUpdate(props ...*apigwFilterActionProps) *apigwFilterActio
 // ApigwFilterActionDelete returns "system:filter.delete" action
 //
 // This function is auto-generated.
-//
 func ApigwFilterActionDelete(props ...*apigwFilterActionProps) *apigwFilterAction {
 	a := &apigwFilterAction{
 		timestamp: time.Now(),
@@ -276,7 +266,6 @@ func ApigwFilterActionDelete(props ...*apigwFilterActionProps) *apigwFilterActio
 // ApigwFilterActionUndelete returns "system:filter.undelete" action
 //
 // This function is auto-generated.
-//
 func ApigwFilterActionUndelete(props ...*apigwFilterActionProps) *apigwFilterAction {
 	a := &apigwFilterAction{
 		timestamp: time.Now(),
@@ -299,9 +288,7 @@ func ApigwFilterActionUndelete(props ...*apigwFilterActionProps) *apigwFilterAct
 
 // ApigwFilterErrGeneric returns "system:filter.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrGeneric(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -335,9 +322,7 @@ func ApigwFilterErrGeneric(mm ...*apigwFilterActionProps) *errors.Error {
 
 // ApigwFilterErrNotFound returns "system:filter.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrNotFound(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -369,9 +354,7 @@ func ApigwFilterErrNotFound(mm ...*apigwFilterActionProps) *errors.Error {
 
 // ApigwFilterErrInvalidID returns "system:filter.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrInvalidID(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -403,9 +386,7 @@ func ApigwFilterErrInvalidID(mm ...*apigwFilterActionProps) *errors.Error {
 
 // ApigwFilterErrInvalidRoute returns "system:filter.invalidRoute" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrInvalidRoute(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -437,9 +418,7 @@ func ApigwFilterErrInvalidRoute(mm ...*apigwFilterActionProps) *errors.Error {
 
 // ApigwFilterErrStaleData returns "system:filter.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrStaleData(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -471,9 +450,7 @@ func ApigwFilterErrStaleData(mm ...*apigwFilterActionProps) *errors.Error {
 
 // ApigwFilterErrAsyncRouteTooManyProcessers returns "system:filter.asyncRouteTooManyProcessers" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrAsyncRouteTooManyProcessers(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -507,9 +484,7 @@ func ApigwFilterErrAsyncRouteTooManyProcessers(mm ...*apigwFilterActionProps) *e
 
 // ApigwFilterErrAsyncRouteTooManyAfterFilters returns "system:filter.asyncRouteTooManyAfterFilters" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwFilterErrAsyncRouteTooManyAfterFilters(mm ...*apigwFilterActionProps) *errors.Error {
 	var p = &apigwFilterActionProps{}
 	if len(mm) > 0 {
@@ -549,7 +524,6 @@ func ApigwFilterErrAsyncRouteTooManyAfterFilters(mm ...*apigwFilterActionProps) 
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc apigwFilter) recordAction(ctx context.Context, props *apigwFilterActionProps, actionFn func(...*apigwFilterActionProps) *apigwFilterAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/apigw_route_actions.gen.go
+++ b/server/system/service/apigw_route_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setRoute updates apigwRouteActionProps's route
 //
 // This function is auto-generated.
-//
 func (p *apigwRouteActionProps) setRoute(route *types.ApigwRoute) *apigwRouteActionProps {
 	p.route = route
 	return p
@@ -64,7 +63,6 @@ func (p *apigwRouteActionProps) setRoute(route *types.ApigwRoute) *apigwRouteAct
 // setNew updates apigwRouteActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *apigwRouteActionProps) setNew(new *types.ApigwRoute) *apigwRouteActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *apigwRouteActionProps) setNew(new *types.ApigwRoute) *apigwRouteActionP
 // setUpdate updates apigwRouteActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *apigwRouteActionProps) setUpdate(update *types.ApigwRoute) *apigwRouteActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *apigwRouteActionProps) setUpdate(update *types.ApigwRoute) *apigwRouteA
 // setSearch updates apigwRouteActionProps's search
 //
 // This function is auto-generated.
-//
 func (p *apigwRouteActionProps) setSearch(search *types.ApigwRouteFilter) *apigwRouteActionProps {
 	p.search = search
 	return p
@@ -91,7 +87,6 @@ func (p *apigwRouteActionProps) setSearch(search *types.ApigwRouteFilter) *apigw
 // Serialize converts apigwRouteActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p apigwRouteActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -118,7 +113,6 @@ func (p apigwRouteActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p apigwRouteActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -200,7 +194,6 @@ func (p apigwRouteActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *apigwRouteAction) String() string {
 	var props = &apigwRouteActionProps{}
 
@@ -228,7 +221,6 @@ func (e *apigwRouteAction) ToAction() *actionlog.Action {
 // ApigwRouteActionSearch returns "system:apigw-route.search" action
 //
 // This function is auto-generated.
-//
 func ApigwRouteActionSearch(props ...*apigwRouteActionProps) *apigwRouteAction {
 	a := &apigwRouteAction{
 		timestamp: time.Now(),
@@ -248,7 +240,6 @@ func ApigwRouteActionSearch(props ...*apigwRouteActionProps) *apigwRouteAction {
 // ApigwRouteActionLookup returns "system:apigw-route.lookup" action
 //
 // This function is auto-generated.
-//
 func ApigwRouteActionLookup(props ...*apigwRouteActionProps) *apigwRouteAction {
 	a := &apigwRouteAction{
 		timestamp: time.Now(),
@@ -268,7 +259,6 @@ func ApigwRouteActionLookup(props ...*apigwRouteActionProps) *apigwRouteAction {
 // ApigwRouteActionCreate returns "system:apigw-route.create" action
 //
 // This function is auto-generated.
-//
 func ApigwRouteActionCreate(props ...*apigwRouteActionProps) *apigwRouteAction {
 	a := &apigwRouteAction{
 		timestamp: time.Now(),
@@ -288,7 +278,6 @@ func ApigwRouteActionCreate(props ...*apigwRouteActionProps) *apigwRouteAction {
 // ApigwRouteActionUpdate returns "system:apigw-route.update" action
 //
 // This function is auto-generated.
-//
 func ApigwRouteActionUpdate(props ...*apigwRouteActionProps) *apigwRouteAction {
 	a := &apigwRouteAction{
 		timestamp: time.Now(),
@@ -308,7 +297,6 @@ func ApigwRouteActionUpdate(props ...*apigwRouteActionProps) *apigwRouteAction {
 // ApigwRouteActionDelete returns "system:apigw-route.delete" action
 //
 // This function is auto-generated.
-//
 func ApigwRouteActionDelete(props ...*apigwRouteActionProps) *apigwRouteAction {
 	a := &apigwRouteAction{
 		timestamp: time.Now(),
@@ -328,7 +316,6 @@ func ApigwRouteActionDelete(props ...*apigwRouteActionProps) *apigwRouteAction {
 // ApigwRouteActionUndelete returns "system:apigw-route.undelete" action
 //
 // This function is auto-generated.
-//
 func ApigwRouteActionUndelete(props ...*apigwRouteActionProps) *apigwRouteAction {
 	a := &apigwRouteAction{
 		timestamp: time.Now(),
@@ -351,9 +338,7 @@ func ApigwRouteActionUndelete(props ...*apigwRouteActionProps) *apigwRouteAction
 
 // ApigwRouteErrGeneric returns "system:apigw-route.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrGeneric(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -387,9 +372,7 @@ func ApigwRouteErrGeneric(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrNotFound returns "system:apigw-route.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotFound(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -421,9 +404,7 @@ func ApigwRouteErrNotFound(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrInvalidID returns "system:apigw-route.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrInvalidID(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -455,9 +436,7 @@ func ApigwRouteErrInvalidID(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrInvalidEndpoint returns "system:apigw-route.invalidEndpoint" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrInvalidEndpoint(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -489,9 +468,7 @@ func ApigwRouteErrInvalidEndpoint(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrStaleData returns "system:apigw-route.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrStaleData(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -523,9 +500,7 @@ func ApigwRouteErrStaleData(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrExistsEndpoint returns "system:apigw-route.existsEndpoint" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrExistsEndpoint(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -557,9 +532,7 @@ func ApigwRouteErrExistsEndpoint(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrAlreadyExists returns "system:apigw-route.alreadyExists" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrAlreadyExists(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -591,9 +564,7 @@ func ApigwRouteErrAlreadyExists(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrNotAllowedToCreate returns "system:apigw-route.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToCreate(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -627,9 +598,7 @@ func ApigwRouteErrNotAllowedToCreate(mm ...*apigwRouteActionProps) *errors.Error
 
 // ApigwRouteErrNotAllowedToRead returns "system:apigw-route.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToRead(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -663,9 +632,7 @@ func ApigwRouteErrNotAllowedToRead(mm ...*apigwRouteActionProps) *errors.Error {
 
 // ApigwRouteErrNotAllowedToSearch returns "system:apigw-route.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToSearch(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -699,9 +666,7 @@ func ApigwRouteErrNotAllowedToSearch(mm ...*apigwRouteActionProps) *errors.Error
 
 // ApigwRouteErrNotAllowedToUpdate returns "system:apigw-route.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToUpdate(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -735,9 +700,7 @@ func ApigwRouteErrNotAllowedToUpdate(mm ...*apigwRouteActionProps) *errors.Error
 
 // ApigwRouteErrNotAllowedToDelete returns "system:apigw-route.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToDelete(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -771,9 +734,7 @@ func ApigwRouteErrNotAllowedToDelete(mm ...*apigwRouteActionProps) *errors.Error
 
 // ApigwRouteErrNotAllowedToUndelete returns "system:apigw-route.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToUndelete(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -807,9 +768,7 @@ func ApigwRouteErrNotAllowedToUndelete(mm ...*apigwRouteActionProps) *errors.Err
 
 // ApigwRouteErrNotAllowedToExec returns "system:apigw-route.notAllowedToExec" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApigwRouteErrNotAllowedToExec(mm ...*apigwRouteActionProps) *errors.Error {
 	var p = &apigwRouteActionProps{}
 	if len(mm) > 0 {
@@ -849,7 +808,6 @@ func ApigwRouteErrNotAllowedToExec(mm ...*apigwRouteActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc apigwRoute) recordAction(ctx context.Context, props *apigwRouteActionProps, actionFn func(...*apigwRouteActionProps) *apigwRouteAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/application_actions.gen.go
+++ b/server/system/service/application_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setApplication updates applicationActionProps's application
 //
 // This function is auto-generated.
-//
 func (p *applicationActionProps) setApplication(application *types.Application) *applicationActionProps {
 	p.application = application
 	return p
@@ -64,7 +63,6 @@ func (p *applicationActionProps) setApplication(application *types.Application) 
 // setNew updates applicationActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *applicationActionProps) setNew(new *types.Application) *applicationActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *applicationActionProps) setNew(new *types.Application) *applicationActi
 // setUpdate updates applicationActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *applicationActionProps) setUpdate(update *types.Application) *applicationActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *applicationActionProps) setUpdate(update *types.Application) *applicati
 // setFilter updates applicationActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *applicationActionProps) setFilter(filter *types.ApplicationFilter) *applicationActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *applicationActionProps) setFilter(filter *types.ApplicationFilter) *app
 // Serialize converts applicationActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p applicationActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -122,7 +117,6 @@ func (p applicationActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p applicationActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -213,7 +207,6 @@ func (p applicationActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *applicationAction) String() string {
 	var props = &applicationActionProps{}
 
@@ -241,7 +234,6 @@ func (e *applicationAction) ToAction() *actionlog.Action {
 // ApplicationActionSearch returns "system:application.search" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionSearch(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -261,7 +253,6 @@ func ApplicationActionSearch(props ...*applicationActionProps) *applicationActio
 // ApplicationActionReorder returns "system:application.reorder" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionReorder(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -281,7 +272,6 @@ func ApplicationActionReorder(props ...*applicationActionProps) *applicationActi
 // ApplicationActionLookup returns "system:application.lookup" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionLookup(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -301,7 +291,6 @@ func ApplicationActionLookup(props ...*applicationActionProps) *applicationActio
 // ApplicationActionCreate returns "system:application.create" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionCreate(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -321,7 +310,6 @@ func ApplicationActionCreate(props ...*applicationActionProps) *applicationActio
 // ApplicationActionUpdate returns "system:application.update" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionUpdate(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -341,7 +329,6 @@ func ApplicationActionUpdate(props ...*applicationActionProps) *applicationActio
 // ApplicationActionDelete returns "system:application.delete" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionDelete(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -361,7 +348,6 @@ func ApplicationActionDelete(props ...*applicationActionProps) *applicationActio
 // ApplicationActionUndelete returns "system:application.undelete" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionUndelete(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -381,7 +367,6 @@ func ApplicationActionUndelete(props ...*applicationActionProps) *applicationAct
 // ApplicationActionFlagManage returns "system:application.flagManage" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionFlagManage(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -401,7 +386,6 @@ func ApplicationActionFlagManage(props ...*applicationActionProps) *applicationA
 // ApplicationActionFlagManageGlobal returns "system:application.flagManageGlobal" action
 //
 // This function is auto-generated.
-//
 func ApplicationActionFlagManageGlobal(props ...*applicationActionProps) *applicationAction {
 	a := &applicationAction{
 		timestamp: time.Now(),
@@ -424,9 +408,7 @@ func ApplicationActionFlagManageGlobal(props ...*applicationActionProps) *applic
 
 // ApplicationErrGeneric returns "system:application.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrGeneric(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -460,9 +442,7 @@ func ApplicationErrGeneric(mm ...*applicationActionProps) *errors.Error {
 
 // ApplicationErrNotFound returns "system:application.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotFound(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -494,9 +474,7 @@ func ApplicationErrNotFound(mm ...*applicationActionProps) *errors.Error {
 
 // ApplicationErrInvalidID returns "system:application.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrInvalidID(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -528,9 +506,7 @@ func ApplicationErrInvalidID(mm ...*applicationActionProps) *errors.Error {
 
 // ApplicationErrStaleData returns "system:application.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrStaleData(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -562,9 +538,7 @@ func ApplicationErrStaleData(mm ...*applicationActionProps) *errors.Error {
 
 // ApplicationErrNotAllowedToRead returns "system:application.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToRead(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -598,9 +572,7 @@ func ApplicationErrNotAllowedToRead(mm ...*applicationActionProps) *errors.Error
 
 // ApplicationErrNotAllowedToSearch returns "system:application.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToSearch(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -634,9 +606,7 @@ func ApplicationErrNotAllowedToSearch(mm ...*applicationActionProps) *errors.Err
 
 // ApplicationErrNotAllowedToCreate returns "system:application.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToCreate(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -670,9 +640,7 @@ func ApplicationErrNotAllowedToCreate(mm ...*applicationActionProps) *errors.Err
 
 // ApplicationErrNotAllowedToUpdate returns "system:application.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToUpdate(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -706,9 +674,7 @@ func ApplicationErrNotAllowedToUpdate(mm ...*applicationActionProps) *errors.Err
 
 // ApplicationErrNotAllowedToDelete returns "system:application.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToDelete(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -742,9 +708,7 @@ func ApplicationErrNotAllowedToDelete(mm ...*applicationActionProps) *errors.Err
 
 // ApplicationErrNotAllowedToUndelete returns "system:application.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToUndelete(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -778,9 +742,7 @@ func ApplicationErrNotAllowedToUndelete(mm ...*applicationActionProps) *errors.E
 
 // ApplicationErrNotAllowedToManageFlag returns "system:application.notAllowedToManageFlag" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToManageFlag(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -814,9 +776,7 @@ func ApplicationErrNotAllowedToManageFlag(mm ...*applicationActionProps) *errors
 
 // ApplicationErrNotAllowedToManageFlagGlobal returns "system:application.notAllowedToManageFlagGlobal" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ApplicationErrNotAllowedToManageFlagGlobal(mm ...*applicationActionProps) *errors.Error {
 	var p = &applicationActionProps{}
 	if len(mm) > 0 {
@@ -856,7 +816,6 @@ func ApplicationErrNotAllowedToManageFlagGlobal(mm ...*applicationActionProps) *
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc application) recordAction(ctx context.Context, props *applicationActionProps, actionFn func(...*applicationActionProps) *applicationAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/attachment_actions.gen.go
+++ b/server/system/service/attachment_actions.gen.go
@@ -57,7 +57,6 @@ var (
 // setSize updates attachmentActionProps's size
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setSize(size int64) *attachmentActionProps {
 	p.size = size
 	return p
@@ -66,7 +65,6 @@ func (p *attachmentActionProps) setSize(size int64) *attachmentActionProps {
 // setName updates attachmentActionProps's name
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setName(name string) *attachmentActionProps {
 	p.name = name
 	return p
@@ -75,7 +73,6 @@ func (p *attachmentActionProps) setName(name string) *attachmentActionProps {
 // setMimetype updates attachmentActionProps's mimetype
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setMimetype(mimetype string) *attachmentActionProps {
 	p.mimetype = mimetype
 	return p
@@ -84,7 +81,6 @@ func (p *attachmentActionProps) setMimetype(mimetype string) *attachmentActionPr
 // setUrl updates attachmentActionProps's url
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setUrl(url string) *attachmentActionProps {
 	p.url = url
 	return p
@@ -93,7 +89,6 @@ func (p *attachmentActionProps) setUrl(url string) *attachmentActionProps {
 // setAttachment updates attachmentActionProps's attachment
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setAttachment(attachment *types.Attachment) *attachmentActionProps {
 	p.attachment = attachment
 	return p
@@ -102,7 +97,6 @@ func (p *attachmentActionProps) setAttachment(attachment *types.Attachment) *att
 // setFilter updates attachmentActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *attachmentActionProps) setFilter(filter *types.AttachmentFilter) *attachmentActionProps {
 	p.filter = filter
 	return p
@@ -111,7 +105,6 @@ func (p *attachmentActionProps) setFilter(filter *types.AttachmentFilter) *attac
 // Serialize converts attachmentActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p attachmentActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -142,7 +135,6 @@ func (p attachmentActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p attachmentActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -217,7 +209,6 @@ func (p attachmentActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *attachmentAction) String() string {
 	var props = &attachmentActionProps{}
 
@@ -245,7 +236,6 @@ func (e *attachmentAction) ToAction() *actionlog.Action {
 // AttachmentActionSearch returns "system:attachment.search" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionSearch(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -265,7 +255,6 @@ func AttachmentActionSearch(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionLookup returns "system:attachment.lookup" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionLookup(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -285,7 +274,6 @@ func AttachmentActionLookup(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionCreate returns "system:attachment.create" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionCreate(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -305,7 +293,6 @@ func AttachmentActionCreate(props ...*attachmentActionProps) *attachmentAction {
 // AttachmentActionDelete returns "system:attachment.delete" action
 //
 // This function is auto-generated.
-//
 func AttachmentActionDelete(props ...*attachmentActionProps) *attachmentAction {
 	a := &attachmentAction{
 		timestamp: time.Now(),
@@ -328,9 +315,7 @@ func AttachmentActionDelete(props ...*attachmentActionProps) *attachmentAction {
 
 // AttachmentErrGeneric returns "system:attachment.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrGeneric(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -364,9 +349,7 @@ func AttachmentErrGeneric(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotFound returns "system:attachment.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotFound(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -398,9 +381,7 @@ func AttachmentErrNotFound(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrInvalidID returns "system:attachment.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidID(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -432,9 +413,7 @@ func AttachmentErrInvalidID(mm ...*attachmentActionProps) *errors.Error {
 
 // AttachmentErrNotAllowedToListAttachments returns "system:attachment.notAllowedToListAttachments" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToListAttachments(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -468,9 +447,7 @@ func AttachmentErrNotAllowedToListAttachments(mm ...*attachmentActionProps) *err
 
 // AttachmentErrNotAllowedToCreate returns "system:attachment.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreate(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -504,9 +481,7 @@ func AttachmentErrNotAllowedToCreate(mm ...*attachmentActionProps) *errors.Error
 
 // AttachmentErrNotAllowedToCreateEmptyAttachment returns "system:attachment.notAllowedToCreateEmptyAttachment" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrNotAllowedToCreateEmptyAttachment(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -540,9 +515,7 @@ func AttachmentErrNotAllowedToCreateEmptyAttachment(mm ...*attachmentActionProps
 
 // AttachmentErrFailedToExtractMimeType returns "system:attachment.failedToExtractMimeType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToExtractMimeType(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -574,9 +547,7 @@ func AttachmentErrFailedToExtractMimeType(mm ...*attachmentActionProps) *errors.
 
 // AttachmentErrFailedToStoreFile returns "system:attachment.failedToStoreFile" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToStoreFile(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -608,9 +579,7 @@ func AttachmentErrFailedToStoreFile(mm ...*attachmentActionProps) *errors.Error 
 
 // AttachmentErrFailedToProcessImage returns "system:attachment.failedToProcessImage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrFailedToProcessImage(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -642,9 +611,7 @@ func AttachmentErrFailedToProcessImage(mm ...*attachmentActionProps) *errors.Err
 
 // AttachmentErrInvalidAvatarFileType returns "system:attachment.invalidAvatarFileType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidAvatarFileType(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -676,9 +643,7 @@ func AttachmentErrInvalidAvatarFileType(mm ...*attachmentActionProps) *errors.Er
 
 // AttachmentErrInvalidAvatarFileSize returns "system:attachment.invalidAvatarFileSize" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidAvatarFileSize(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -710,9 +675,7 @@ func AttachmentErrInvalidAvatarFileSize(mm ...*attachmentActionProps) *errors.Er
 
 // AttachmentErrInvalidAvatarGenerateFontFile returns "system:attachment.invalidAvatarGenerateFontFile" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AttachmentErrInvalidAvatarGenerateFontFile(mm ...*attachmentActionProps) *errors.Error {
 	var p = &attachmentActionProps{}
 	if len(mm) > 0 {
@@ -750,7 +713,6 @@ func AttachmentErrInvalidAvatarGenerateFontFile(mm ...*attachmentActionProps) *e
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc attachment) recordAction(ctx context.Context, props *attachmentActionProps, actionFn func(...*attachmentActionProps) *attachmentAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/auth_actions.gen.go
+++ b/server/system/service/auth_actions.gen.go
@@ -56,7 +56,6 @@ var (
 // setEmail updates authActionProps's email
 //
 // This function is auto-generated.
-//
 func (p *authActionProps) setEmail(email string) *authActionProps {
 	p.email = email
 	return p
@@ -65,7 +64,6 @@ func (p *authActionProps) setEmail(email string) *authActionProps {
 // setProvider updates authActionProps's provider
 //
 // This function is auto-generated.
-//
 func (p *authActionProps) setProvider(provider string) *authActionProps {
 	p.provider = provider
 	return p
@@ -74,7 +72,6 @@ func (p *authActionProps) setProvider(provider string) *authActionProps {
 // setCredentials updates authActionProps's credentials
 //
 // This function is auto-generated.
-//
 func (p *authActionProps) setCredentials(credentials *types.Credential) *authActionProps {
 	p.credentials = credentials
 	return p
@@ -83,7 +80,6 @@ func (p *authActionProps) setCredentials(credentials *types.Credential) *authAct
 // setRole updates authActionProps's role
 //
 // This function is auto-generated.
-//
 func (p *authActionProps) setRole(role *types.Role) *authActionProps {
 	p.role = role
 	return p
@@ -92,7 +88,6 @@ func (p *authActionProps) setRole(role *types.Role) *authActionProps {
 // setUser updates authActionProps's user
 //
 // This function is auto-generated.
-//
 func (p *authActionProps) setUser(user *types.User) *authActionProps {
 	p.user = user
 	return p
@@ -101,7 +96,6 @@ func (p *authActionProps) setUser(user *types.User) *authActionProps {
 // Serialize converts authActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p authActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -134,7 +128,6 @@ func (p authActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p authActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -221,7 +214,6 @@ func (p authActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *authAction) String() string {
 	var props = &authActionProps{}
 
@@ -249,7 +241,6 @@ func (e *authAction) ToAction() *actionlog.Action {
 // AuthActionAuthenticate returns "system:auth.authenticate" action
 //
 // This function is auto-generated.
-//
 func AuthActionAuthenticate(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -269,7 +260,6 @@ func AuthActionAuthenticate(props ...*authActionProps) *authAction {
 // AuthActionIssueToken returns "system:auth.issueToken" action
 //
 // This function is auto-generated.
-//
 func AuthActionIssueToken(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -289,7 +279,6 @@ func AuthActionIssueToken(props ...*authActionProps) *authAction {
 // AuthActionValidateToken returns "system:auth.validateToken" action
 //
 // This function is auto-generated.
-//
 func AuthActionValidateToken(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -309,7 +298,6 @@ func AuthActionValidateToken(props ...*authActionProps) *authAction {
 // AuthActionChangePassword returns "system:auth.changePassword" action
 //
 // This function is auto-generated.
-//
 func AuthActionChangePassword(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -329,7 +317,6 @@ func AuthActionChangePassword(props ...*authActionProps) *authAction {
 // AuthActionInternalSignup returns "system:auth.internalSignup" action
 //
 // This function is auto-generated.
-//
 func AuthActionInternalSignup(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -349,7 +336,6 @@ func AuthActionInternalSignup(props ...*authActionProps) *authAction {
 // AuthActionConfirmEmail returns "system:auth.confirmEmail" action
 //
 // This function is auto-generated.
-//
 func AuthActionConfirmEmail(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -369,7 +355,6 @@ func AuthActionConfirmEmail(props ...*authActionProps) *authAction {
 // AuthActionExternalSignup returns "system:auth.externalSignup" action
 //
 // This function is auto-generated.
-//
 func AuthActionExternalSignup(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -389,7 +374,6 @@ func AuthActionExternalSignup(props ...*authActionProps) *authAction {
 // AuthActionSendEmailConfirmationToken returns "system:auth.sendEmailConfirmationToken" action
 //
 // This function is auto-generated.
-//
 func AuthActionSendEmailConfirmationToken(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -409,7 +393,6 @@ func AuthActionSendEmailConfirmationToken(props ...*authActionProps) *authAction
 // AuthActionSendPasswordResetToken returns "system:auth.sendPasswordResetToken" action
 //
 // This function is auto-generated.
-//
 func AuthActionSendPasswordResetToken(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -429,7 +412,6 @@ func AuthActionSendPasswordResetToken(props ...*authActionProps) *authAction {
 // AuthActionExchangePasswordResetToken returns "system:auth.exchangePasswordResetToken" action
 //
 // This function is auto-generated.
-//
 func AuthActionExchangePasswordResetToken(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -449,7 +431,6 @@ func AuthActionExchangePasswordResetToken(props ...*authActionProps) *authAction
 // AuthActionGeneratePasswordCreateToken returns "system:auth.generatePasswordCreateToken" action
 //
 // This function is auto-generated.
-//
 func AuthActionGeneratePasswordCreateToken(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -469,7 +450,6 @@ func AuthActionGeneratePasswordCreateToken(props ...*authActionProps) *authActio
 // AuthActionAutoPromote returns "system:auth.autoPromote" action
 //
 // This function is auto-generated.
-//
 func AuthActionAutoPromote(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -489,7 +469,6 @@ func AuthActionAutoPromote(props ...*authActionProps) *authAction {
 // AuthActionUpdateCredentials returns "system:auth.updateCredentials" action
 //
 // This function is auto-generated.
-//
 func AuthActionUpdateCredentials(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -509,7 +488,6 @@ func AuthActionUpdateCredentials(props ...*authActionProps) *authAction {
 // AuthActionCreateCredentials returns "system:auth.createCredentials" action
 //
 // This function is auto-generated.
-//
 func AuthActionCreateCredentials(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -529,7 +507,6 @@ func AuthActionCreateCredentials(props ...*authActionProps) *authAction {
 // AuthActionImpersonate returns "system:auth.impersonate" action
 //
 // This function is auto-generated.
-//
 func AuthActionImpersonate(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -549,7 +526,6 @@ func AuthActionImpersonate(props ...*authActionProps) *authAction {
 // AuthActionTotpConfigure returns "system:auth.totpConfigure" action
 //
 // This function is auto-generated.
-//
 func AuthActionTotpConfigure(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -569,7 +545,6 @@ func AuthActionTotpConfigure(props ...*authActionProps) *authAction {
 // AuthActionTotpRemove returns "system:auth.totpRemove" action
 //
 // This function is auto-generated.
-//
 func AuthActionTotpRemove(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -589,7 +564,6 @@ func AuthActionTotpRemove(props ...*authActionProps) *authAction {
 // AuthActionTotpValidate returns "system:auth.totpValidate" action
 //
 // This function is auto-generated.
-//
 func AuthActionTotpValidate(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -609,7 +583,6 @@ func AuthActionTotpValidate(props ...*authActionProps) *authAction {
 // AuthActionEmailOtpVerify returns "system:auth.emailOtpVerify" action
 //
 // This function is auto-generated.
-//
 func AuthActionEmailOtpVerify(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -629,7 +602,6 @@ func AuthActionEmailOtpVerify(props ...*authActionProps) *authAction {
 // AuthActionAccessTokensRemoved returns "system:auth.accessTokensRemoved" action
 //
 // This function is auto-generated.
-//
 func AuthActionAccessTokensRemoved(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -649,7 +621,6 @@ func AuthActionAccessTokensRemoved(props ...*authActionProps) *authAction {
 // AuthActionSendInviteEMail returns "system:auth.sendInviteEMail" action
 //
 // This function is auto-generated.
-//
 func AuthActionSendInviteEMail(props ...*authActionProps) *authAction {
 	a := &authAction{
 		timestamp: time.Now(),
@@ -672,9 +643,7 @@ func AuthActionSendInviteEMail(props ...*authActionProps) *authAction {
 
 // AuthErrGeneric returns "system:auth.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrGeneric(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -708,9 +677,7 @@ func AuthErrGeneric(mm ...*authActionProps) *errors.Error {
 
 // AuthErrInvalidCredentials returns "system:auth.invalidCredentials" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInvalidCredentials(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -744,9 +711,7 @@ func AuthErrInvalidCredentials(mm ...*authActionProps) *errors.Error {
 
 // AuthErrInvalidEmailFormat returns "system:auth.invalidEmailFormat" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInvalidEmailFormat(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -778,9 +743,7 @@ func AuthErrInvalidEmailFormat(mm ...*authActionProps) *errors.Error {
 
 // AuthErrInvalidHandle returns "system:auth.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInvalidHandle(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -815,7 +778,6 @@ func AuthErrInvalidHandle(mm ...*authActionProps) *errors.Error {
 // Note: This error will be wrapped with safe (system:auth.invalidCredentials) error!
 //
 // This function is auto-generated.
-//
 func AuthErrFailedForUnknownUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -855,7 +817,6 @@ func AuthErrFailedForUnknownUser(mm ...*authActionProps) *errors.Error {
 // Note: This error will be wrapped with safe (system:auth.invalidCredentials) error!
 //
 // This function is auto-generated.
-//
 func AuthErrFailedForDeletedUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -895,7 +856,6 @@ func AuthErrFailedForDeletedUser(mm ...*authActionProps) *errors.Error {
 // Note: This error will be wrapped with safe (system:auth.invalidCredentials) error!
 //
 // This function is auto-generated.
-//
 func AuthErrFailedForSuspendedUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -935,7 +895,6 @@ func AuthErrFailedForSuspendedUser(mm ...*authActionProps) *errors.Error {
 // Note: This error will be wrapped with safe (system:auth.invalidCredentials) error!
 //
 // This function is auto-generated.
-//
 func AuthErrFailedForSystemUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -972,9 +931,7 @@ func AuthErrFailedForSystemUser(mm ...*authActionProps) *errors.Error {
 
 // AuthErrFailedUnconfirmedEmail returns "system:auth.failedUnconfirmedEmail" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrFailedUnconfirmedEmail(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1008,9 +965,7 @@ func AuthErrFailedUnconfirmedEmail(mm ...*authActionProps) *errors.Error {
 
 // AuthErrInternalLoginDisabledByConfig returns "system:auth.internalLoginDisabledByConfig" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInternalLoginDisabledByConfig(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1042,9 +997,7 @@ func AuthErrInternalLoginDisabledByConfig(mm ...*authActionProps) *errors.Error 
 
 // AuthErrInternalSignupDisabledByConfig returns "system:auth.internalSignupDisabledByConfig" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInternalSignupDisabledByConfig(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1076,9 +1029,7 @@ func AuthErrInternalSignupDisabledByConfig(mm ...*authActionProps) *errors.Error
 
 // AuthErrPasswordChangeFailedForUnknownUser returns "system:auth.passwordChangeFailedForUnknownUser" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordChangeFailedForUnknownUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1110,9 +1061,7 @@ func AuthErrPasswordChangeFailedForUnknownUser(mm ...*authActionProps) *errors.E
 
 // AuthErrPasswordResetFailedOldPasswordCheckFailed returns "system:auth.passwordResetFailedOldPasswordCheckFailed" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordResetFailedOldPasswordCheckFailed(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1144,9 +1093,7 @@ func AuthErrPasswordResetFailedOldPasswordCheckFailed(mm ...*authActionProps) *e
 
 // AuthErrPasswordSetFailedReusedPasswordCheckFailed returns "system:auth.passwordSetFailedReusedPasswordCheckFailed" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordSetFailedReusedPasswordCheckFailed(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1178,9 +1125,7 @@ func AuthErrPasswordSetFailedReusedPasswordCheckFailed(mm ...*authActionProps) *
 
 // AuthErrPasswordCreateFailedForUnknownUser returns "system:auth.passwordCreateFailedForUnknownUser" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordCreateFailedForUnknownUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1212,9 +1157,7 @@ func AuthErrPasswordCreateFailedForUnknownUser(mm ...*authActionProps) *errors.E
 
 // AuthErrPasswordResetDisabledByConfig returns "system:auth.passwordResetDisabledByConfig" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordResetDisabledByConfig(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1246,9 +1189,7 @@ func AuthErrPasswordResetDisabledByConfig(mm ...*authActionProps) *errors.Error 
 
 // AuthErrPasswordCreateDisabledByConfig returns "system:auth.passwordCreateDisabledByConfig" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordCreateDisabledByConfig(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1280,9 +1221,7 @@ func AuthErrPasswordCreateDisabledByConfig(mm ...*authActionProps) *errors.Error
 
 // AuthErrPasswordNotSecure returns "system:auth.passwordNotSecure" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrPasswordNotSecure(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1314,9 +1253,7 @@ func AuthErrPasswordNotSecure(mm ...*authActionProps) *errors.Error {
 
 // AuthErrExternalDisabledByConfig returns "system:auth.externalDisabledByConfig" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrExternalDisabledByConfig(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1350,9 +1287,7 @@ func AuthErrExternalDisabledByConfig(mm ...*authActionProps) *errors.Error {
 
 // AuthErrProfileWithoutValidEmail returns "system:auth.profileWithoutValidEmail" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrProfileWithoutValidEmail(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1386,9 +1321,7 @@ func AuthErrProfileWithoutValidEmail(mm ...*authActionProps) *errors.Error {
 
 // AuthErrCredentialsLinkedToInvalidUser returns "system:auth.credentialsLinkedToInvalidUser" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrCredentialsLinkedToInvalidUser(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1420,9 +1353,7 @@ func AuthErrCredentialsLinkedToInvalidUser(mm ...*authActionProps) *errors.Error
 
 // AuthErrInvalidToken returns "system:auth.invalidToken" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInvalidToken(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1454,9 +1385,7 @@ func AuthErrInvalidToken(mm ...*authActionProps) *errors.Error {
 
 // AuthErrNotAllowedToImpersonate returns "system:auth.notAllowedToImpersonate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrNotAllowedToImpersonate(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1488,9 +1417,7 @@ func AuthErrNotAllowedToImpersonate(mm ...*authActionProps) *errors.Error {
 
 // AuthErrNotAllowedToRemoveTOTP returns "system:auth.notAllowedToRemoveTOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrNotAllowedToRemoveTOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1522,9 +1449,7 @@ func AuthErrNotAllowedToRemoveTOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrUnconfiguredTOTP returns "system:auth.unconfiguredTOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrUnconfiguredTOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1556,9 +1481,7 @@ func AuthErrUnconfiguredTOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrNotAllowedToConfigureTOTP returns "system:auth.notAllowedToConfigureTOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrNotAllowedToConfigureTOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1590,9 +1513,7 @@ func AuthErrNotAllowedToConfigureTOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrEnforcedMFAWithTOTP returns "system:auth.enforcedMFAWithTOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrEnforcedMFAWithTOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1624,9 +1545,7 @@ func AuthErrEnforcedMFAWithTOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrInvalidTOTP returns "system:auth.invalidTOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInvalidTOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1658,9 +1577,7 @@ func AuthErrInvalidTOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrDisabledMFAWithTOTP returns "system:auth.disabledMFAWithTOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrDisabledMFAWithTOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1692,9 +1609,7 @@ func AuthErrDisabledMFAWithTOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrDisabledMFAWithEmailOTP returns "system:auth.disabledMFAWithEmailOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrDisabledMFAWithEmailOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1726,9 +1641,7 @@ func AuthErrDisabledMFAWithEmailOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrEnforcedMFAWithEmailOTP returns "system:auth.enforcedMFAWithEmailOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrEnforcedMFAWithEmailOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1760,9 +1673,7 @@ func AuthErrEnforcedMFAWithEmailOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrInvalidEmailOTP returns "system:auth.invalidEmailOTP" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrInvalidEmailOTP(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1794,9 +1705,7 @@ func AuthErrInvalidEmailOTP(mm ...*authActionProps) *errors.Error {
 
 // AuthErrRateLimitExceeded returns "system:auth.rateLimitExceeded" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrRateLimitExceeded(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1830,9 +1739,7 @@ func AuthErrRateLimitExceeded(mm ...*authActionProps) *errors.Error {
 
 // AuthErrMaxUserLimitReached returns "system:auth.maxUserLimitReached" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrMaxUserLimitReached(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1864,9 +1771,7 @@ func AuthErrMaxUserLimitReached(mm ...*authActionProps) *errors.Error {
 
 // AuthErrDisabledSendUserInviteEmail returns "system:auth.disabledSendUserInviteEmail" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthErrDisabledSendUserInviteEmail(mm ...*authActionProps) *errors.Error {
 	var p = &authActionProps{}
 	if len(mm) > 0 {
@@ -1904,7 +1809,6 @@ func AuthErrDisabledSendUserInviteEmail(mm ...*authActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc auth) recordAction(ctx context.Context, props *authActionProps, actionFn func(...*authActionProps) *authAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/auth_client_actions.gen.go
+++ b/server/system/service/auth_client_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setAuthClient updates authClientActionProps's authClient
 //
 // This function is auto-generated.
-//
 func (p *authClientActionProps) setAuthClient(authClient *types.AuthClient) *authClientActionProps {
 	p.authClient = authClient
 	return p
@@ -64,7 +63,6 @@ func (p *authClientActionProps) setAuthClient(authClient *types.AuthClient) *aut
 // setNew updates authClientActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *authClientActionProps) setNew(new *types.AuthClient) *authClientActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *authClientActionProps) setNew(new *types.AuthClient) *authClientActionP
 // setUpdate updates authClientActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *authClientActionProps) setUpdate(update *types.AuthClient) *authClientActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *authClientActionProps) setUpdate(update *types.AuthClient) *authClientA
 // setFilter updates authClientActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *authClientActionProps) setFilter(filter *types.AuthClientFilter) *authClientActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *authClientActionProps) setFilter(filter *types.AuthClientFilter) *authC
 // Serialize converts authClientActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p authClientActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -121,7 +116,6 @@ func (p authClientActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p authClientActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -210,7 +204,6 @@ func (p authClientActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *authClientAction) String() string {
 	var props = &authClientActionProps{}
 
@@ -238,7 +231,6 @@ func (e *authClientAction) ToAction() *actionlog.Action {
 // AuthClientActionSearch returns "system:auth-client.search" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionSearch(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -258,7 +250,6 @@ func AuthClientActionSearch(props ...*authClientActionProps) *authClientAction {
 // AuthClientActionLookup returns "system:auth-client.lookup" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionLookup(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -278,7 +269,6 @@ func AuthClientActionLookup(props ...*authClientActionProps) *authClientAction {
 // AuthClientActionCreate returns "system:auth-client.create" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionCreate(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -298,7 +288,6 @@ func AuthClientActionCreate(props ...*authClientActionProps) *authClientAction {
 // AuthClientActionUpdate returns "system:auth-client.update" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionUpdate(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -318,7 +307,6 @@ func AuthClientActionUpdate(props ...*authClientActionProps) *authClientAction {
 // AuthClientActionDelete returns "system:auth-client.delete" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionDelete(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -338,7 +326,6 @@ func AuthClientActionDelete(props ...*authClientActionProps) *authClientAction {
 // AuthClientActionUndelete returns "system:auth-client.undelete" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionUndelete(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -358,7 +345,6 @@ func AuthClientActionUndelete(props ...*authClientActionProps) *authClientAction
 // AuthClientActionExposeSecret returns "system:auth-client.exposeSecret" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionExposeSecret(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -378,7 +364,6 @@ func AuthClientActionExposeSecret(props ...*authClientActionProps) *authClientAc
 // AuthClientActionRegenerateSecret returns "system:auth-client.regenerateSecret" action
 //
 // This function is auto-generated.
-//
 func AuthClientActionRegenerateSecret(props ...*authClientActionProps) *authClientAction {
 	a := &authClientAction{
 		timestamp: time.Now(),
@@ -401,9 +386,7 @@ func AuthClientActionRegenerateSecret(props ...*authClientActionProps) *authClie
 
 // AuthClientErrGeneric returns "system:auth-client.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrGeneric(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -437,9 +420,7 @@ func AuthClientErrGeneric(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrNotFound returns "system:auth-client.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotFound(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -471,9 +452,7 @@ func AuthClientErrNotFound(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrInvalidID returns "system:auth-client.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrInvalidID(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -505,9 +484,7 @@ func AuthClientErrInvalidID(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrStaleData returns "system:auth-client.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrStaleData(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -539,9 +516,7 @@ func AuthClientErrStaleData(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrMissingName returns "system:auth-client.missingName" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrMissingName(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -573,9 +548,7 @@ func AuthClientErrMissingName(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrUnknownGrantType returns "system:auth-client.unknownGrantType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrUnknownGrantType(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -607,9 +580,7 @@ func AuthClientErrUnknownGrantType(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrUnknownScope returns "system:auth-client.unknownScope" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrUnknownScope(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -641,9 +612,7 @@ func AuthClientErrUnknownScope(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrUnableToChangeDefaultClientHandle returns "system:auth-client.unableToChangeDefaultClientHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrUnableToChangeDefaultClientHandle(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -677,9 +646,7 @@ func AuthClientErrUnableToChangeDefaultClientHandle(mm ...*authClientActionProps
 
 // AuthClientErrUnableToDisableDefaultClient returns "system:auth-client.unableToDisableDefaultClient" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrUnableToDisableDefaultClient(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -713,9 +680,7 @@ func AuthClientErrUnableToDisableDefaultClient(mm ...*authClientActionProps) *er
 
 // AuthClientErrUnableToDeleteDefaultClient returns "system:auth-client.unableToDeleteDefaultClient" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrUnableToDeleteDefaultClient(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -749,9 +714,7 @@ func AuthClientErrUnableToDeleteDefaultClient(mm ...*authClientActionProps) *err
 
 // AuthClientErrNotAllowedToRead returns "system:auth-client.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotAllowedToRead(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -785,9 +748,7 @@ func AuthClientErrNotAllowedToRead(mm ...*authClientActionProps) *errors.Error {
 
 // AuthClientErrNotAllowedToSearch returns "system:auth-client.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotAllowedToSearch(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -821,9 +782,7 @@ func AuthClientErrNotAllowedToSearch(mm ...*authClientActionProps) *errors.Error
 
 // AuthClientErrNotAllowedToCreate returns "system:auth-client.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotAllowedToCreate(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -857,9 +816,7 @@ func AuthClientErrNotAllowedToCreate(mm ...*authClientActionProps) *errors.Error
 
 // AuthClientErrNotAllowedToUpdate returns "system:auth-client.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotAllowedToUpdate(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -893,9 +850,7 @@ func AuthClientErrNotAllowedToUpdate(mm ...*authClientActionProps) *errors.Error
 
 // AuthClientErrNotAllowedToDelete returns "system:auth-client.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotAllowedToDelete(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -929,9 +884,7 @@ func AuthClientErrNotAllowedToDelete(mm ...*authClientActionProps) *errors.Error
 
 // AuthClientErrNotAllowedToUndelete returns "system:auth-client.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func AuthClientErrNotAllowedToUndelete(mm ...*authClientActionProps) *errors.Error {
 	var p = &authClientActionProps{}
 	if len(mm) > 0 {
@@ -971,7 +924,6 @@ func AuthClientErrNotAllowedToUndelete(mm ...*authClientActionProps) *errors.Err
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc authClient) recordAction(ctx context.Context, props *authClientActionProps, actionFn func(...*authClientActionProps) *authClientAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/credentials_actions.gen.go
+++ b/server/system/service/credentials_actions.gen.go
@@ -53,7 +53,6 @@ var (
 // setUser updates credentialsActionProps's user
 //
 // This function is auto-generated.
-//
 func (p *credentialsActionProps) setUser(user *types.User) *credentialsActionProps {
 	p.user = user
 	return p
@@ -62,7 +61,6 @@ func (p *credentialsActionProps) setUser(user *types.User) *credentialsActionPro
 // setCredentials updates credentialsActionProps's credentials
 //
 // This function is auto-generated.
-//
 func (p *credentialsActionProps) setCredentials(credentials *types.Credential) *credentialsActionProps {
 	p.credentials = credentials
 	return p
@@ -71,7 +69,6 @@ func (p *credentialsActionProps) setCredentials(credentials *types.Credential) *
 // Serialize converts credentialsActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p credentialsActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -94,7 +91,6 @@ func (p credentialsActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p credentialsActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -157,7 +153,6 @@ func (p credentialsActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *credentialsAction) String() string {
 	var props = &credentialsActionProps{}
 
@@ -185,7 +180,6 @@ func (e *credentialsAction) ToAction() *actionlog.Action {
 // CredentialsActionSearch returns "system:credentials.search" action
 //
 // This function is auto-generated.
-//
 func CredentialsActionSearch(props ...*credentialsActionProps) *credentialsAction {
 	a := &credentialsAction{
 		timestamp: time.Now(),
@@ -205,7 +199,6 @@ func CredentialsActionSearch(props ...*credentialsActionProps) *credentialsActio
 // CredentialsActionDelete returns "system:credentials.delete" action
 //
 // This function is auto-generated.
-//
 func CredentialsActionDelete(props ...*credentialsActionProps) *credentialsAction {
 	a := &credentialsAction{
 		timestamp: time.Now(),
@@ -225,7 +218,6 @@ func CredentialsActionDelete(props ...*credentialsActionProps) *credentialsActio
 // CredentialsActionCreate returns "system:credentials.create" action
 //
 // This function is auto-generated.
-//
 func CredentialsActionCreate(props ...*credentialsActionProps) *credentialsAction {
 	a := &credentialsAction{
 		timestamp: time.Now(),
@@ -245,7 +237,6 @@ func CredentialsActionCreate(props ...*credentialsActionProps) *credentialsActio
 // CredentialsActionUpdate returns "system:credentials.update" action
 //
 // This function is auto-generated.
-//
 func CredentialsActionUpdate(props ...*credentialsActionProps) *credentialsAction {
 	a := &credentialsAction{
 		timestamp: time.Now(),
@@ -268,9 +259,7 @@ func CredentialsActionUpdate(props ...*credentialsActionProps) *credentialsActio
 
 // CredentialsErrGeneric returns "system:credentials.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func CredentialsErrGeneric(mm ...*credentialsActionProps) *errors.Error {
 	var p = &credentialsActionProps{}
 	if len(mm) > 0 {
@@ -304,9 +293,7 @@ func CredentialsErrGeneric(mm ...*credentialsActionProps) *errors.Error {
 
 // CredentialsErrNotFound returns "system:credentials.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func CredentialsErrNotFound(mm ...*credentialsActionProps) *errors.Error {
 	var p = &credentialsActionProps{}
 	if len(mm) > 0 {
@@ -338,9 +325,7 @@ func CredentialsErrNotFound(mm ...*credentialsActionProps) *errors.Error {
 
 // CredentialsErrInvalidID returns "system:credentials.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func CredentialsErrInvalidID(mm ...*credentialsActionProps) *errors.Error {
 	var p = &credentialsActionProps{}
 	if len(mm) > 0 {
@@ -372,9 +357,7 @@ func CredentialsErrInvalidID(mm ...*credentialsActionProps) *errors.Error {
 
 // CredentialsErrNotAllowedToManage returns "system:credentials.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func CredentialsErrNotAllowedToManage(mm ...*credentialsActionProps) *errors.Error {
 	var p = &credentialsActionProps{}
 	if len(mm) > 0 {
@@ -414,7 +397,6 @@ func CredentialsErrNotAllowedToManage(mm ...*credentialsActionProps) *errors.Err
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc credentials) recordAction(ctx context.Context, props *credentialsActionProps, actionFn func(...*credentialsActionProps) *credentialsAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/dal_connection_actions.gen.go
+++ b/server/system/service/dal_connection_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setConnection updates dalConnectionActionProps's connection
 //
 // This function is auto-generated.
-//
 func (p *dalConnectionActionProps) setConnection(connection *types.DalConnection) *dalConnectionActionProps {
 	p.connection = connection
 	return p
@@ -64,7 +63,6 @@ func (p *dalConnectionActionProps) setConnection(connection *types.DalConnection
 // setNew updates dalConnectionActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *dalConnectionActionProps) setNew(new *types.DalConnection) *dalConnectionActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *dalConnectionActionProps) setNew(new *types.DalConnection) *dalConnecti
 // setUpdate updates dalConnectionActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *dalConnectionActionProps) setUpdate(update *types.DalConnection) *dalConnectionActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *dalConnectionActionProps) setUpdate(update *types.DalConnection) *dalCo
 // setSearch updates dalConnectionActionProps's search
 //
 // This function is auto-generated.
-//
 func (p *dalConnectionActionProps) setSearch(search *types.DalConnectionFilter) *dalConnectionActionProps {
 	p.search = search
 	return p
@@ -91,7 +87,6 @@ func (p *dalConnectionActionProps) setSearch(search *types.DalConnectionFilter) 
 // Serialize converts dalConnectionActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p dalConnectionActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -118,7 +113,6 @@ func (p dalConnectionActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p dalConnectionActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -200,7 +194,6 @@ func (p dalConnectionActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *dalConnectionAction) String() string {
 	var props = &dalConnectionActionProps{}
 
@@ -228,7 +221,6 @@ func (e *dalConnectionAction) ToAction() *actionlog.Action {
 // DalConnectionActionSearch returns "system:dal-connection.search" action
 //
 // This function is auto-generated.
-//
 func DalConnectionActionSearch(props ...*dalConnectionActionProps) *dalConnectionAction {
 	a := &dalConnectionAction{
 		timestamp: time.Now(),
@@ -248,7 +240,6 @@ func DalConnectionActionSearch(props ...*dalConnectionActionProps) *dalConnectio
 // DalConnectionActionLookup returns "system:dal-connection.lookup" action
 //
 // This function is auto-generated.
-//
 func DalConnectionActionLookup(props ...*dalConnectionActionProps) *dalConnectionAction {
 	a := &dalConnectionAction{
 		timestamp: time.Now(),
@@ -268,7 +259,6 @@ func DalConnectionActionLookup(props ...*dalConnectionActionProps) *dalConnectio
 // DalConnectionActionCreate returns "system:dal-connection.create" action
 //
 // This function is auto-generated.
-//
 func DalConnectionActionCreate(props ...*dalConnectionActionProps) *dalConnectionAction {
 	a := &dalConnectionAction{
 		timestamp: time.Now(),
@@ -288,7 +278,6 @@ func DalConnectionActionCreate(props ...*dalConnectionActionProps) *dalConnectio
 // DalConnectionActionUpdate returns "system:dal-connection.update" action
 //
 // This function is auto-generated.
-//
 func DalConnectionActionUpdate(props ...*dalConnectionActionProps) *dalConnectionAction {
 	a := &dalConnectionAction{
 		timestamp: time.Now(),
@@ -308,7 +297,6 @@ func DalConnectionActionUpdate(props ...*dalConnectionActionProps) *dalConnectio
 // DalConnectionActionDelete returns "system:dal-connection.delete" action
 //
 // This function is auto-generated.
-//
 func DalConnectionActionDelete(props ...*dalConnectionActionProps) *dalConnectionAction {
 	a := &dalConnectionAction{
 		timestamp: time.Now(),
@@ -328,7 +316,6 @@ func DalConnectionActionDelete(props ...*dalConnectionActionProps) *dalConnectio
 // DalConnectionActionUndelete returns "system:dal-connection.undelete" action
 //
 // This function is auto-generated.
-//
 func DalConnectionActionUndelete(props ...*dalConnectionActionProps) *dalConnectionAction {
 	a := &dalConnectionAction{
 		timestamp: time.Now(),
@@ -351,9 +338,7 @@ func DalConnectionActionUndelete(props ...*dalConnectionActionProps) *dalConnect
 
 // DalConnectionErrGeneric returns "system:dal-connection.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrGeneric(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -387,9 +372,7 @@ func DalConnectionErrGeneric(mm ...*dalConnectionActionProps) *errors.Error {
 
 // DalConnectionErrNotFound returns "system:dal-connection.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotFound(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -421,9 +404,7 @@ func DalConnectionErrNotFound(mm ...*dalConnectionActionProps) *errors.Error {
 
 // DalConnectionErrInvalidID returns "system:dal-connection.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrInvalidID(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -455,9 +436,7 @@ func DalConnectionErrInvalidID(mm ...*dalConnectionActionProps) *errors.Error {
 
 // DalConnectionErrMissingName returns "system:dal-connection.missingName" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrMissingName(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -489,9 +468,7 @@ func DalConnectionErrMissingName(mm ...*dalConnectionActionProps) *errors.Error 
 
 // DalConnectionErrInvalidEndpoint returns "system:dal-connection.invalidEndpoint" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrInvalidEndpoint(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -523,9 +500,7 @@ func DalConnectionErrInvalidEndpoint(mm ...*dalConnectionActionProps) *errors.Er
 
 // DalConnectionErrStaleData returns "system:dal-connection.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrStaleData(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -557,9 +532,7 @@ func DalConnectionErrStaleData(mm ...*dalConnectionActionProps) *errors.Error {
 
 // DalConnectionErrExistsEndpoint returns "system:dal-connection.existsEndpoint" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrExistsEndpoint(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -591,9 +564,7 @@ func DalConnectionErrExistsEndpoint(mm ...*dalConnectionActionProps) *errors.Err
 
 // DalConnectionErrAlreadyExists returns "system:dal-connection.alreadyExists" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrAlreadyExists(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -625,9 +596,7 @@ func DalConnectionErrAlreadyExists(mm ...*dalConnectionActionProps) *errors.Erro
 
 // DalConnectionErrNotAllowedToCreate returns "system:dal-connection.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToCreate(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -661,9 +630,7 @@ func DalConnectionErrNotAllowedToCreate(mm ...*dalConnectionActionProps) *errors
 
 // DalConnectionErrNotAllowedToRead returns "system:dal-connection.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToRead(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -697,9 +664,7 @@ func DalConnectionErrNotAllowedToRead(mm ...*dalConnectionActionProps) *errors.E
 
 // DalConnectionErrNotAllowedToSearch returns "system:dal-connection.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToSearch(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -733,9 +698,7 @@ func DalConnectionErrNotAllowedToSearch(mm ...*dalConnectionActionProps) *errors
 
 // DalConnectionErrNotAllowedToUpdate returns "system:dal-connection.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToUpdate(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -769,9 +732,7 @@ func DalConnectionErrNotAllowedToUpdate(mm ...*dalConnectionActionProps) *errors
 
 // DalConnectionErrNotAllowedToDelete returns "system:dal-connection.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToDelete(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -805,9 +766,7 @@ func DalConnectionErrNotAllowedToDelete(mm ...*dalConnectionActionProps) *errors
 
 // DalConnectionErrNotAllowedToUndelete returns "system:dal-connection.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToUndelete(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -841,9 +800,7 @@ func DalConnectionErrNotAllowedToUndelete(mm ...*dalConnectionActionProps) *erro
 
 // DalConnectionErrNotAllowedToExec returns "system:dal-connection.notAllowedToExec" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalConnectionErrNotAllowedToExec(mm ...*dalConnectionActionProps) *errors.Error {
 	var p = &dalConnectionActionProps{}
 	if len(mm) > 0 {
@@ -883,7 +840,6 @@ func DalConnectionErrNotAllowedToExec(mm ...*dalConnectionActionProps) *errors.E
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc dalConnection) recordAction(ctx context.Context, props *dalConnectionActionProps, actionFn func(...*dalConnectionActionProps) *dalConnectionAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/dal_schema_alteration_actions.gen.go
+++ b/server/system/service/dal_schema_alteration_actions.gen.go
@@ -57,7 +57,6 @@ var (
 // setDalSchemaAlteration updates dalSchemaAlterationActionProps's dalSchemaAlteration
 //
 // This function is auto-generated.
-//
 func (p *dalSchemaAlterationActionProps) setDalSchemaAlteration(dalSchemaAlteration *types.DalSchemaAlteration) *dalSchemaAlterationActionProps {
 	p.dalSchemaAlteration = dalSchemaAlteration
 	return p
@@ -66,7 +65,6 @@ func (p *dalSchemaAlterationActionProps) setDalSchemaAlteration(dalSchemaAlterat
 // setNew updates dalSchemaAlterationActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *dalSchemaAlterationActionProps) setNew(new *types.DalSchemaAlteration) *dalSchemaAlterationActionProps {
 	p.new = new
 	return p
@@ -75,7 +73,6 @@ func (p *dalSchemaAlterationActionProps) setNew(new *types.DalSchemaAlteration) 
 // setApply updates dalSchemaAlterationActionProps's apply
 //
 // This function is auto-generated.
-//
 func (p *dalSchemaAlterationActionProps) setApply(apply []uint64) *dalSchemaAlterationActionProps {
 	p.apply = apply
 	return p
@@ -84,7 +81,6 @@ func (p *dalSchemaAlterationActionProps) setApply(apply []uint64) *dalSchemaAlte
 // setDismiss updates dalSchemaAlterationActionProps's dismiss
 //
 // This function is auto-generated.
-//
 func (p *dalSchemaAlterationActionProps) setDismiss(dismiss []uint64) *dalSchemaAlterationActionProps {
 	p.dismiss = dismiss
 	return p
@@ -93,7 +89,6 @@ func (p *dalSchemaAlterationActionProps) setDismiss(dismiss []uint64) *dalSchema
 // setExisting updates dalSchemaAlterationActionProps's existing
 //
 // This function is auto-generated.
-//
 func (p *dalSchemaAlterationActionProps) setExisting(existing *types.DalSchemaAlteration) *dalSchemaAlterationActionProps {
 	p.existing = existing
 	return p
@@ -102,7 +97,6 @@ func (p *dalSchemaAlterationActionProps) setExisting(existing *types.DalSchemaAl
 // setFilter updates dalSchemaAlterationActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *dalSchemaAlterationActionProps) setFilter(filter *types.DalSchemaAlterationFilter) *dalSchemaAlterationActionProps {
 	p.filter = filter
 	return p
@@ -111,7 +105,6 @@ func (p *dalSchemaAlterationActionProps) setFilter(filter *types.DalSchemaAltera
 // Serialize converts dalSchemaAlterationActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p dalSchemaAlterationActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -142,7 +135,6 @@ func (p dalSchemaAlterationActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p dalSchemaAlterationActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -231,7 +223,6 @@ func (p dalSchemaAlterationActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *dalSchemaAlterationAction) String() string {
 	var props = &dalSchemaAlterationActionProps{}
 
@@ -259,7 +250,6 @@ func (e *dalSchemaAlterationAction) ToAction() *actionlog.Action {
 // DalSchemaAlterationActionSearch returns "system:dal-schema-alteration.search" action
 //
 // This function is auto-generated.
-//
 func DalSchemaAlterationActionSearch(props ...*dalSchemaAlterationActionProps) *dalSchemaAlterationAction {
 	a := &dalSchemaAlterationAction{
 		timestamp: time.Now(),
@@ -279,7 +269,6 @@ func DalSchemaAlterationActionSearch(props ...*dalSchemaAlterationActionProps) *
 // DalSchemaAlterationActionApply returns "system:dal-schema-alteration.apply" action
 //
 // This function is auto-generated.
-//
 func DalSchemaAlterationActionApply(props ...*dalSchemaAlterationActionProps) *dalSchemaAlterationAction {
 	a := &dalSchemaAlterationAction{
 		timestamp: time.Now(),
@@ -299,7 +288,6 @@ func DalSchemaAlterationActionApply(props ...*dalSchemaAlterationActionProps) *d
 // DalSchemaAlterationActionDismiss returns "system:dal-schema-alteration.dismiss" action
 //
 // This function is auto-generated.
-//
 func DalSchemaAlterationActionDismiss(props ...*dalSchemaAlterationActionProps) *dalSchemaAlterationAction {
 	a := &dalSchemaAlterationAction{
 		timestamp: time.Now(),
@@ -319,7 +307,6 @@ func DalSchemaAlterationActionDismiss(props ...*dalSchemaAlterationActionProps) 
 // DalSchemaAlterationActionLookup returns "system:dal-schema-alteration.lookup" action
 //
 // This function is auto-generated.
-//
 func DalSchemaAlterationActionLookup(props ...*dalSchemaAlterationActionProps) *dalSchemaAlterationAction {
 	a := &dalSchemaAlterationAction{
 		timestamp: time.Now(),
@@ -342,9 +329,7 @@ func DalSchemaAlterationActionLookup(props ...*dalSchemaAlterationActionProps) *
 
 // DalSchemaAlterationErrGeneric returns "system:dal-schema-alteration.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSchemaAlterationErrGeneric(mm ...*dalSchemaAlterationActionProps) *errors.Error {
 	var p = &dalSchemaAlterationActionProps{}
 	if len(mm) > 0 {
@@ -378,9 +363,7 @@ func DalSchemaAlterationErrGeneric(mm ...*dalSchemaAlterationActionProps) *error
 
 // DalSchemaAlterationErrNotFound returns "system:dal-schema-alteration.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSchemaAlterationErrNotFound(mm ...*dalSchemaAlterationActionProps) *errors.Error {
 	var p = &dalSchemaAlterationActionProps{}
 	if len(mm) > 0 {
@@ -412,9 +395,7 @@ func DalSchemaAlterationErrNotFound(mm ...*dalSchemaAlterationActionProps) *erro
 
 // DalSchemaAlterationErrInvalidID returns "system:dal-schema-alteration.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSchemaAlterationErrInvalidID(mm ...*dalSchemaAlterationActionProps) *errors.Error {
 	var p = &dalSchemaAlterationActionProps{}
 	if len(mm) > 0 {
@@ -446,9 +427,7 @@ func DalSchemaAlterationErrInvalidID(mm ...*dalSchemaAlterationActionProps) *err
 
 // DalSchemaAlterationErrNotAllowedToManage returns "system:dal-schema-alteration.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSchemaAlterationErrNotAllowedToManage(mm ...*dalSchemaAlterationActionProps) *errors.Error {
 	var p = &dalSchemaAlterationActionProps{}
 	if len(mm) > 0 {
@@ -488,7 +467,6 @@ func DalSchemaAlterationErrNotAllowedToManage(mm ...*dalSchemaAlterationActionPr
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc dalSchemaAlteration) recordAction(ctx context.Context, props *dalSchemaAlterationActionProps, actionFn func(...*dalSchemaAlterationActionProps) *dalSchemaAlterationAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/dal_sensitivity_level_actions.gen.go
+++ b/server/system/service/dal_sensitivity_level_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setSensitivityLevel updates dalSensitivityLevelActionProps's sensitivityLevel
 //
 // This function is auto-generated.
-//
 func (p *dalSensitivityLevelActionProps) setSensitivityLevel(sensitivityLevel *types.DalSensitivityLevel) *dalSensitivityLevelActionProps {
 	p.sensitivityLevel = sensitivityLevel
 	return p
@@ -64,7 +63,6 @@ func (p *dalSensitivityLevelActionProps) setSensitivityLevel(sensitivityLevel *t
 // setNew updates dalSensitivityLevelActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *dalSensitivityLevelActionProps) setNew(new *types.DalSensitivityLevel) *dalSensitivityLevelActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *dalSensitivityLevelActionProps) setNew(new *types.DalSensitivityLevel) 
 // setUpdate updates dalSensitivityLevelActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *dalSensitivityLevelActionProps) setUpdate(update *types.DalSensitivityLevel) *dalSensitivityLevelActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *dalSensitivityLevelActionProps) setUpdate(update *types.DalSensitivityL
 // setSearch updates dalSensitivityLevelActionProps's search
 //
 // This function is auto-generated.
-//
 func (p *dalSensitivityLevelActionProps) setSearch(search *types.DalSensitivityLevelFilter) *dalSensitivityLevelActionProps {
 	p.search = search
 	return p
@@ -91,7 +87,6 @@ func (p *dalSensitivityLevelActionProps) setSearch(search *types.DalSensitivityL
 // Serialize converts dalSensitivityLevelActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p dalSensitivityLevelActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -118,7 +113,6 @@ func (p dalSensitivityLevelActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p dalSensitivityLevelActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -200,7 +194,6 @@ func (p dalSensitivityLevelActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *dalSensitivityLevelAction) String() string {
 	var props = &dalSensitivityLevelActionProps{}
 
@@ -228,7 +221,6 @@ func (e *dalSensitivityLevelAction) ToAction() *actionlog.Action {
 // DalSensitivityLevelActionSearch returns "system:dal-sensitivity-level.search" action
 //
 // This function is auto-generated.
-//
 func DalSensitivityLevelActionSearch(props ...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction {
 	a := &dalSensitivityLevelAction{
 		timestamp: time.Now(),
@@ -248,7 +240,6 @@ func DalSensitivityLevelActionSearch(props ...*dalSensitivityLevelActionProps) *
 // DalSensitivityLevelActionLookup returns "system:dal-sensitivity-level.lookup" action
 //
 // This function is auto-generated.
-//
 func DalSensitivityLevelActionLookup(props ...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction {
 	a := &dalSensitivityLevelAction{
 		timestamp: time.Now(),
@@ -268,7 +259,6 @@ func DalSensitivityLevelActionLookup(props ...*dalSensitivityLevelActionProps) *
 // DalSensitivityLevelActionCreate returns "system:dal-sensitivity-level.create" action
 //
 // This function is auto-generated.
-//
 func DalSensitivityLevelActionCreate(props ...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction {
 	a := &dalSensitivityLevelAction{
 		timestamp: time.Now(),
@@ -288,7 +278,6 @@ func DalSensitivityLevelActionCreate(props ...*dalSensitivityLevelActionProps) *
 // DalSensitivityLevelActionUpdate returns "system:dal-sensitivity-level.update" action
 //
 // This function is auto-generated.
-//
 func DalSensitivityLevelActionUpdate(props ...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction {
 	a := &dalSensitivityLevelAction{
 		timestamp: time.Now(),
@@ -308,7 +297,6 @@ func DalSensitivityLevelActionUpdate(props ...*dalSensitivityLevelActionProps) *
 // DalSensitivityLevelActionDelete returns "system:dal-sensitivity-level.delete" action
 //
 // This function is auto-generated.
-//
 func DalSensitivityLevelActionDelete(props ...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction {
 	a := &dalSensitivityLevelAction{
 		timestamp: time.Now(),
@@ -328,7 +316,6 @@ func DalSensitivityLevelActionDelete(props ...*dalSensitivityLevelActionProps) *
 // DalSensitivityLevelActionUndelete returns "system:dal-sensitivity-level.undelete" action
 //
 // This function is auto-generated.
-//
 func DalSensitivityLevelActionUndelete(props ...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction {
 	a := &dalSensitivityLevelAction{
 		timestamp: time.Now(),
@@ -351,9 +338,7 @@ func DalSensitivityLevelActionUndelete(props ...*dalSensitivityLevelActionProps)
 
 // DalSensitivityLevelErrGeneric returns "system:dal-sensitivity-level.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrGeneric(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -387,9 +372,7 @@ func DalSensitivityLevelErrGeneric(mm ...*dalSensitivityLevelActionProps) *error
 
 // DalSensitivityLevelErrNotFound returns "system:dal-sensitivity-level.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrNotFound(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -421,9 +404,7 @@ func DalSensitivityLevelErrNotFound(mm ...*dalSensitivityLevelActionProps) *erro
 
 // DalSensitivityLevelErrInvalidID returns "system:dal-sensitivity-level.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrInvalidID(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -455,9 +436,7 @@ func DalSensitivityLevelErrInvalidID(mm ...*dalSensitivityLevelActionProps) *err
 
 // DalSensitivityLevelErrMissingName returns "system:dal-sensitivity-level.missingName" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrMissingName(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -489,9 +468,7 @@ func DalSensitivityLevelErrMissingName(mm ...*dalSensitivityLevelActionProps) *e
 
 // DalSensitivityLevelErrInvalidEndpoint returns "system:dal-sensitivity-level.invalidEndpoint" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrInvalidEndpoint(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -523,9 +500,7 @@ func DalSensitivityLevelErrInvalidEndpoint(mm ...*dalSensitivityLevelActionProps
 
 // DalSensitivityLevelErrStaleData returns "system:dal-sensitivity-level.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrStaleData(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -557,9 +532,7 @@ func DalSensitivityLevelErrStaleData(mm ...*dalSensitivityLevelActionProps) *err
 
 // DalSensitivityLevelErrExistsEndpoint returns "system:dal-sensitivity-level.existsEndpoint" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrExistsEndpoint(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -591,9 +564,7 @@ func DalSensitivityLevelErrExistsEndpoint(mm ...*dalSensitivityLevelActionProps)
 
 // DalSensitivityLevelErrAlreadyExists returns "system:dal-sensitivity-level.alreadyExists" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrAlreadyExists(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -625,9 +596,7 @@ func DalSensitivityLevelErrAlreadyExists(mm ...*dalSensitivityLevelActionProps) 
 
 // DalSensitivityLevelErrDeleteInUse returns "system:dal-sensitivity-level.deleteInUse" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrDeleteInUse(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -659,9 +628,7 @@ func DalSensitivityLevelErrDeleteInUse(mm ...*dalSensitivityLevelActionProps) *e
 
 // DalSensitivityLevelErrNotAllowedToManage returns "system:dal-sensitivity-level.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DalSensitivityLevelErrNotAllowedToManage(mm ...*dalSensitivityLevelActionProps) *errors.Error {
 	var p = &dalSensitivityLevelActionProps{}
 	if len(mm) > 0 {
@@ -701,7 +668,6 @@ func DalSensitivityLevelErrNotAllowedToManage(mm ...*dalSensitivityLevelActionPr
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc dalSensitivityLevel) recordAction(ctx context.Context, props *dalSensitivityLevelActionProps, actionFn func(...*dalSensitivityLevelActionProps) *dalSensitivityLevelAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/data_privacy_request_actions.gen.go
+++ b/server/system/service/data_privacy_request_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setDataPrivacyRequest updates dataPrivacyActionProps's dataPrivacyRequest
 //
 // This function is auto-generated.
-//
 func (p *dataPrivacyActionProps) setDataPrivacyRequest(dataPrivacyRequest *types.DataPrivacyRequest) *dataPrivacyActionProps {
 	p.dataPrivacyRequest = dataPrivacyRequest
 	return p
@@ -64,7 +63,6 @@ func (p *dataPrivacyActionProps) setDataPrivacyRequest(dataPrivacyRequest *types
 // setNew updates dataPrivacyActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *dataPrivacyActionProps) setNew(new *types.DataPrivacyRequest) *dataPrivacyActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *dataPrivacyActionProps) setNew(new *types.DataPrivacyRequest) *dataPriv
 // setUpdate updates dataPrivacyActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *dataPrivacyActionProps) setUpdate(update *types.DataPrivacyRequest) *dataPrivacyActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *dataPrivacyActionProps) setUpdate(update *types.DataPrivacyRequest) *da
 // setFilter updates dataPrivacyActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *dataPrivacyActionProps) setFilter(filter *types.DataPrivacyRequestFilter) *dataPrivacyActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *dataPrivacyActionProps) setFilter(filter *types.DataPrivacyRequestFilte
 // Serialize converts dataPrivacyActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p dataPrivacyActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -120,7 +115,6 @@ func (p dataPrivacyActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p dataPrivacyActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -207,7 +201,6 @@ func (p dataPrivacyActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *dataPrivacyAction) String() string {
 	var props = &dataPrivacyActionProps{}
 
@@ -235,7 +228,6 @@ func (e *dataPrivacyAction) ToAction() *actionlog.Action {
 // DataPrivacyActionSearch returns "system:data-privacy-request.search" action
 //
 // This function is auto-generated.
-//
 func DataPrivacyActionSearch(props ...*dataPrivacyActionProps) *dataPrivacyAction {
 	a := &dataPrivacyAction{
 		timestamp: time.Now(),
@@ -255,7 +247,6 @@ func DataPrivacyActionSearch(props ...*dataPrivacyActionProps) *dataPrivacyActio
 // DataPrivacyActionLookup returns "system:data-privacy-request.lookup" action
 //
 // This function is auto-generated.
-//
 func DataPrivacyActionLookup(props ...*dataPrivacyActionProps) *dataPrivacyAction {
 	a := &dataPrivacyAction{
 		timestamp: time.Now(),
@@ -275,7 +266,6 @@ func DataPrivacyActionLookup(props ...*dataPrivacyActionProps) *dataPrivacyActio
 // DataPrivacyActionCreate returns "system:data-privacy-request.create" action
 //
 // This function is auto-generated.
-//
 func DataPrivacyActionCreate(props ...*dataPrivacyActionProps) *dataPrivacyAction {
 	a := &dataPrivacyAction{
 		timestamp: time.Now(),
@@ -295,7 +285,6 @@ func DataPrivacyActionCreate(props ...*dataPrivacyActionProps) *dataPrivacyActio
 // DataPrivacyActionUpdate returns "system:data-privacy-request.update" action
 //
 // This function is auto-generated.
-//
 func DataPrivacyActionUpdate(props ...*dataPrivacyActionProps) *dataPrivacyAction {
 	a := &dataPrivacyAction{
 		timestamp: time.Now(),
@@ -315,7 +304,6 @@ func DataPrivacyActionUpdate(props ...*dataPrivacyActionProps) *dataPrivacyActio
 // DataPrivacyActionApprove returns "system:data-privacy-request.approve" action
 //
 // This function is auto-generated.
-//
 func DataPrivacyActionApprove(props ...*dataPrivacyActionProps) *dataPrivacyAction {
 	a := &dataPrivacyAction{
 		timestamp: time.Now(),
@@ -338,9 +326,7 @@ func DataPrivacyActionApprove(props ...*dataPrivacyActionProps) *dataPrivacyActi
 
 // DataPrivacyErrGeneric returns "system:data-privacy-request.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrGeneric(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -374,9 +360,7 @@ func DataPrivacyErrGeneric(mm ...*dataPrivacyActionProps) *errors.Error {
 
 // DataPrivacyErrNotFound returns "system:data-privacy-request.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrNotFound(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -408,9 +392,7 @@ func DataPrivacyErrNotFound(mm ...*dataPrivacyActionProps) *errors.Error {
 
 // DataPrivacyErrInvalidID returns "system:data-privacy-request.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrInvalidID(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -442,9 +424,7 @@ func DataPrivacyErrInvalidID(mm ...*dataPrivacyActionProps) *errors.Error {
 
 // DataPrivacyErrInvalidKind returns "system:data-privacy-request.invalidKind" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrInvalidKind(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -476,9 +456,7 @@ func DataPrivacyErrInvalidKind(mm ...*dataPrivacyActionProps) *errors.Error {
 
 // DataPrivacyErrInvalidStatus returns "system:data-privacy-request.invalidStatus" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrInvalidStatus(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -510,9 +488,7 @@ func DataPrivacyErrInvalidStatus(mm ...*dataPrivacyActionProps) *errors.Error {
 
 // DataPrivacyErrStaleData returns "system:data-privacy-request.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrStaleData(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -544,9 +520,7 @@ func DataPrivacyErrStaleData(mm ...*dataPrivacyActionProps) *errors.Error {
 
 // DataPrivacyErrNotAllowedToRead returns "system:data-privacy-request.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrNotAllowedToRead(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -580,9 +554,7 @@ func DataPrivacyErrNotAllowedToRead(mm ...*dataPrivacyActionProps) *errors.Error
 
 // DataPrivacyErrNotAllowedToSearch returns "system:data-privacy-request.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrNotAllowedToSearch(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -616,9 +588,7 @@ func DataPrivacyErrNotAllowedToSearch(mm ...*dataPrivacyActionProps) *errors.Err
 
 // DataPrivacyErrNotAllowedToCreate returns "system:data-privacy-request.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrNotAllowedToCreate(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -652,9 +622,7 @@ func DataPrivacyErrNotAllowedToCreate(mm ...*dataPrivacyActionProps) *errors.Err
 
 // DataPrivacyErrNotAllowedToApprove returns "system:data-privacy-request.notAllowedToApprove" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func DataPrivacyErrNotAllowedToApprove(mm ...*dataPrivacyActionProps) *errors.Error {
 	var p = &dataPrivacyActionProps{}
 	if len(mm) > 0 {
@@ -694,7 +662,6 @@ func DataPrivacyErrNotAllowedToApprove(mm ...*dataPrivacyActionProps) *errors.Er
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc dataPrivacy) recordAction(ctx context.Context, props *dataPrivacyActionProps, actionFn func(...*dataPrivacyActionProps) *dataPrivacyAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/queue_actions.gen.go
+++ b/server/system/service/queue_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setQueue updates queueActionProps's queue
 //
 // This function is auto-generated.
-//
 func (p *queueActionProps) setQueue(queue *types.Queue) *queueActionProps {
 	p.queue = queue
 	return p
@@ -64,7 +63,6 @@ func (p *queueActionProps) setQueue(queue *types.Queue) *queueActionProps {
 // setNew updates queueActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *queueActionProps) setNew(new *types.Queue) *queueActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *queueActionProps) setNew(new *types.Queue) *queueActionProps {
 // setUpdate updates queueActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *queueActionProps) setUpdate(update *types.Queue) *queueActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *queueActionProps) setUpdate(update *types.Queue) *queueActionProps {
 // setSearch updates queueActionProps's search
 //
 // This function is auto-generated.
-//
 func (p *queueActionProps) setSearch(search *types.QueueFilter) *queueActionProps {
 	p.search = search
 	return p
@@ -91,7 +87,6 @@ func (p *queueActionProps) setSearch(search *types.QueueFilter) *queueActionProp
 // Serialize converts queueActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p queueActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -120,7 +115,6 @@ func (p queueActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p queueActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -206,7 +200,6 @@ func (p queueActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *queueAction) String() string {
 	var props = &queueActionProps{}
 
@@ -234,7 +227,6 @@ func (e *queueAction) ToAction() *actionlog.Action {
 // QueueActionSearch returns "system:queue.search" action
 //
 // This function is auto-generated.
-//
 func QueueActionSearch(props ...*queueActionProps) *queueAction {
 	a := &queueAction{
 		timestamp: time.Now(),
@@ -254,7 +246,6 @@ func QueueActionSearch(props ...*queueActionProps) *queueAction {
 // QueueActionLookup returns "system:queue.lookup" action
 //
 // This function is auto-generated.
-//
 func QueueActionLookup(props ...*queueActionProps) *queueAction {
 	a := &queueAction{
 		timestamp: time.Now(),
@@ -274,7 +265,6 @@ func QueueActionLookup(props ...*queueActionProps) *queueAction {
 // QueueActionCreate returns "system:queue.create" action
 //
 // This function is auto-generated.
-//
 func QueueActionCreate(props ...*queueActionProps) *queueAction {
 	a := &queueAction{
 		timestamp: time.Now(),
@@ -294,7 +284,6 @@ func QueueActionCreate(props ...*queueActionProps) *queueAction {
 // QueueActionUpdate returns "system:queue.update" action
 //
 // This function is auto-generated.
-//
 func QueueActionUpdate(props ...*queueActionProps) *queueAction {
 	a := &queueAction{
 		timestamp: time.Now(),
@@ -314,7 +303,6 @@ func QueueActionUpdate(props ...*queueActionProps) *queueAction {
 // QueueActionDelete returns "system:queue.delete" action
 //
 // This function is auto-generated.
-//
 func QueueActionDelete(props ...*queueActionProps) *queueAction {
 	a := &queueAction{
 		timestamp: time.Now(),
@@ -334,7 +322,6 @@ func QueueActionDelete(props ...*queueActionProps) *queueAction {
 // QueueActionUndelete returns "system:queue.undelete" action
 //
 // This function is auto-generated.
-//
 func QueueActionUndelete(props ...*queueActionProps) *queueAction {
 	a := &queueAction{
 		timestamp: time.Now(),
@@ -357,9 +344,7 @@ func QueueActionUndelete(props ...*queueActionProps) *queueAction {
 
 // QueueErrGeneric returns "system:queue.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrGeneric(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -393,9 +378,7 @@ func QueueErrGeneric(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotFound returns "system:queue.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotFound(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -427,9 +410,7 @@ func QueueErrNotFound(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrInvalidID returns "system:queue.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrInvalidID(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -461,9 +442,7 @@ func QueueErrInvalidID(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrInvalidConsumer returns "system:queue.invalidConsumer" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrInvalidConsumer(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -495,9 +474,7 @@ func QueueErrInvalidConsumer(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrStaleData returns "system:queue.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrStaleData(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -529,9 +506,7 @@ func QueueErrStaleData(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrAlreadyExists returns "system:queue.alreadyExists" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrAlreadyExists(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -563,9 +538,7 @@ func QueueErrAlreadyExists(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToCreate returns "system:queue.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToCreate(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -599,9 +572,7 @@ func QueueErrNotAllowedToCreate(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToRead returns "system:queue.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToRead(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -635,9 +606,7 @@ func QueueErrNotAllowedToRead(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToSearch returns "system:queue.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToSearch(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -671,9 +640,7 @@ func QueueErrNotAllowedToSearch(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToUpdate returns "system:queue.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToUpdate(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -707,9 +674,7 @@ func QueueErrNotAllowedToUpdate(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToDelete returns "system:queue.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToDelete(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -743,9 +708,7 @@ func QueueErrNotAllowedToDelete(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToUndelete returns "system:queue.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToUndelete(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -779,9 +742,7 @@ func QueueErrNotAllowedToUndelete(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToWriteTo returns "system:queue.notAllowedToWriteTo" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToWriteTo(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -815,9 +776,7 @@ func QueueErrNotAllowedToWriteTo(mm ...*queueActionProps) *errors.Error {
 
 // QueueErrNotAllowedToReadFrom returns "system:queue.notAllowedToReadFrom" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func QueueErrNotAllowedToReadFrom(mm ...*queueActionProps) *errors.Error {
 	var p = &queueActionProps{}
 	if len(mm) > 0 {
@@ -857,7 +816,6 @@ func QueueErrNotAllowedToReadFrom(mm ...*queueActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc queue) recordAction(ctx context.Context, props *queueActionProps, actionFn func(...*queueActionProps) *queueAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/reminder_actions.gen.go
+++ b/server/system/service/reminder_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setReminder updates reminderActionProps's reminder
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setReminder(reminder *types.Reminder) *reminderActionProps {
 	p.reminder = reminder
 	return p
@@ -64,7 +63,6 @@ func (p *reminderActionProps) setReminder(reminder *types.Reminder) *reminderAct
 // setNew updates reminderActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setNew(new *types.Reminder) *reminderActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *reminderActionProps) setNew(new *types.Reminder) *reminderActionProps {
 // setUpdated updates reminderActionProps's updated
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setUpdated(updated *types.Reminder) *reminderActionProps {
 	p.updated = updated
 	return p
@@ -82,7 +79,6 @@ func (p *reminderActionProps) setUpdated(updated *types.Reminder) *reminderActio
 // setFilter updates reminderActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *reminderActionProps) setFilter(filter *types.ReminderFilter) *reminderActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *reminderActionProps) setFilter(filter *types.ReminderFilter) *reminderA
 // Serialize converts reminderActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p reminderActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -135,7 +130,6 @@ func (p reminderActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p reminderActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -252,7 +246,6 @@ func (p reminderActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *reminderAction) String() string {
 	var props = &reminderActionProps{}
 
@@ -280,7 +273,6 @@ func (e *reminderAction) ToAction() *actionlog.Action {
 // ReminderActionSearch returns "system:reminder.search" action
 //
 // This function is auto-generated.
-//
 func ReminderActionSearch(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -300,7 +292,6 @@ func ReminderActionSearch(props ...*reminderActionProps) *reminderAction {
 // ReminderActionLookup returns "system:reminder.lookup" action
 //
 // This function is auto-generated.
-//
 func ReminderActionLookup(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -320,7 +311,6 @@ func ReminderActionLookup(props ...*reminderActionProps) *reminderAction {
 // ReminderActionCreate returns "system:reminder.create" action
 //
 // This function is auto-generated.
-//
 func ReminderActionCreate(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -340,7 +330,6 @@ func ReminderActionCreate(props ...*reminderActionProps) *reminderAction {
 // ReminderActionUpdate returns "system:reminder.update" action
 //
 // This function is auto-generated.
-//
 func ReminderActionUpdate(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -360,7 +349,6 @@ func ReminderActionUpdate(props ...*reminderActionProps) *reminderAction {
 // ReminderActionDelete returns "system:reminder.delete" action
 //
 // This function is auto-generated.
-//
 func ReminderActionDelete(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -380,7 +368,6 @@ func ReminderActionDelete(props ...*reminderActionProps) *reminderAction {
 // ReminderActionDismiss returns "system:reminder.dismiss" action
 //
 // This function is auto-generated.
-//
 func ReminderActionDismiss(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -400,7 +387,6 @@ func ReminderActionDismiss(props ...*reminderActionProps) *reminderAction {
 // ReminderActionUndismiss returns "system:reminder.undismiss" action
 //
 // This function is auto-generated.
-//
 func ReminderActionUndismiss(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -420,7 +406,6 @@ func ReminderActionUndismiss(props ...*reminderActionProps) *reminderAction {
 // ReminderActionSnooze returns "system:reminder.snooze" action
 //
 // This function is auto-generated.
-//
 func ReminderActionSnooze(props ...*reminderActionProps) *reminderAction {
 	a := &reminderAction{
 		timestamp: time.Now(),
@@ -443,9 +428,7 @@ func ReminderActionSnooze(props ...*reminderActionProps) *reminderAction {
 
 // ReminderErrGeneric returns "system:reminder.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrGeneric(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -479,9 +462,7 @@ func ReminderErrGeneric(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotFound returns "system:reminder.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotFound(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -513,9 +494,7 @@ func ReminderErrNotFound(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrInvalidID returns "system:reminder.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrInvalidID(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -547,9 +526,7 @@ func ReminderErrInvalidID(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToAssign returns "system:reminder.notAllowedToAssign" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToAssign(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -581,9 +558,7 @@ func ReminderErrNotAllowedToAssign(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToDismiss returns "system:reminder.notAllowedToDismiss" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToDismiss(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -615,9 +590,7 @@ func ReminderErrNotAllowedToDismiss(mm ...*reminderActionProps) *errors.Error {
 
 // ReminderErrNotAllowedToUndismiss returns "system:reminder.notAllowedToUndismiss" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToUndismiss(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -649,9 +622,7 @@ func ReminderErrNotAllowedToUndismiss(mm ...*reminderActionProps) *errors.Error 
 
 // ReminderErrNotAllowedToRead returns "system:reminder.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReminderErrNotAllowedToRead(mm ...*reminderActionProps) *errors.Error {
 	var p = &reminderActionProps{}
 	if len(mm) > 0 {
@@ -689,7 +660,6 @@ func ReminderErrNotAllowedToRead(mm ...*reminderActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc reminder) recordAction(ctx context.Context, props *reminderActionProps, actionFn func(...*reminderActionProps) *reminderAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/report_actions.gen.go
+++ b/server/system/service/report_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setReport updates reportActionProps's report
 //
 // This function is auto-generated.
-//
 func (p *reportActionProps) setReport(report *types.Report) *reportActionProps {
 	p.report = report
 	return p
@@ -64,7 +63,6 @@ func (p *reportActionProps) setReport(report *types.Report) *reportActionProps {
 // setNew updates reportActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *reportActionProps) setNew(new *types.Report) *reportActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *reportActionProps) setNew(new *types.Report) *reportActionProps {
 // setUpdate updates reportActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *reportActionProps) setUpdate(update *types.Report) *reportActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *reportActionProps) setUpdate(update *types.Report) *reportActionProps {
 // setFilter updates reportActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *reportActionProps) setFilter(filter *types.ReportFilter) *reportActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *reportActionProps) setFilter(filter *types.ReportFilter) *reportActionP
 // Serialize converts reportActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p reportActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -121,7 +116,6 @@ func (p reportActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p reportActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -210,7 +204,6 @@ func (p reportActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *reportAction) String() string {
 	var props = &reportActionProps{}
 
@@ -238,7 +231,6 @@ func (e *reportAction) ToAction() *actionlog.Action {
 // ReportActionSearch returns "system:report.search" action
 //
 // This function is auto-generated.
-//
 func ReportActionSearch(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -258,7 +250,6 @@ func ReportActionSearch(props ...*reportActionProps) *reportAction {
 // ReportActionLookup returns "system:report.lookup" action
 //
 // This function is auto-generated.
-//
 func ReportActionLookup(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -278,7 +269,6 @@ func ReportActionLookup(props ...*reportActionProps) *reportAction {
 // ReportActionCreate returns "system:report.create" action
 //
 // This function is auto-generated.
-//
 func ReportActionCreate(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -298,7 +288,6 @@ func ReportActionCreate(props ...*reportActionProps) *reportAction {
 // ReportActionUpdate returns "system:report.update" action
 //
 // This function is auto-generated.
-//
 func ReportActionUpdate(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -318,7 +307,6 @@ func ReportActionUpdate(props ...*reportActionProps) *reportAction {
 // ReportActionDelete returns "system:report.delete" action
 //
 // This function is auto-generated.
-//
 func ReportActionDelete(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -338,7 +326,6 @@ func ReportActionDelete(props ...*reportActionProps) *reportAction {
 // ReportActionUndelete returns "system:report.undelete" action
 //
 // This function is auto-generated.
-//
 func ReportActionUndelete(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -358,7 +345,6 @@ func ReportActionUndelete(props ...*reportActionProps) *reportAction {
 // ReportActionRun returns "system:report.run" action
 //
 // This function is auto-generated.
-//
 func ReportActionRun(props ...*reportActionProps) *reportAction {
 	a := &reportAction{
 		timestamp: time.Now(),
@@ -381,9 +367,7 @@ func ReportActionRun(props ...*reportActionProps) *reportAction {
 
 // ReportErrGeneric returns "system:report.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrGeneric(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -417,9 +401,7 @@ func ReportErrGeneric(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotFound returns "system:report.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotFound(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -451,9 +433,7 @@ func ReportErrNotFound(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrInvalidID returns "system:report.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrInvalidID(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -485,9 +465,7 @@ func ReportErrInvalidID(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrStaleData returns "system:report.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrStaleData(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -519,9 +497,7 @@ func ReportErrStaleData(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToRead returns "system:report.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToRead(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -555,9 +531,7 @@ func ReportErrNotAllowedToRead(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToSearch returns "system:report.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToSearch(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -591,9 +565,7 @@ func ReportErrNotAllowedToSearch(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToListReports returns "system:report.notAllowedToListReports" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToListReports(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -627,9 +599,7 @@ func ReportErrNotAllowedToListReports(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToCreate returns "system:report.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToCreate(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -663,9 +633,7 @@ func ReportErrNotAllowedToCreate(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToUpdate returns "system:report.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToUpdate(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -699,9 +667,7 @@ func ReportErrNotAllowedToUpdate(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToDelete returns "system:report.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToDelete(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -735,9 +701,7 @@ func ReportErrNotAllowedToDelete(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToUndelete returns "system:report.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToUndelete(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -771,9 +735,7 @@ func ReportErrNotAllowedToUndelete(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrNotAllowedToRun returns "system:report.notAllowedToRun" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrNotAllowedToRun(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -807,9 +769,7 @@ func ReportErrNotAllowedToRun(mm ...*reportActionProps) *errors.Error {
 
 // ReportErrInvalidConfiguration returns "system:report.invalidConfiguration" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ReportErrInvalidConfiguration(mm ...*reportActionProps) *errors.Error {
 	var p = &reportActionProps{}
 	if len(mm) > 0 {
@@ -849,7 +809,6 @@ func ReportErrInvalidConfiguration(mm ...*reportActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc report) recordAction(ctx context.Context, props *reportActionProps, actionFn func(...*reportActionProps) *reportAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/resource_translation_actions.gen.go
+++ b/server/system/service/resource_translation_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setResourceTranslation updates resourceTranslationActionProps's resourceTranslation
 //
 // This function is auto-generated.
-//
 func (p *resourceTranslationActionProps) setResourceTranslation(resourceTranslation *types.ResourceTranslation) *resourceTranslationActionProps {
 	p.resourceTranslation = resourceTranslation
 	return p
@@ -64,7 +63,6 @@ func (p *resourceTranslationActionProps) setResourceTranslation(resourceTranslat
 // setNew updates resourceTranslationActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *resourceTranslationActionProps) setNew(new *types.ResourceTranslation) *resourceTranslationActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *resourceTranslationActionProps) setNew(new *types.ResourceTranslation) 
 // setUpdate updates resourceTranslationActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *resourceTranslationActionProps) setUpdate(update *types.ResourceTranslation) *resourceTranslationActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *resourceTranslationActionProps) setUpdate(update *types.ResourceTransla
 // setFilter updates resourceTranslationActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *resourceTranslationActionProps) setFilter(filter *types.ResourceTranslationFilter) *resourceTranslationActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *resourceTranslationActionProps) setFilter(filter *types.ResourceTransla
 // Serialize converts resourceTranslationActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p resourceTranslationActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -131,7 +126,6 @@ func (p resourceTranslationActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p resourceTranslationActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -240,7 +234,6 @@ func (p resourceTranslationActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *resourceTranslationAction) String() string {
 	var props = &resourceTranslationActionProps{}
 
@@ -268,7 +261,6 @@ func (e *resourceTranslationAction) ToAction() *actionlog.Action {
 // ResourceTranslationActionSearch returns "system:resource-translation.search" action
 //
 // This function is auto-generated.
-//
 func ResourceTranslationActionSearch(props ...*resourceTranslationActionProps) *resourceTranslationAction {
 	a := &resourceTranslationAction{
 		timestamp: time.Now(),
@@ -288,7 +280,6 @@ func ResourceTranslationActionSearch(props ...*resourceTranslationActionProps) *
 // ResourceTranslationActionLookup returns "system:resource-translation.lookup" action
 //
 // This function is auto-generated.
-//
 func ResourceTranslationActionLookup(props ...*resourceTranslationActionProps) *resourceTranslationAction {
 	a := &resourceTranslationAction{
 		timestamp: time.Now(),
@@ -308,7 +299,6 @@ func ResourceTranslationActionLookup(props ...*resourceTranslationActionProps) *
 // ResourceTranslationActionCreate returns "system:resource-translation.create" action
 //
 // This function is auto-generated.
-//
 func ResourceTranslationActionCreate(props ...*resourceTranslationActionProps) *resourceTranslationAction {
 	a := &resourceTranslationAction{
 		timestamp: time.Now(),
@@ -328,7 +318,6 @@ func ResourceTranslationActionCreate(props ...*resourceTranslationActionProps) *
 // ResourceTranslationActionUpdate returns "system:resource-translation.update" action
 //
 // This function is auto-generated.
-//
 func ResourceTranslationActionUpdate(props ...*resourceTranslationActionProps) *resourceTranslationAction {
 	a := &resourceTranslationAction{
 		timestamp: time.Now(),
@@ -348,7 +337,6 @@ func ResourceTranslationActionUpdate(props ...*resourceTranslationActionProps) *
 // ResourceTranslationActionDelete returns "system:resource-translation.delete" action
 //
 // This function is auto-generated.
-//
 func ResourceTranslationActionDelete(props ...*resourceTranslationActionProps) *resourceTranslationAction {
 	a := &resourceTranslationAction{
 		timestamp: time.Now(),
@@ -368,7 +356,6 @@ func ResourceTranslationActionDelete(props ...*resourceTranslationActionProps) *
 // ResourceTranslationActionUndelete returns "system:resource-translation.undelete" action
 //
 // This function is auto-generated.
-//
 func ResourceTranslationActionUndelete(props ...*resourceTranslationActionProps) *resourceTranslationAction {
 	a := &resourceTranslationAction{
 		timestamp: time.Now(),
@@ -391,9 +378,7 @@ func ResourceTranslationActionUndelete(props ...*resourceTranslationActionProps)
 
 // ResourceTranslationErrGeneric returns "system:resource-translation.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrGeneric(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -427,9 +412,7 @@ func ResourceTranslationErrGeneric(mm ...*resourceTranslationActionProps) *error
 
 // ResourceTranslationErrNotFound returns "system:resource-translation.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrNotFound(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -461,9 +444,7 @@ func ResourceTranslationErrNotFound(mm ...*resourceTranslationActionProps) *erro
 
 // ResourceTranslationErrInvalidID returns "system:resource-translation.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrInvalidID(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -495,9 +476,7 @@ func ResourceTranslationErrInvalidID(mm ...*resourceTranslationActionProps) *err
 
 // ResourceTranslationErrStaleData returns "system:resource-translation.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrStaleData(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -529,9 +508,7 @@ func ResourceTranslationErrStaleData(mm ...*resourceTranslationActionProps) *err
 
 // ResourceTranslationErrNotAllowedToRead returns "system:resource-translation.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrNotAllowedToRead(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -565,9 +542,7 @@ func ResourceTranslationErrNotAllowedToRead(mm ...*resourceTranslationActionProp
 
 // ResourceTranslationErrNotAllowedToSearch returns "system:resource-translation.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrNotAllowedToSearch(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -601,9 +576,7 @@ func ResourceTranslationErrNotAllowedToSearch(mm ...*resourceTranslationActionPr
 
 // ResourceTranslationErrNotAllowedToManage returns "system:resource-translation.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func ResourceTranslationErrNotAllowedToManage(mm ...*resourceTranslationActionProps) *errors.Error {
 	var p = &resourceTranslationActionProps{}
 	if len(mm) > 0 {
@@ -643,7 +616,6 @@ func ResourceTranslationErrNotAllowedToManage(mm ...*resourceTranslationActionPr
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc resourceTranslation) recordAction(ctx context.Context, props *resourceTranslationActionProps, actionFn func(...*resourceTranslationActionProps) *resourceTranslationAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/role_actions.gen.go
+++ b/server/system/service/role_actions.gen.go
@@ -58,7 +58,6 @@ var (
 // setMember updates roleActionProps's member
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setMember(member *types.User) *roleActionProps {
 	p.member = member
 	return p
@@ -67,7 +66,6 @@ func (p *roleActionProps) setMember(member *types.User) *roleActionProps {
 // setRole updates roleActionProps's role
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setRole(role *types.Role) *roleActionProps {
 	p.role = role
 	return p
@@ -76,7 +74,6 @@ func (p *roleActionProps) setRole(role *types.Role) *roleActionProps {
 // setNew updates roleActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setNew(new *types.Role) *roleActionProps {
 	p.new = new
 	return p
@@ -85,7 +82,6 @@ func (p *roleActionProps) setNew(new *types.Role) *roleActionProps {
 // setUpdate updates roleActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setUpdate(update *types.Role) *roleActionProps {
 	p.update = update
 	return p
@@ -94,7 +90,6 @@ func (p *roleActionProps) setUpdate(update *types.Role) *roleActionProps {
 // setExisting updates roleActionProps's existing
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setExisting(existing *types.Role) *roleActionProps {
 	p.existing = existing
 	return p
@@ -103,7 +98,6 @@ func (p *roleActionProps) setExisting(existing *types.Role) *roleActionProps {
 // setTarget updates roleActionProps's target
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setTarget(target *types.Role) *roleActionProps {
 	p.target = target
 	return p
@@ -112,7 +106,6 @@ func (p *roleActionProps) setTarget(target *types.Role) *roleActionProps {
 // setFilter updates roleActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *roleActionProps) setFilter(filter *types.RoleFilter) *roleActionProps {
 	p.filter = filter
 	return p
@@ -121,7 +114,6 @@ func (p *roleActionProps) setFilter(filter *types.RoleFilter) *roleActionProps {
 // Serialize converts roleActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p roleActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -175,7 +167,6 @@ func (p roleActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p roleActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -330,7 +321,6 @@ func (p roleActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *roleAction) String() string {
 	var props = &roleActionProps{}
 
@@ -358,7 +348,6 @@ func (e *roleAction) ToAction() *actionlog.Action {
 // RoleActionSearch returns "system:role.search" action
 //
 // This function is auto-generated.
-//
 func RoleActionSearch(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -378,7 +367,6 @@ func RoleActionSearch(props ...*roleActionProps) *roleAction {
 // RoleActionLookup returns "system:role.lookup" action
 //
 // This function is auto-generated.
-//
 func RoleActionLookup(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -398,7 +386,6 @@ func RoleActionLookup(props ...*roleActionProps) *roleAction {
 // RoleActionCreate returns "system:role.create" action
 //
 // This function is auto-generated.
-//
 func RoleActionCreate(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -418,7 +405,6 @@ func RoleActionCreate(props ...*roleActionProps) *roleAction {
 // RoleActionUpdate returns "system:role.update" action
 //
 // This function is auto-generated.
-//
 func RoleActionUpdate(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -438,7 +424,6 @@ func RoleActionUpdate(props ...*roleActionProps) *roleAction {
 // RoleActionDelete returns "system:role.delete" action
 //
 // This function is auto-generated.
-//
 func RoleActionDelete(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -458,7 +443,6 @@ func RoleActionDelete(props ...*roleActionProps) *roleAction {
 // RoleActionUndelete returns "system:role.undelete" action
 //
 // This function is auto-generated.
-//
 func RoleActionUndelete(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -478,7 +462,6 @@ func RoleActionUndelete(props ...*roleActionProps) *roleAction {
 // RoleActionArchive returns "system:role.archive" action
 //
 // This function is auto-generated.
-//
 func RoleActionArchive(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -498,7 +481,6 @@ func RoleActionArchive(props ...*roleActionProps) *roleAction {
 // RoleActionUnarchive returns "system:role.unarchive" action
 //
 // This function is auto-generated.
-//
 func RoleActionUnarchive(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -518,7 +500,6 @@ func RoleActionUnarchive(props ...*roleActionProps) *roleAction {
 // RoleActionMerge returns "system:role.merge" action
 //
 // This function is auto-generated.
-//
 func RoleActionMerge(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -538,7 +519,6 @@ func RoleActionMerge(props ...*roleActionProps) *roleAction {
 // RoleActionMembers returns "system:role.members" action
 //
 // This function is auto-generated.
-//
 func RoleActionMembers(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -558,7 +538,6 @@ func RoleActionMembers(props ...*roleActionProps) *roleAction {
 // RoleActionMemberAdd returns "system:role.memberAdd" action
 //
 // This function is auto-generated.
-//
 func RoleActionMemberAdd(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -578,7 +557,6 @@ func RoleActionMemberAdd(props ...*roleActionProps) *roleAction {
 // RoleActionMemberRemove returns "system:role.memberRemove" action
 //
 // This function is auto-generated.
-//
 func RoleActionMemberRemove(props ...*roleActionProps) *roleAction {
 	a := &roleAction{
 		timestamp: time.Now(),
@@ -601,9 +579,7 @@ func RoleActionMemberRemove(props ...*roleActionProps) *roleAction {
 
 // RoleErrGeneric returns "system:role.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrGeneric(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -637,9 +613,7 @@ func RoleErrGeneric(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotFound returns "system:role.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotFound(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -671,9 +645,7 @@ func RoleErrNotFound(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrInvalidID returns "system:role.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrInvalidID(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -705,9 +677,7 @@ func RoleErrInvalidID(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrInvalidHandle returns "system:role.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrInvalidHandle(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -739,9 +709,7 @@ func RoleErrInvalidHandle(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrStaleData returns "system:role.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrStaleData(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -773,9 +741,7 @@ func RoleErrStaleData(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToRead returns "system:role.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToRead(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -809,9 +775,7 @@ func RoleErrNotAllowedToRead(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToSearch returns "system:role.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToSearch(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -845,9 +809,7 @@ func RoleErrNotAllowedToSearch(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToCreate returns "system:role.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToCreate(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -881,9 +843,7 @@ func RoleErrNotAllowedToCreate(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToUpdate returns "system:role.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToUpdate(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -917,9 +877,7 @@ func RoleErrNotAllowedToUpdate(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToDelete returns "system:role.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToDelete(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -953,9 +911,7 @@ func RoleErrNotAllowedToDelete(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToUndelete returns "system:role.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToUndelete(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -989,9 +945,7 @@ func RoleErrNotAllowedToUndelete(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToArchive returns "system:role.notAllowedToArchive" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToArchive(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -1025,9 +979,7 @@ func RoleErrNotAllowedToArchive(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToUnarchive returns "system:role.notAllowedToUnarchive" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToUnarchive(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -1061,9 +1013,7 @@ func RoleErrNotAllowedToUnarchive(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToCloneRules returns "system:role.notAllowedToCloneRules" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToCloneRules(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -1097,9 +1047,7 @@ func RoleErrNotAllowedToCloneRules(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNotAllowedToManageMembers returns "system:role.notAllowedToManageMembers" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNotAllowedToManageMembers(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -1133,9 +1081,7 @@ func RoleErrNotAllowedToManageMembers(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrHandleNotUnique returns "system:role.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrHandleNotUnique(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -1169,9 +1115,7 @@ func RoleErrHandleNotUnique(mm ...*roleActionProps) *errors.Error {
 
 // RoleErrNameNotUnique returns "system:role.nameNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func RoleErrNameNotUnique(mm ...*roleActionProps) *errors.Error {
 	var p = &roleActionProps{}
 	if len(mm) > 0 {
@@ -1211,7 +1155,6 @@ func RoleErrNameNotUnique(mm ...*roleActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc role) recordAction(ctx context.Context, props *roleActionProps, actionFn func(...*roleActionProps) *roleAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/setting_actions.gen.go
+++ b/server/system/service/setting_actions.gen.go
@@ -52,7 +52,6 @@ var (
 // setSettings updates settingsActionProps's settings
 //
 // This function is auto-generated.
-//
 func (p *settingsActionProps) setSettings(settings *types.SettingValue) *settingsActionProps {
 	p.settings = settings
 	return p
@@ -61,7 +60,6 @@ func (p *settingsActionProps) setSettings(settings *types.SettingValue) *setting
 // Serialize converts settingsActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p settingsActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -78,7 +76,6 @@ func (p settingsActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p settingsActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -123,7 +120,6 @@ func (p settingsActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *settingsAction) String() string {
 	var props = &settingsActionProps{}
 
@@ -151,7 +147,6 @@ func (e *settingsAction) ToAction() *actionlog.Action {
 // SettingsActionLookup returns "system:setting.lookup" action
 //
 // This function is auto-generated.
-//
 func SettingsActionLookup(props ...*settingsActionProps) *settingsAction {
 	a := &settingsAction{
 		timestamp: time.Now(),
@@ -174,9 +169,7 @@ func SettingsActionLookup(props ...*settingsActionProps) *settingsAction {
 
 // SettingsErrGeneric returns "system:setting.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrGeneric(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -210,9 +203,7 @@ func SettingsErrGeneric(mm ...*settingsActionProps) *errors.Error {
 
 // SettingsErrNotAllowedToRead returns "system:setting.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrNotAllowedToRead(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -246,9 +237,7 @@ func SettingsErrNotAllowedToRead(mm ...*settingsActionProps) *errors.Error {
 
 // SettingsErrNotAllowedToManage returns "system:setting.notAllowedToManage" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrNotAllowedToManage(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -282,9 +271,7 @@ func SettingsErrNotAllowedToManage(mm ...*settingsActionProps) *errors.Error {
 
 // SettingsErrInvalidPasswordMinLength returns "system:setting.invalidPasswordMinLength" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrInvalidPasswordMinLength(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -316,9 +303,7 @@ func SettingsErrInvalidPasswordMinLength(mm ...*settingsActionProps) *errors.Err
 
 // SettingsErrInvalidPasswordMinUpperCase returns "system:setting.invalidPasswordMinUpperCase" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrInvalidPasswordMinUpperCase(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -350,9 +335,7 @@ func SettingsErrInvalidPasswordMinUpperCase(mm ...*settingsActionProps) *errors.
 
 // SettingsErrInvalidPasswordMinLowerCase returns "system:setting.invalidPasswordMinLowerCase" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrInvalidPasswordMinLowerCase(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -384,9 +367,7 @@ func SettingsErrInvalidPasswordMinLowerCase(mm ...*settingsActionProps) *errors.
 
 // SettingsErrInvalidPasswordMinNumCount returns "system:setting.invalidPasswordMinNumCount" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrInvalidPasswordMinNumCount(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -418,9 +399,7 @@ func SettingsErrInvalidPasswordMinNumCount(mm ...*settingsActionProps) *errors.E
 
 // SettingsErrInvalidPasswordMinSpecialCharCount returns "system:setting.invalidPasswordMinSpecialCharCount" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SettingsErrInvalidPasswordMinSpecialCharCount(mm ...*settingsActionProps) *errors.Error {
 	var p = &settingsActionProps{}
 	if len(mm) > 0 {
@@ -458,7 +437,6 @@ func SettingsErrInvalidPasswordMinSpecialCharCount(mm ...*settingsActionProps) *
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc settings) recordAction(ctx context.Context, props *settingsActionProps, actionFn func(...*settingsActionProps) *settingsAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/sink_actions.gen.go
+++ b/server/system/service/sink_actions.gen.go
@@ -56,7 +56,6 @@ var (
 // setUrl updates sinkActionProps's url
 //
 // This function is auto-generated.
-//
 func (p *sinkActionProps) setUrl(url string) *sinkActionProps {
 	p.url = url
 	return p
@@ -65,7 +64,6 @@ func (p *sinkActionProps) setUrl(url string) *sinkActionProps {
 // setResponseStatus updates sinkActionProps's responseStatus
 //
 // This function is auto-generated.
-//
 func (p *sinkActionProps) setResponseStatus(responseStatus int) *sinkActionProps {
 	p.responseStatus = responseStatus
 	return p
@@ -74,7 +72,6 @@ func (p *sinkActionProps) setResponseStatus(responseStatus int) *sinkActionProps
 // setContentType updates sinkActionProps's contentType
 //
 // This function is auto-generated.
-//
 func (p *sinkActionProps) setContentType(contentType string) *sinkActionProps {
 	p.contentType = contentType
 	return p
@@ -83,7 +80,6 @@ func (p *sinkActionProps) setContentType(contentType string) *sinkActionProps {
 // setSinkParams updates sinkActionProps's sinkParams
 //
 // This function is auto-generated.
-//
 func (p *sinkActionProps) setSinkParams(sinkParams *SinkRequestUrlParams) *sinkActionProps {
 	p.sinkParams = sinkParams
 	return p
@@ -92,7 +88,6 @@ func (p *sinkActionProps) setSinkParams(sinkParams *SinkRequestUrlParams) *sinkA
 // setMailHeader updates sinkActionProps's mailHeader
 //
 // This function is auto-generated.
-//
 func (p *sinkActionProps) setMailHeader(mailHeader *types.MailMessageHeader) *sinkActionProps {
 	p.mailHeader = mailHeader
 	return p
@@ -101,7 +96,6 @@ func (p *sinkActionProps) setMailHeader(mailHeader *types.MailMessageHeader) *si
 // Serialize converts sinkActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p sinkActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -126,7 +120,6 @@ func (p sinkActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p sinkActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -183,7 +176,6 @@ func (p sinkActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *sinkAction) String() string {
 	var props = &sinkActionProps{}
 
@@ -211,7 +203,6 @@ func (e *sinkAction) ToAction() *actionlog.Action {
 // SinkActionSign returns "system:sink.sign" action
 //
 // This function is auto-generated.
-//
 func SinkActionSign(props ...*sinkActionProps) *sinkAction {
 	a := &sinkAction{
 		timestamp: time.Now(),
@@ -231,7 +222,6 @@ func SinkActionSign(props ...*sinkActionProps) *sinkAction {
 // SinkActionPreprocess returns "system:sink.preprocess" action
 //
 // This function is auto-generated.
-//
 func SinkActionPreprocess(props ...*sinkActionProps) *sinkAction {
 	a := &sinkAction{
 		timestamp: time.Now(),
@@ -251,7 +241,6 @@ func SinkActionPreprocess(props ...*sinkActionProps) *sinkAction {
 // SinkActionRequest returns "system:sink.request" action
 //
 // This function is auto-generated.
-//
 func SinkActionRequest(props ...*sinkActionProps) *sinkAction {
 	a := &sinkAction{
 		timestamp: time.Now(),
@@ -274,9 +263,7 @@ func SinkActionRequest(props ...*sinkActionProps) *sinkAction {
 
 // SinkErrGeneric returns "system:sink.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrGeneric(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -310,9 +297,7 @@ func SinkErrGeneric(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrFailedToSign returns "system:sink.failedToSign" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrFailedToSign(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -344,9 +329,7 @@ func SinkErrFailedToSign(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrFailedToCreateEvent returns "system:sink.failedToCreateEvent" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrFailedToCreateEvent(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -378,9 +361,7 @@ func SinkErrFailedToCreateEvent(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrFailedToProcess returns "system:sink.failedToProcess" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrFailedToProcess(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -412,9 +393,7 @@ func SinkErrFailedToProcess(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrFailedToRespond returns "system:sink.failedToRespond" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrFailedToRespond(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -446,9 +425,7 @@ func SinkErrFailedToRespond(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrMissingSignature returns "system:sink.missingSignature" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrMissingSignature(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -480,9 +457,7 @@ func SinkErrMissingSignature(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrInvalidSignatureParam returns "system:sink.invalidSignatureParam" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrInvalidSignatureParam(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -514,9 +489,7 @@ func SinkErrInvalidSignatureParam(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrBadSinkParamEncoding returns "system:sink.badSinkParamEncoding" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrBadSinkParamEncoding(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -548,9 +521,7 @@ func SinkErrBadSinkParamEncoding(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrInvalidSignature returns "system:sink.invalidSignature" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrInvalidSignature(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -582,9 +553,7 @@ func SinkErrInvalidSignature(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrInvalidSinkRequestUrlParams returns "system:sink.invalidSinkRequestUrlParams" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrInvalidSinkRequestUrlParams(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -616,9 +585,7 @@ func SinkErrInvalidSinkRequestUrlParams(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrInvalidHttpMethod returns "system:sink.invalidHttpMethod" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrInvalidHttpMethod(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -650,9 +617,7 @@ func SinkErrInvalidHttpMethod(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrInvalidContentType returns "system:sink.invalidContentType" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrInvalidContentType(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -684,9 +649,7 @@ func SinkErrInvalidContentType(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrInvalidPath returns "system:sink.invalidPath" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrInvalidPath(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -718,9 +681,7 @@ func SinkErrInvalidPath(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrMisplacedSignature returns "system:sink.misplacedSignature" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrMisplacedSignature(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -752,9 +713,7 @@ func SinkErrMisplacedSignature(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrSignatureExpired returns "system:sink.signatureExpired" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrSignatureExpired(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -786,9 +745,7 @@ func SinkErrSignatureExpired(mm ...*sinkActionProps) *errors.Error {
 
 // SinkErrContentLengthExceedsMaxAllowedSize returns "system:sink.contentLengthExceedsMaxAllowedSize" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrContentLengthExceedsMaxAllowedSize(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -820,9 +777,7 @@ func SinkErrContentLengthExceedsMaxAllowedSize(mm ...*sinkActionProps) *errors.E
 
 // SinkErrProcessingError returns "system:sink.processingError" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func SinkErrProcessingError(mm ...*sinkActionProps) *errors.Error {
 	var p = &sinkActionProps{}
 	if len(mm) > 0 {
@@ -860,7 +815,6 @@ func SinkErrProcessingError(mm ...*sinkActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc sink) recordAction(ctx context.Context, props *sinkActionProps, actionFn func(...*sinkActionProps) *sinkAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/statistics_actions.gen.go
+++ b/server/system/service/statistics_actions.gen.go
@@ -51,7 +51,6 @@ var (
 // Serialize converts statisticsActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p statisticsActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -63,7 +62,6 @@ func (p statisticsActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p statisticsActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -84,7 +82,6 @@ func (p statisticsActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *statisticsAction) String() string {
 	var props = &statisticsActionProps{}
 
@@ -112,7 +109,6 @@ func (e *statisticsAction) ToAction() *actionlog.Action {
 // StatisticsActionServe returns "system:statistics.serve" action
 //
 // This function is auto-generated.
-//
 func StatisticsActionServe(props ...*statisticsActionProps) *statisticsAction {
 	a := &statisticsAction{
 		timestamp: time.Now(),
@@ -135,9 +131,7 @@ func StatisticsActionServe(props ...*statisticsActionProps) *statisticsAction {
 
 // StatisticsErrGeneric returns "system:statistics.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func StatisticsErrGeneric(mm ...*statisticsActionProps) *errors.Error {
 	var p = &statisticsActionProps{}
 	if len(mm) > 0 {
@@ -171,9 +165,7 @@ func StatisticsErrGeneric(mm ...*statisticsActionProps) *errors.Error {
 
 // StatisticsErrNotAllowedToReadStatistics returns "system:statistics.notAllowedToReadStatistics" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func StatisticsErrNotAllowedToReadStatistics(mm ...*statisticsActionProps) *errors.Error {
 	var p = &statisticsActionProps{}
 	if len(mm) > 0 {
@@ -211,7 +203,6 @@ func StatisticsErrNotAllowedToReadStatistics(mm ...*statisticsActionProps) *erro
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc statistics) recordAction(ctx context.Context, props *statisticsActionProps, actionFn func(...*statisticsActionProps) *statisticsAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/template_actions.gen.go
+++ b/server/system/service/template_actions.gen.go
@@ -55,7 +55,6 @@ var (
 // setTemplate updates templateActionProps's template
 //
 // This function is auto-generated.
-//
 func (p *templateActionProps) setTemplate(template *types.Template) *templateActionProps {
 	p.template = template
 	return p
@@ -64,7 +63,6 @@ func (p *templateActionProps) setTemplate(template *types.Template) *templateAct
 // setNew updates templateActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *templateActionProps) setNew(new *types.Template) *templateActionProps {
 	p.new = new
 	return p
@@ -73,7 +71,6 @@ func (p *templateActionProps) setNew(new *types.Template) *templateActionProps {
 // setUpdate updates templateActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *templateActionProps) setUpdate(update *types.Template) *templateActionProps {
 	p.update = update
 	return p
@@ -82,7 +79,6 @@ func (p *templateActionProps) setUpdate(update *types.Template) *templateActionP
 // setFilter updates templateActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *templateActionProps) setFilter(filter *types.TemplateFilter) *templateActionProps {
 	p.filter = filter
 	return p
@@ -91,7 +87,6 @@ func (p *templateActionProps) setFilter(filter *types.TemplateFilter) *templateA
 // Serialize converts templateActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p templateActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -127,7 +122,6 @@ func (p templateActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p templateActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -228,7 +222,6 @@ func (p templateActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *templateAction) String() string {
 	var props = &templateActionProps{}
 
@@ -256,7 +249,6 @@ func (e *templateAction) ToAction() *actionlog.Action {
 // TemplateActionSearch returns "system:template.search" action
 //
 // This function is auto-generated.
-//
 func TemplateActionSearch(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -276,7 +268,6 @@ func TemplateActionSearch(props ...*templateActionProps) *templateAction {
 // TemplateActionLookup returns "system:template.lookup" action
 //
 // This function is auto-generated.
-//
 func TemplateActionLookup(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -296,7 +287,6 @@ func TemplateActionLookup(props ...*templateActionProps) *templateAction {
 // TemplateActionCreate returns "system:template.create" action
 //
 // This function is auto-generated.
-//
 func TemplateActionCreate(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -316,7 +306,6 @@ func TemplateActionCreate(props ...*templateActionProps) *templateAction {
 // TemplateActionUpdate returns "system:template.update" action
 //
 // This function is auto-generated.
-//
 func TemplateActionUpdate(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -336,7 +325,6 @@ func TemplateActionUpdate(props ...*templateActionProps) *templateAction {
 // TemplateActionDelete returns "system:template.delete" action
 //
 // This function is auto-generated.
-//
 func TemplateActionDelete(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -356,7 +344,6 @@ func TemplateActionDelete(props ...*templateActionProps) *templateAction {
 // TemplateActionUndelete returns "system:template.undelete" action
 //
 // This function is auto-generated.
-//
 func TemplateActionUndelete(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -376,7 +363,6 @@ func TemplateActionUndelete(props ...*templateActionProps) *templateAction {
 // TemplateActionRender returns "system:template.render" action
 //
 // This function is auto-generated.
-//
 func TemplateActionRender(props ...*templateActionProps) *templateAction {
 	a := &templateAction{
 		timestamp: time.Now(),
@@ -399,9 +385,7 @@ func TemplateActionRender(props ...*templateActionProps) *templateAction {
 
 // TemplateErrGeneric returns "system:template.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrGeneric(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -435,9 +419,7 @@ func TemplateErrGeneric(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotFound returns "system:template.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotFound(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -469,9 +451,7 @@ func TemplateErrNotFound(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrInvalidID returns "system:template.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrInvalidID(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -503,9 +483,7 @@ func TemplateErrInvalidID(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrStaleData returns "system:template.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrStaleData(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -537,9 +515,7 @@ func TemplateErrStaleData(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrInvalidHandle returns "system:template.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrInvalidHandle(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -571,9 +547,7 @@ func TemplateErrInvalidHandle(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrMissingShort returns "system:template.missingShort" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrMissingShort(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -605,9 +579,7 @@ func TemplateErrMissingShort(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrCannotRenderPartial returns "system:template.cannotRenderPartial" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrCannotRenderPartial(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -639,9 +611,7 @@ func TemplateErrCannotRenderPartial(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToRead returns "system:template.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToRead(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -675,9 +645,7 @@ func TemplateErrNotAllowedToRead(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToSearch returns "system:template.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToSearch(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -711,9 +679,7 @@ func TemplateErrNotAllowedToSearch(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToCreate returns "system:template.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToCreate(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -747,9 +713,7 @@ func TemplateErrNotAllowedToCreate(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToUpdate returns "system:template.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToUpdate(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -783,9 +747,7 @@ func TemplateErrNotAllowedToUpdate(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToDelete returns "system:template.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToDelete(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -819,9 +781,7 @@ func TemplateErrNotAllowedToDelete(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToUndelete returns "system:template.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToUndelete(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -855,9 +815,7 @@ func TemplateErrNotAllowedToUndelete(mm ...*templateActionProps) *errors.Error {
 
 // TemplateErrNotAllowedToRender returns "system:template.notAllowedToRender" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func TemplateErrNotAllowedToRender(mm ...*templateActionProps) *errors.Error {
 	var p = &templateActionProps{}
 	if len(mm) > 0 {
@@ -897,7 +855,6 @@ func TemplateErrNotAllowedToRender(mm ...*templateActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc template) recordAction(ctx context.Context, props *templateActionProps, actionFn func(...*templateActionProps) *templateAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is

--- a/server/system/service/user_actions.gen.go
+++ b/server/system/service/user_actions.gen.go
@@ -56,7 +56,6 @@ var (
 // setUser updates userActionProps's user
 //
 // This function is auto-generated.
-//
 func (p *userActionProps) setUser(user *types.User) *userActionProps {
 	p.user = user
 	return p
@@ -65,7 +64,6 @@ func (p *userActionProps) setUser(user *types.User) *userActionProps {
 // setNew updates userActionProps's new
 //
 // This function is auto-generated.
-//
 func (p *userActionProps) setNew(new *types.User) *userActionProps {
 	p.new = new
 	return p
@@ -74,7 +72,6 @@ func (p *userActionProps) setNew(new *types.User) *userActionProps {
 // setUpdate updates userActionProps's update
 //
 // This function is auto-generated.
-//
 func (p *userActionProps) setUpdate(update *types.User) *userActionProps {
 	p.update = update
 	return p
@@ -83,7 +80,6 @@ func (p *userActionProps) setUpdate(update *types.User) *userActionProps {
 // setExisting updates userActionProps's existing
 //
 // This function is auto-generated.
-//
 func (p *userActionProps) setExisting(existing *types.User) *userActionProps {
 	p.existing = existing
 	return p
@@ -92,7 +88,6 @@ func (p *userActionProps) setExisting(existing *types.User) *userActionProps {
 // setFilter updates userActionProps's filter
 //
 // This function is auto-generated.
-//
 func (p *userActionProps) setFilter(filter *types.UserFilter) *userActionProps {
 	p.filter = filter
 	return p
@@ -101,7 +96,6 @@ func (p *userActionProps) setFilter(filter *types.UserFilter) *userActionProps {
 // Serialize converts userActionProps to actionlog.Meta
 //
 // This function is auto-generated.
-//
 func (p userActionProps) Serialize() actionlog.Meta {
 	var (
 		m = make(actionlog.Meta)
@@ -153,7 +147,6 @@ func (p userActionProps) Serialize() actionlog.Meta {
 // tr translates string and replaces meta value placeholder with values
 //
 // This function is auto-generated.
-//
 func (p userActionProps) Format(in string, err error) string {
 	var (
 		pairs = []string{"{{err}}"}
@@ -292,7 +285,6 @@ func (p userActionProps) Format(in string, err error) string {
 // String returns loggable description as string
 //
 // This function is auto-generated.
-//
 func (a *userAction) String() string {
 	var props = &userActionProps{}
 
@@ -320,7 +312,6 @@ func (e *userAction) ToAction() *actionlog.Action {
 // UserActionSearch returns "system:user.search" action
 //
 // This function is auto-generated.
-//
 func UserActionSearch(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -340,7 +331,6 @@ func UserActionSearch(props ...*userActionProps) *userAction {
 // UserActionLookup returns "system:user.lookup" action
 //
 // This function is auto-generated.
-//
 func UserActionLookup(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -360,7 +350,6 @@ func UserActionLookup(props ...*userActionProps) *userAction {
 // UserActionCreate returns "system:user.create" action
 //
 // This function is auto-generated.
-//
 func UserActionCreate(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -380,7 +369,6 @@ func UserActionCreate(props ...*userActionProps) *userAction {
 // UserActionUpdate returns "system:user.update" action
 //
 // This function is auto-generated.
-//
 func UserActionUpdate(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -400,7 +388,6 @@ func UserActionUpdate(props ...*userActionProps) *userAction {
 // UserActionDelete returns "system:user.delete" action
 //
 // This function is auto-generated.
-//
 func UserActionDelete(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -420,7 +407,6 @@ func UserActionDelete(props ...*userActionProps) *userAction {
 // UserActionUndelete returns "system:user.undelete" action
 //
 // This function is auto-generated.
-//
 func UserActionUndelete(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -440,7 +426,6 @@ func UserActionUndelete(props ...*userActionProps) *userAction {
 // UserActionSuspend returns "system:user.suspend" action
 //
 // This function is auto-generated.
-//
 func UserActionSuspend(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -460,7 +445,6 @@ func UserActionSuspend(props ...*userActionProps) *userAction {
 // UserActionUnsuspend returns "system:user.unsuspend" action
 //
 // This function is auto-generated.
-//
 func UserActionUnsuspend(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -480,7 +464,6 @@ func UserActionUnsuspend(props ...*userActionProps) *userAction {
 // UserActionSetPassword returns "system:user.setPassword" action
 //
 // This function is auto-generated.
-//
 func UserActionSetPassword(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -500,7 +483,6 @@ func UserActionSetPassword(props ...*userActionProps) *userAction {
 // UserActionRemovePassword returns "system:user.removePassword" action
 //
 // This function is auto-generated.
-//
 func UserActionRemovePassword(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -520,7 +502,6 @@ func UserActionRemovePassword(props ...*userActionProps) *userAction {
 // UserActionDeleteAuthTokens returns "system:user.deleteAuthTokens" action
 //
 // This function is auto-generated.
-//
 func UserActionDeleteAuthTokens(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -540,7 +521,6 @@ func UserActionDeleteAuthTokens(props ...*userActionProps) *userAction {
 // UserActionDeleteAuthSessions returns "system:user.deleteAuthSessions" action
 //
 // This function is auto-generated.
-//
 func UserActionDeleteAuthSessions(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -560,7 +540,6 @@ func UserActionDeleteAuthSessions(props ...*userActionProps) *userAction {
 // UserActionUploadAvatar returns "system:user.uploadAvatar" action
 //
 // This function is auto-generated.
-//
 func UserActionUploadAvatar(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -580,7 +559,6 @@ func UserActionUploadAvatar(props ...*userActionProps) *userAction {
 // UserActionGenerateAvatar returns "system:user.generateAvatar" action
 //
 // This function is auto-generated.
-//
 func UserActionGenerateAvatar(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -600,7 +578,6 @@ func UserActionGenerateAvatar(props ...*userActionProps) *userAction {
 // UserActionDeleteAvatar returns "system:user.deleteAvatar" action
 //
 // This function is auto-generated.
-//
 func UserActionDeleteAvatar(props ...*userActionProps) *userAction {
 	a := &userAction{
 		timestamp: time.Now(),
@@ -623,9 +600,7 @@ func UserActionDeleteAvatar(props ...*userActionProps) *userAction {
 
 // UserErrGeneric returns "system:user.generic" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrGeneric(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -659,9 +634,7 @@ func UserErrGeneric(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotFound returns "system:user.notFound" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotFound(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -693,9 +666,7 @@ func UserErrNotFound(mm ...*userActionProps) *errors.Error {
 
 // UserErrInvalidID returns "system:user.invalidID" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrInvalidID(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -727,9 +698,7 @@ func UserErrInvalidID(mm ...*userActionProps) *errors.Error {
 
 // UserErrInvalidHandle returns "system:user.invalidHandle" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrInvalidHandle(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -761,9 +730,7 @@ func UserErrInvalidHandle(mm ...*userActionProps) *errors.Error {
 
 // UserErrInvalidEmail returns "system:user.invalidEmail" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrInvalidEmail(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -795,9 +762,7 @@ func UserErrInvalidEmail(mm ...*userActionProps) *errors.Error {
 
 // UserErrStaleData returns "system:user.staleData" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrStaleData(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -829,9 +794,7 @@ func UserErrStaleData(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToRead returns "system:user.notAllowedToRead" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToRead(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -865,9 +828,7 @@ func UserErrNotAllowedToRead(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToSearch returns "system:user.notAllowedToSearch" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToSearch(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -901,9 +862,7 @@ func UserErrNotAllowedToSearch(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToListUsers returns "system:user.notAllowedToListUsers" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToListUsers(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -937,9 +896,7 @@ func UserErrNotAllowedToListUsers(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToCreate returns "system:user.notAllowedToCreate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToCreate(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -973,9 +930,7 @@ func UserErrNotAllowedToCreate(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToCreateSystem returns "system:user.notAllowedToCreateSystem" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToCreateSystem(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1009,9 +964,7 @@ func UserErrNotAllowedToCreateSystem(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToUpdate returns "system:user.notAllowedToUpdate" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToUpdate(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1045,9 +998,7 @@ func UserErrNotAllowedToUpdate(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToUpdateSystem returns "system:user.notAllowedToUpdateSystem" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToUpdateSystem(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1081,9 +1032,7 @@ func UserErrNotAllowedToUpdateSystem(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToDelete returns "system:user.notAllowedToDelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToDelete(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1117,9 +1066,7 @@ func UserErrNotAllowedToDelete(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToUndelete returns "system:user.notAllowedToUndelete" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToUndelete(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1153,9 +1100,7 @@ func UserErrNotAllowedToUndelete(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToSuspend returns "system:user.notAllowedToSuspend" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToSuspend(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1189,9 +1134,7 @@ func UserErrNotAllowedToSuspend(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToUnsuspend returns "system:user.notAllowedToUnsuspend" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToUnsuspend(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1225,9 +1168,7 @@ func UserErrNotAllowedToUnsuspend(mm ...*userActionProps) *errors.Error {
 
 // UserErrHandleNotUnique returns "system:user.handleNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrHandleNotUnique(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1261,9 +1202,7 @@ func UserErrHandleNotUnique(mm ...*userActionProps) *errors.Error {
 
 // UserErrEmailNotUnique returns "system:user.emailNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrEmailNotUnique(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1297,9 +1236,7 @@ func UserErrEmailNotUnique(mm ...*userActionProps) *errors.Error {
 
 // UserErrUsernameNotUnique returns "system:user.usernameNotUnique" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrUsernameNotUnique(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1333,9 +1270,7 @@ func UserErrUsernameNotUnique(mm ...*userActionProps) *errors.Error {
 
 // UserErrPasswordNotSecure returns "system:user.passwordNotSecure" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrPasswordNotSecure(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1367,9 +1302,7 @@ func UserErrPasswordNotSecure(mm ...*userActionProps) *errors.Error {
 
 // UserErrMaxUserLimitReached returns "system:user.maxUserLimitReached" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrMaxUserLimitReached(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1401,9 +1334,7 @@ func UserErrMaxUserLimitReached(mm ...*userActionProps) *errors.Error {
 
 // UserErrNotAllowedToDeleteAvatar returns "system:user.notAllowedToDeleteAvatar" as *errors.Error
 //
-//
 // This function is auto-generated.
-//
 func UserErrNotAllowedToDeleteAvatar(mm ...*userActionProps) *errors.Error {
 	var p = &userActionProps{}
 	if len(mm) > 0 {
@@ -1443,7 +1374,6 @@ func UserErrNotAllowedToDeleteAvatar(mm ...*userActionProps) *errors.Error {
 // It will wrap unrecognized/internal errors with generic errors.
 //
 // This function is auto-generated.
-//
 func (svc user) recordAction(ctx context.Context, props *userActionProps, actionFn func(...*userActionProps) *userAction, err error) error {
 	if svc.actionlog == nil || actionFn == nil {
 		// action log disabled or no action fn passed, return error as-is


### PR DESCRIPTION
This PR resolves issues in the corteza-discovery flow by :
1.  Fixing the reindexing process to ensure data is actually reindexed on opensearch/elastic search
2. Adds proper mapping for the security field in indexed compose documents
3.  Adds the super-admin role in the allowed roles list for all the documents.