### PR TITLE
Fix corredor dial opts issue

### DIFF
--- a/server/pkg/corredor/conn.go
+++ b/server/pkg/corredor/conn.go
@@ -86,7 +86,7 @@ func NewConnection(ctx context.Context, opt options.CorredorOpt, logger *zap.Log
 	}
 
 	if opt.MaxReceiveMessageSize > 0 {
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(opt.MaxReceiveMessageSize))
+		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(opt.MaxReceiveMessageSize)))
 	}
 
 	if opt.MaxBackoffDelay > 0 {


### PR DESCRIPTION
Dial option with max receive message size was silently ignored as it wasn't added to the DialOpts slice. Now it is added similarly to other opts.
