### PR TITLE
2024.9.6 fix local key

### DIFF
--- a/extra/server-discovery/vendor/github.com/cortezaproject/corteza/server/compose/types/page_layout.go
+++ b/extra/server-discovery/vendor/github.com/cortezaproject/corteza/server/compose/types/page_layout.go
@@ -175,7 +175,7 @@ func (p *PageLayout) decodeTranslations(tt locale.ResourceTranslationIndex) {
 			"{{actionID}}", strconv.FormatUint(actionID, 10),
 		)
 
-		if aux = tt.FindByKey(rpl.Replace(LocaleKeyPagePageBlockBlockIDTitle.Path)); aux != nil {
+		if aux = tt.FindByKey(rpl.Replace(LocaleKeyPageLayoutConfigActionsActionIDMetaLabel.Path)); aux != nil {
 			p.Config.Actions[i].Meta.Label = aux.Msg
 		}
 	}


### PR DESCRIPTION
Based on upstream/2024.9.6. Fixes #2164 by correcting the local key in page_layout.go.