### PR TITLE
Fix websocket panics on session disconnect

### DIFF
--- a/server/pkg/websocket/session.go
+++ b/server/pkg/websocket/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cortezaproject/corteza/server/pkg/auth"
@@ -39,9 +40,10 @@ type (
 	session struct {
 		l sync.RWMutex
 
-		id   uint64
-		once sync.Once
-		conn conection
+		id     uint64
+		once   sync.Once
+		conn   conection
+		closed atomic.Bool
 
 		ctx       context.Context
 		ctxCancel context.CancelFunc
@@ -91,6 +93,9 @@ func (s *session) Identity() auth.Identifiable {
 func (s *session) disconnect() {
 	s.l.Lock()
 	defer s.l.Unlock()
+
+	// Mark session as closed before closing channels
+	s.closed.Store(true)
 
 	// Cancel context
 	s.ctxCancel()
@@ -189,6 +194,11 @@ func (s *session) read() (raw []byte, err error) {
 
 	s.l.RLock()
 	defer s.l.RUnlock()
+
+	// Check if connection was closed by disconnect()
+	if s.conn == nil {
+		return nil, net.ErrClosed
+	}
 
 	if _, raw, err = s.conn.ReadMessage(); err != nil {
 		return nil, errHandler("websocket read failed", err)
@@ -291,6 +301,11 @@ func (s *session) write(t int, msg []byte) (err error) {
 		}
 	}()
 
+	// Check if connection was closed by disconnect()
+	if s.conn == nil {
+		return net.ErrClosed
+	}
+
 	if err = s.conn.SetWriteDeadline(time.Now().Add(s.config.Timeout)); err != nil {
 		return fmt.Errorf("deadline error: %w", err)
 	}
@@ -324,6 +339,11 @@ func (s *session) authenticate(p *payloadAuth) error {
 
 // sendBytes sends byte to channel or timeout
 func (s *session) Write(p []byte) (int, error) {
+	// Check if session is closed before attempting to send
+	if s.closed.Load() {
+		return 0, net.ErrClosed
+	}
+
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			s.logger.Debug("recovering from websocket write panic", zap.Any("recovered-error", recovered))
@@ -331,6 +351,9 @@ func (s *session) Write(p []byte) (int, error) {
 	}()
 
 	select {
+	case <-s.ctx.Done():
+		// Session is disconnecting, channel may be closed
+		return 0, net.ErrClosed
 	case s.send <- p:
 		return len(p), nil
 	case <-time.After(2 * time.Millisecond):
@@ -343,14 +366,23 @@ func errHandler(prefix string, err error) error {
 		return nil
 	}
 
-	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-		// normal closing
-		return nil
+	// Handle websocket close errors - these are expected during disconnection
+	if websocket.IsCloseError(err,
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseAbnormalClosure,
+		websocket.CloseNoStatusReceived,
+	) {
+		return net.ErrClosed
 	}
 
 	if errors.Is(err, net.ErrClosed) {
-		// suppress errors when reading/writing from/to a closed connection
-		return nil
+		return net.ErrClosed
+	}
+
+	// "close sent" occurs when writing to a connection that's closing
+	if err.Error() == "websocket: close sent" {
+		return net.ErrClosed
 	}
 
 	return fmt.Errorf(prefix+": %w", err)


### PR DESCRIPTION
## Summary

Fixes multiple race conditions and error handling issues in websocket session management that caused panics during unauthenticated visitor access and login redirects.

## Problem

When unauthenticated users connect via WebSocket (e.g., during redirect from base URL to login page), several issues can occur:

1. **Nil pointer dereference**: `disconnect()` sets `conn = nil` while `read()`/`write()` operations are pending, causing panic when they try to use the connection
2. **Read loop spinning**: `errHandler()` returned `nil` for close errors, causing the read loop to continue instead of exiting. After ~1000 iterations, gorilla/websocket triggers a safety panic
3. **Send on closed channel**: `Write()` could attempt to send to `s.send` channel after `disconnect()` closed it
4. **Noisy error logs**: Expected close conditions (1006 abnormal closure, "close sent") were logged as errors

## Changes

- Add nil checks in `read()` and `write()` after acquiring lock to prevent nil pointer dereference
- Return `net.ErrClosed` from `errHandler()` for close errors to exit read/write loops cleanly
- Add `atomic.Bool` closed flag to session, set before closing channels in `disconnect()`
- Check closed flag in `Write()` before attempting channel send
- Handle additional expected close codes (1005, 1006) and "close sent" error in `errHandler()`

## Testing

- Existing websocket tests pass
- Manually verified with unauthenticated visitor access and login redirect flow

Fixes #2223