### PR TITLE
Feature - Record / Record list block improvements

### DIFF
--- a/client/web/compose/src/components/Common/FieldPicker.vue
+++ b/client/web/compose/src/components/Common/FieldPicker.vue
@@ -21,12 +21,15 @@
           <template
             v-if="field.label"
           >
-            {{ field.label }} ({{ field.name }})
+            {{ field.label }}
+            <template v-if="field.originalName">
+              ({{ field.originalName }})
+            </template>
           </template>
           <template
             v-else
           >
-            {{ field.name }}
+            {{ field.originalName || field.name }}
           </template>
           <template
             v-if="field.isRequired"
@@ -39,6 +42,12 @@
           class="cursor-default ml-1 text-truncate"
         >
           {{ $t('selector.systemField') }}
+        </small>
+        <small
+          v-if="field.isParentField"
+          class="cursor-default ml-1 text-truncate text-primary"
+        >
+          {{ field.parentModuleName }}
         </small>
       </template>
     </c-item-picker>
@@ -94,6 +103,18 @@ export default {
     fieldSubset: {
       type: Array,
       default: null,
+    },
+
+    // NEW: optional parent module object
+    extraModule: {
+      type: Object,
+      default: null,
+    },
+
+    // NEW: array of field objects from the parent module
+    extraModuleFields: {
+      type: Array,
+      default: () => [],
     },
   },
 
@@ -153,8 +174,10 @@ export default {
         mFields.sort((a, b) => a.label.localeCompare(b.label))
       }
 
+      // Build base options from child module fields
+      let baseOptions = []
       if (mFields && sysFields) {
-        return [
+        baseOptions = [
           ...[...mFields],
           ...sysFields,
         ].map(field => ({
@@ -169,7 +192,7 @@ export default {
           field,
         }))
       } else {
-        return Object.keys(this.module).map(key => {
+        baseOptions = Object.keys(this.module).map(key => {
           return this.module[key]
         }).map(f => ({
           ...f,
@@ -178,6 +201,32 @@ export default {
           },
         }))
       }
+
+      // Build parent module field options (if extraModule and extraModuleFields are provided)
+      const extraFieldOptions = (this.extraModule && this.extraModuleFields.length > 0)
+        ? this.extraModuleFields.map(field => {
+          // Use moduleID::fieldName as the unique key to avoid name collisions
+          const uniqueName = `${this.extraModule.moduleID}::${field.name}`
+          return {
+            value: uniqueName,
+            text: [field.name, field.label, field.kind, this.extraModule.name].join(' '),
+            field: {
+              ...field,
+              // Override name with the namespaced version for storage/lookup
+              name: uniqueName,
+              label: field.label || field.name,
+              // Flags and metadata for downstream use
+              isParentField: true,
+              parentModuleID: this.extraModule.moduleID,
+              parentModuleName: this.extraModule.name,
+              originalName: field.name,
+            },
+          }
+        })
+        : []
+
+      // Concat extra options after the base options
+      return [...baseOptions, ...extraFieldOptions]
     },
   },
 }

--- a/client/web/compose/src/components/PageBlocks/RecordBase.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordBase.vue
@@ -19,7 +19,7 @@
       <template v-for="field in fields">
         <b-form-group
           v-if="canDisplay(field)"
-          :key="`${field.fieldID}-${field.name}`"
+          :key="`${field.fieldID || field.originalName}-${field.name}`"
           :data-test-id="getFieldCypressId(field.label || field.name)"
           :label-cols-md="options.horizontalFieldLayoutEnabled && '6'"
           :label-cols-xl="options.horizontalFieldLayoutEnabled && '5'"
@@ -43,7 +43,7 @@
               <c-hint :tooltip="((field.options.hint || {}).view || '')" />
 
               <div
-                v-if="!record.deletedAt && options.inlineRecordEditEnabled && isFieldEditable(field)"
+                v-if="!field.isParentField && !record.deletedAt && options.inlineRecordEditEnabled && isFieldEditable(field)"
                 class="inline-actions ml-1"
               >
                 <b-button
@@ -70,7 +70,27 @@
           </template>
 
           <div
-            v-if="field.canReadRecordValue"
+            v-if="field.isParentField"
+            class="value align-self-center"
+          >
+            <template v-if="resolvedParentRecord">
+              <field-viewer
+                :field="field"
+                :record="resolvedParentRecord"
+                :module="getModuleByID(field.parentModuleID)"
+                :namespace="namespace"
+                :extra-options="options"
+                value-only
+              />
+            </template>
+            <span
+              v-else
+              class="text-muted"
+            >&mdash;</span>
+          </div>
+
+          <div
+            v-else-if="field.canReadRecordValue"
             class="value align-self-center"
           >
             <field-viewer
@@ -108,7 +128,7 @@
 </template>
 <script>
 import { compose, NoID } from '@cortezaproject/corteza-js'
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 import axios from 'axios'
 import base from './base'
 import FieldViewer from 'corteza-webapp-compose/src/components/ModuleFields/Viewer'
@@ -141,6 +161,7 @@ export default {
     return {
       referenceRecord: undefined,
       referenceModule: undefined,
+      resolvedParentRecord: null,
       inlineEdit: {
         fields: [],
         recordIDs: [],
@@ -152,22 +173,74 @@ export default {
   },
 
   computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+    }),
+
     fields () {
       if (!this.fieldModule) {
-        // No module, no fields
         return []
       }
 
       if (!this.options.fields || this.options.fields.length === 0) {
-        // No fields defined in the options, show all (buy system)
         return this.fieldModule.fields
       }
 
-      // Show filtered & ordered list of fields
-      return this.fieldModule.filterFields(this.options.fields).map(f => {
+      const childFieldConfigs = (this.options.fields || []).filter(f => !f.isParentField)
+      const parentFieldConfigs = (this.options.fields || []).filter(f => f.isParentField)
+
+      let moduleFields = []
+      if (childFieldConfigs.length > 0) {
+        moduleFields = this.fieldModule.filterFields(childFieldConfigs)
+      } else {
+        moduleFields = this.fieldModule.fields
+      }
+
+      const configured = moduleFields.map(f => {
         f.label = f.isSystem ? this.$t(`field:system.${f.name}`) : f.label || f.name
+        f.isParentField = false
         return f
       })
+
+      const parentModule = this.parentModule
+      const parentConfigured = parentFieldConfigs
+        .map(pf => {
+          const actualField = parentModule ? parentModule.fields.find(f => f.name === pf.originalName) : null
+          if (!actualField) return null
+          return {
+            ...actualField,
+            isParentField: true,
+            parentModuleID: pf.parentModuleID,
+            originalName: pf.originalName,
+            label: actualField.label || actualField.name,
+          }
+        })
+        .filter(Boolean)
+
+      if (parentFieldConfigs.length > 0 && this.options.fields.length > 0) {
+        const allConfigured = [...configured, ...parentConfigured]
+        const orderedFields = []
+
+        this.options.fields.forEach(configField => {
+          const match = allConfigured.find(c => {
+            if (configField.isParentField) {
+              return c.isParentField && c.originalName === configField.originalName && c.parentModuleID === configField.parentModuleID
+            }
+            return !c.isParentField && (c.name === configField.name || c.fieldID === configField.name)
+          })
+          if (match) orderedFields.push(match)
+        })
+
+        allConfigured.forEach(c => {
+          if (!orderedFields.find(o => o === c)) {
+            orderedFields.push(c)
+          }
+        })
+
+        return orderedFields
+      }
+
+      return [...configured, ...parentConfigured]
     },
 
     fieldLayoutClass () {
@@ -186,6 +259,30 @@ export default {
 
     fieldRecord () {
       return this.options.referenceField ? this.referenceRecord : this.record
+    },
+
+    parentFieldConfigs () {
+      if (!this.options.fields || !this.options.fields.length) {
+        return []
+      }
+      return this.options.fields.filter(f => f.isParentField && f.parentModuleID)
+    },
+
+    parentModule () {
+      if (!this.options.includeParentFields || !this.options.parentField) {
+        return null
+      }
+
+      const linkField = this.module.fields.find(f => f.name === this.options.parentField)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return null
+      }
+
+      return this.getModuleByID(linkField.options.moduleID) || null
+    },
+
+    parentLinkFieldName () {
+      return this.options.parentField || null
     },
 
     isProcessing () {
@@ -229,6 +326,10 @@ export default {
 
         if (this.options.referenceModuleID) {
           this.fetchReferenceModule(this.options.referenceModuleID)
+        }
+
+        if (this.options.includeParentFields) {
+          this.fetchParentRecord()
         }
       },
     },
@@ -376,8 +477,60 @@ export default {
     setDefaultValues () {
       this.referenceRecord = undefined
       this.referenceModule = undefined
+      this.resolvedParentRecord = null
       this.inlineEdit = {}
       this.abortableRequests = []
+    },
+
+    async fetchParentRecord () {
+      if (!this.options.includeParentFields || !this.parentLinkFieldName || !this.parentFieldConfigs.length) {
+        return
+      }
+
+      if (!this.record || !this.record.recordID || this.record.recordID === NoID) {
+        return
+      }
+
+      const linkField = this.module.fields.find(f => f.name === this.parentLinkFieldName)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return
+      }
+
+      const parentModuleID = linkField.options.moduleID
+      const parentRecordID = this.record.values[this.parentLinkFieldName]
+
+      if (!parentRecordID || parentRecordID === '0') {
+        this.resolvedParentRecord = null
+        return
+      }
+
+      const parentModule = this.getModuleByID(parentModuleID)
+      if (!parentModule) return
+
+      try {
+        const { response } = this.$ComposeAPI.recordReadCancellable({
+          namespaceID: this.namespace.namespaceID,
+          moduleID: parentModuleID,
+          recordID: parentRecordID,
+        })
+
+        const record = await response()
+        this.resolvedParentRecord = new compose.Record(parentModule, { ...record })
+
+        const selectedParentFields = this.parentFieldConfigs
+          .map(pf => parentModule.fields.find(f => f.name === pf.originalName))
+          .filter(Boolean)
+
+        await Promise.all([
+          this.fetchRecords(this.namespace.namespaceID, selectedParentFields, [this.resolvedParentRecord]),
+          this.fetchUsers(selectedParentFields, [this.resolvedParentRecord]),
+        ])
+      } catch (e) {
+        if (!axios.isCancel(e)) {
+          console.warn('[RecordBlock] Failed to fetch parent record:', e)
+          this.resolvedParentRecord = null
+        }
+      }
     },
 
     abortRequests () {

--- a/client/web/compose/src/components/PageBlocks/RecordConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordConfigurator.vue
@@ -138,11 +138,14 @@
       <b-row class="mt-2">
         <b-col
           cols="12"
+          lg="6"
         >
-          <b-form-group>
+          <b-form-group
+            :label="$t('record.parentFields.enable')"
+            label-class="text-primary"
+          >
             <c-input-checkbox
               v-model="options.includeParentFields"
-              :label="$t('record.parentFields.enable')"
               switch
               :labels="checkboxLabel"
             />

--- a/client/web/compose/src/components/PageBlocks/RecordConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordConfigurator.vue
@@ -127,9 +127,45 @@
         <b-col cols="12">
           <field-picker
             :module="fieldModule"
+            :extra-module="parentModuleConfig.extraModule"
+            :extra-module-fields="parentModuleConfig.extraModuleFields"
             :fields.sync="options.fields"
             style="height: 52vh;"
           />
+        </b-col>
+      </b-row>
+
+      <b-row class="mt-2">
+        <b-col
+          cols="12"
+        >
+          <b-form-group>
+            <c-input-checkbox
+              v-model="options.includeParentFields"
+              :label="$t('record.parentFields.enable')"
+              switch
+              :labels="checkboxLabel"
+            />
+          </b-form-group>
+        </b-col>
+
+        <b-col
+          v-if="options.includeParentFields"
+          cols="12"
+          lg="6"
+        >
+          <b-form-group
+            :label="$t('record.parentFields.field')"
+            label-class="text-primary"
+          >
+            <c-input-select
+              v-model="options.parentField"
+              :options="availableParentFields"
+              label="label"
+              :reduce="f => f.name"
+              :placeholder="$t('general.label.none')"
+            />
+          </b-form-group>
         </b-col>
       </b-row>
 
@@ -343,7 +379,7 @@
 <script>
 import base from './base'
 import FieldPicker from 'corteza-webapp-compose/src/components/Common/FieldPicker'
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 import { NoID, compose } from '@cortezaproject/corteza-js'
 import autocomplete from 'corteza-webapp-compose/src/mixins/autocomplete.js'
 import { components } from '@cortezaproject/corteza-vue'
@@ -377,6 +413,10 @@ export default {
   },
 
   computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+    }),
+
     visibilityDocumentationURL () {
       // eslint-disable-next-line no-undef
       const [year, month] = VERSION.split('.')
@@ -421,6 +461,91 @@ export default {
         return this.module.fields.some(f => f.kind === 'Record')
       } else {
         return this.options.fields.some(f => f.kind === 'Record')
+      }
+    },
+
+    availableParentFields () {
+      if (!this.module) {
+        return []
+      }
+
+      return this.module.fields
+        .filter(field => {
+          if (field.kind !== 'Record') return false
+          if (field.isMulti) return false
+          if (!field.options || !field.options.moduleID) return false
+          return true
+        })
+        .map(field => {
+          const linkedModule = this.getModuleByID(field.options.moduleID)
+          return {
+            ...field,
+            label: linkedModule
+              ? `${field.label || field.name} → ${linkedModule.name}`
+              : field.label || field.name,
+          }
+        })
+    },
+
+    parentModuleConfig () {
+      if (!this.options.includeParentFields || !this.options.parentField) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      if (!this.module) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      const linkField = this.module.fields.find(f => f.name === this.options.parentField)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      const parentModule = this.getModuleByID(linkField.options.moduleID)
+      if (!parentModule) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      return {
+        extraModule: {
+          moduleID: parentModule.moduleID,
+          name: parentModule.name,
+        },
+        extraModuleFields: parentModule.fields.map(f => ({
+          ...f,
+          originalName: f.name,
+        })),
+      }
+    },
+  },
+
+  watch: {
+    'options.parentField' (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        if (this.options.fields && this.options.fields.length > 0) {
+          this.options.fields = this.options.fields.filter(f => !f.isParentField)
+        }
+      }
+    },
+
+    'options.includeParentFields' (newVal) {
+      if (!newVal) {
+        if (this.options.fields && this.options.fields.length) {
+          this.options.fields = this.options.fields.filter(f => !f.isParentField)
+        }
+        this.options.parentField = null
       }
     },
   },

--- a/client/web/compose/src/components/PageBlocks/RecordEditor.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordEditor.vue
@@ -20,75 +20,124 @@
       <template v-for="field in fields">
         <div
           v-if="canDisplay(field)"
-          :key="`${field.fieldID}-${field.name}`"
+          :key="`${field.fieldID || field.originalName}-${field.name}`"
           :class="`field-container ${columnWrapClass}`"
           :style="fieldWidth"
         >
-          <field-editor
-            v-if="isFieldEditable(field)"
-            v-bind="{ ...$props, errors: fieldErrors(field.name) }"
-            :horizontal="horizontal"
-            :field="field"
-            :extra-options="options"
-            @change="onFieldChange(field)"
-          />
-
-          <b-form-group
-            v-else
-            :label-cols-md="horizontal && '5'"
-            :label-cols-xl="horizontal && '4'"
-            :content-cols-md="horizontal && '7'"
-            :content-cols-xl="horizontal && '8'"
-          >
-            <template #label>
-              <div
-                class="d-flex align-items-center text-primary mb-0"
-              >
-                <span
-                  class="d-flex"
+          <template v-if="field.isParentField">
+            <b-form-group
+              :label-cols-md="horizontal && '5'"
+              :label-cols-xl="horizontal && '4'"
+              :content-cols-md="horizontal && '7'"
+              :content-cols-xl="horizontal && '8'"
+            >
+              <template #label>
+                <div
+                  class="d-flex align-items-center text-primary mb-0"
                 >
-                  {{ field.label || field.name }}
-                </span>
+                  <span
+                    class="d-flex"
+                  >
+                    {{ field.label || field.name }}
+                  </span>
 
-                <c-hint :tooltip="((field.options.hint || {}).view || '')" />
+                  <c-hint :tooltip="((field.options.hint || {}).view || '')" />
+                </div>
+
+                <div
+                  class="small text-muted"
+                  :class="{ 'mb-1': !!(field.options.description || {}).view }"
+                >
+                  {{ (field.options.description || {}).view }}
+                </div>
+              </template>
+
+              <div class="value align-self-center">
+                <template v-if="resolvedParentRecord">
+                  <field-viewer
+                    :field="field"
+                    :record="resolvedParentRecord"
+                    :module="getModuleByID(field.parentModuleID)"
+                    :namespace="namespace"
+                    :extra-options="options"
+                    value-only
+                  />
+                </template>
+                <span
+                  v-else
+                  class="text-muted"
+                >&mdash;</span>
+              </div>
+            </b-form-group>
+          </template>
+
+          <template v-else>
+            <field-editor
+              v-if="isFieldEditable(field)"
+              v-bind="{ ...$props, errors: fieldErrors(field.name) }"
+              :horizontal="horizontal"
+              :field="field"
+              :extra-options="options"
+              @change="onFieldChange(field)"
+            />
+
+            <b-form-group
+              v-else
+              :label-cols-md="horizontal && '5'"
+              :label-cols-xl="horizontal && '4'"
+              :content-cols-md="horizontal && '7'"
+              :content-cols-xl="horizontal && '8'"
+            >
+              <template #label>
+                <div
+                  class="d-flex align-items-center text-primary mb-0"
+                >
+                  <span
+                    class="d-flex"
+                  >
+                    {{ field.label || field.name }}
+                  </span>
+
+                  <c-hint :tooltip="((field.options.hint || {}).view || '')" />
+                </div>
+
+                <div
+                  class="small text-muted"
+                  :class="{ 'mb-1': !!(field.options.description || {}).view }"
+                >
+                  {{ (field.options.description || {}).view }}
+                </div>
+              </template>
+
+              <div
+                v-if="field.canReadRecordValue"
+                class="value align-self-center"
+              >
+                <field-viewer
+                  :field="field"
+                  v-bind="{ ...$props, errors: fieldErrors(field.name) }"
+                  value-only
+                />
               </div>
 
               <div
-                class="small text-muted"
-                :class="{ 'mb-1': !!(field.options.description || {}).view }"
+                v-else
               >
-                {{ (field.options.description || {}).view }}
+                <i
+                  class="text-muted"
+                >
+                  {{ $t('field.noPermission') }}
+                </i>
               </div>
-            </template>
-
-            <div
-              v-if="field.canReadRecordValue"
-              class="value align-self-center"
-            >
-              <field-viewer
-                :field="field"
-                v-bind="{ ...$props, errors: fieldErrors(field.name) }"
-                value-only
-              />
-            </div>
-
-            <div
-              v-else
-            >
-              <i
-                class="text-muted"
-              >
-                {{ $t('field.noPermission') }}
-              </i>
-            </div>
-          </b-form-group>
+            </b-form-group>
+          </template>
         </div>
       </template>
     </div>
   </wrap>
 </template>
 <script>
-import { NoID } from '@cortezaproject/corteza-js'
+import { NoID, compose } from '@cortezaproject/corteza-js'
 import base from './base'
 import users from 'corteza-webapp-compose/src/mixins/users'
 import records from 'corteza-webapp-compose/src/mixins/records'
@@ -97,6 +146,8 @@ import FieldViewer from 'corteza-webapp-compose/src/components/ModuleFields/View
 import conditionalFields from 'corteza-webapp-compose/src/mixins/conditionalFields'
 import recordLayout from 'corteza-webapp-compose/src/mixins/recordLayout'
 import { debounce } from 'lodash'
+import { mapGetters } from 'vuex'
+import axios from 'axios'
 
 export default {
   i18nOptions: {
@@ -117,23 +168,81 @@ export default {
     recordLayout,
   ],
 
+  data () {
+    return {
+      resolvedParentRecord: null,
+    }
+  },
+
   computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+    }),
+
     fields () {
       if (!this.module) {
-        // No module, no fields
         return []
       }
 
       if (!this.options.fields || this.options.fields.length === 0) {
-        // No fields defined in the options, show all (but system)
         return this.module.fields
       }
 
-      // Show filtered & ordered list of fields
-      return this.module.filterFields(this.options.fields).map(f => {
+      const childFieldConfigs = (this.options.fields || []).filter(f => !f.isParentField)
+      const parentFieldConfigs = (this.options.fields || []).filter(f => f.isParentField)
+
+      let moduleFields = []
+      if (childFieldConfigs.length > 0) {
+        moduleFields = this.module.filterFields(childFieldConfigs)
+      } else {
+        moduleFields = this.module.fields
+      }
+
+      const configured = moduleFields.map(f => {
         f.label = f.isSystem ? this.$t(`field:system.${f.name}`) : f.label || f.name
+        f.isParentField = false
         return f
       })
+
+      const parentModule = this.parentModule
+      const parentConfigured = parentFieldConfigs
+        .map(pf => {
+          const actualField = parentModule ? parentModule.fields.find(f => f.name === pf.originalName) : null
+          if (!actualField) return null
+          return {
+            ...actualField,
+            isParentField: true,
+            parentModuleID: pf.parentModuleID,
+            originalName: pf.originalName,
+            label: actualField.label || actualField.name,
+          }
+        })
+        .filter(Boolean)
+
+      if (parentFieldConfigs.length > 0 && this.options.fields.length > 0) {
+        const allConfigured = [...configured, ...parentConfigured]
+        const orderedFields = []
+
+        this.options.fields.forEach(configField => {
+          const match = allConfigured.find(c => {
+            if (configField.isParentField) {
+              return c.isParentField && c.originalName === configField.originalName && c.parentModuleID === configField.parentModuleID
+            }
+            return !c.isParentField && (c.name === configField.name || c.fieldID === configField.name)
+          })
+          if (match) orderedFields.push(match)
+        })
+
+        allConfigured.forEach(c => {
+          if (!orderedFields.find(o => o === c)) {
+            orderedFields.push(c)
+          }
+        })
+
+        return orderedFields
+      }
+
+      return [...configured, ...parentConfigured]
     },
 
     fieldLayoutClass () {
@@ -165,6 +274,30 @@ export default {
     isNew () {
       return this.record && this.record.recordID === NoID
     },
+
+    parentFieldConfigs () {
+      if (!this.options.fields || !this.options.fields.length) {
+        return []
+      }
+      return this.options.fields.filter(f => f.isParentField && f.parentModuleID)
+    },
+
+    parentModule () {
+      if (!this.options.includeParentFields || !this.options.parentField) {
+        return null
+      }
+
+      const linkField = this.module.fields.find(f => f.name === this.options.parentField)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return null
+      }
+
+      return this.getModuleByID(linkField.options.moduleID) || null
+    },
+
+    parentLinkFieldName () {
+      return this.options.parentField || null
+    },
   },
 
   watch: {
@@ -192,6 +325,10 @@ export default {
         ]).finally(() => {
           this.evaluating = false
         })
+
+        if (this.options.includeParentFields) {
+          this.fetchParentRecord()
+        }
       },
     },
 
@@ -220,6 +357,57 @@ export default {
   },
 
   methods: {
+    async fetchParentRecord () {
+      if (!this.options.includeParentFields || !this.parentLinkFieldName || !this.parentFieldConfigs.length) {
+        return
+      }
+
+      if (!this.record || !this.record.recordID || this.record.recordID === NoID) {
+        return
+      }
+
+      const linkField = this.module.fields.find(f => f.name === this.parentLinkFieldName)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return
+      }
+
+      const parentModuleID = linkField.options.moduleID
+      const parentRecordID = this.record.values[this.parentLinkFieldName]
+
+      if (!parentRecordID || parentRecordID === '0') {
+        this.resolvedParentRecord = null
+        return
+      }
+
+      const parentModule = this.getModuleByID(parentModuleID)
+      if (!parentModule) return
+
+      try {
+        const { response } = this.$ComposeAPI.recordReadCancellable({
+          namespaceID: this.namespace.namespaceID,
+          moduleID: parentModuleID,
+          recordID: parentRecordID,
+        })
+
+        const record = await response()
+        this.resolvedParentRecord = new compose.Record(parentModule, { ...record })
+
+        const selectedParentFields = this.parentFieldConfigs
+          .map(pf => parentModule.fields.find(f => f.name === pf.originalName))
+          .filter(Boolean)
+
+        await Promise.all([
+          this.fetchRecords(this.namespace.namespaceID, selectedParentFields, [this.resolvedParentRecord]),
+          this.fetchUsers(selectedParentFields, [this.resolvedParentRecord]),
+        ])
+      } catch (e) {
+        if (!axios.isCancel(e)) {
+          console.warn('[RecordEditor] Failed to fetch parent record:', e)
+          this.resolvedParentRecord = null
+        }
+      }
+    },
+
     onFieldChange: debounce(function (field) {
       this.$root.$emit('record-field-change', {
         fieldName: field.name,

--- a/client/web/compose/src/components/PageBlocks/RecordListBase.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListBase.vue
@@ -130,123 +130,104 @@
           class="d-flex align-items-start flex-wrap gap-1"
         >
           <div
-            v-if="groupedByConnector.length"
+            v-if="groupRecordListFilter.length"
             class="d-flex align-items-center flex-wrap gap-2"
           >
             <div
-              v-for="(segment, segmentIdx) in groupedByConnector"
-              :key="`segment-${segmentIdx}`"
+              v-for="(filterGroup, groupIdx) in groupRecordListFilter"
+              :key="groupIdx"
               class="d-flex align-items-center gap-2"
             >
-              <div
-                class="d-flex flex-wrap align-items-center gap-1 border rounded p-1"
-              >
-                <template
-                  v-for="(filterGroup, groupIdx) in segment.groups"
+              <div class="d-flex flex-wrap align-items-center border rounded p-1 gap-1 flex-wrap">
+                <div
+                  v-for="(f, filterIndex) in filterGroup.filter"
+                  :key="filterIndex"
+                  class="active-filter d-flex align-items-center rounded gap-1 pl-2 pr-1 py-1 bg-light"
                 >
-                  <div
-                    :key="`group-${filterGroup.originalIndex}`"
-                    class="d-flex flex-wrap align-items-center gap-1"
-                  >
-                    <div
-                      v-for="(f, filterIndex) in filterGroup.filter"
-                      :key="filterIndex"
-                      class="active-filter d-flex align-items-center rounded gap-1 pl-2 pr-1 py-1 bg-light"
-                    >
-                      <span class="field-label">
-                        {{ f.label || f.name }}
-                      </span>
+                  <span class="field-label">
+                    {{ f.label || f.name }}
+                  </span>
 
-                      <span>
-                        {{ $t(`recordList.filter.operatorLabels.${formatActiveFilterOperator(f.operator)}`) }}
-                      </span>
+                  <span>
+                    {{ $t(`recordList.filter.operatorLabels.${formatActiveFilterOperator(f.operator)}`) }}
+                  </span>
 
-                      <template v-if="f.value">
-                        <template v-if="isBetweenOperator(f.operator)">
-                          <field-viewer
-                            v-if="f.value.start"
-                            value-only
-                            :field="f.field"
-                            :record="f.record[0]"
-                            :module="recordListModule"
-                            :namespace="namespace"
-                            class="font-weight-bold text-primary"
-                          />
-
-                          <span
-                            v-else
-                            class="text-primary font-weight-bold"
-                          >
-                            {{ !f.value.start ? $t('recordList.filter.nil') : '' }}
-                          </span>
-
-                          <span class="text-lowercase">
-                            {{ $t('recordList.filter.conditions.and') }}
-                          </span>
-
-                          <field-viewer
-                            v-if="f.value.end"
-                            value-only
-                            :field="f.field"
-                            :record="f.record[1]"
-                            :module="recordListModule"
-                            :namespace="namespace"
-                            class="font-weight-bold text-primary"
-                          />
-
-                          <span
-                            v-else
-                            class="text-primary font-weight-bold"
-                          >
-                            {{ !f.value.end ? $t('recordList.filter.nil') : '' }}
-                          </span>
-                        </template>
-
-                        <field-viewer
-                          v-else
-                          value-only
-                          :field="f.field"
-                          :record="f.record"
-                          :module="recordListModule"
-                          :namespace="namespace"
-                          class="font-weight-bold text-primary"
-                        />
-                      </template>
+                  <template v-if="f.value">
+                    <template v-if="isBetweenOperator(f.operator)">
+                      <field-viewer
+                        v-if="f.value.start"
+                        value-only
+                        :field="f.field"
+                        :record="f.record[0]"
+                        :module="recordListModule"
+                        :namespace="namespace"
+                        class="font-weight-bold text-primary"
+                      />
 
                       <span
                         v-else
                         class="text-primary font-weight-bold"
                       >
-                        {{ $t('recordList.filter.nil') }}
+                        {{ !f.value.start ? $t('recordList.filter.nil') : '' }}
                       </span>
 
-                      <b-button
-                        variant="light"
-                        class="d-flex align-items-center p-1 active-filter-close-btn bg-transparent border-0"
-                        @click="removeFilter(filterGroup.originalIndex, filterIndex)"
+                      <span
+                        class="text-lowercase"
                       >
-                        <font-awesome-icon
-                          :icon="['fas', 'times']"
-                        />
-                      </b-button>
-                    </div>
-                  </div>
+                        {{ $t('recordList.filter.conditions.and') }}
+                      </span>
 
-                  <!-- AND connector between groups in same segment -->
+                      <field-viewer
+                        v-if="f.value.end"
+                        value-only
+                        :field="f.field"
+                        :record="f.record[1]"
+                        :module="recordListModule"
+                        :namespace="namespace"
+                        class="font-weight-bold text-primary"
+                      />
+
+                      <span
+                        v-else
+                        class="text-primary font-weight-bold"
+                      >
+                        {{ !f.value.end ? $t('recordList.filter.nil') : '' }}
+                      </span>
+                    </template>
+
+                    <field-viewer
+                      v-else
+                      value-only
+                      :field="f.field"
+                      :record="f.record"
+                      :module="recordListModule"
+                      :namespace="namespace"
+                      class="font-weight-bold text-primary"
+                    />
+                  </template>
+
                   <span
-                    v-if="groupIdx < segment.groups.length - 1"
-                    :key="`and-${filterGroup.originalIndex}`"
-                    class="text-secondary text-uppercase"
+                    v-else
+                    class="text-primary font-weight-bold"
                   >
-                    {{ $t('recordList.filter.conditions.and') }}
+                    {{ $t('recordList.filter.nil') }}
                   </span>
-                </template>
+
+                  <b-button
+                    variant="light"
+                    class="d-flex align-items-center p-1 active-filter-close-btn bg-transparent border-0"
+                    @click="removeFilter(groupIdx, filterIndex) "
+                  >
+                    <font-awesome-icon
+                      :icon="['fas', 'times']"
+                    />
+                  </b-button>
+                </div>
               </div>
 
-              <!-- OR connector between segments -->
               <span
-                v-if="segment.connector"
-                class="text-secondary text-uppercase"
+                v-if="groupIdx < groupRecordListFilter.length - 1"
+                class="text-secondary"
               >
                 {{ $t('recordList.filter.conditions.or') }}
               </span>
@@ -279,18 +260,15 @@
         </div>
 
         <div
-          v-if="(options.selectable && selected.length) || (inlineEditing && dirtyRecordsCount > 1)"
+          v-if="options.selectable && selected.length"
           class="d-flex align-items-center flex-wrap align-items-center"
         >
-          <div
-            v-if="options.selectable && selected.length"
-            class="mr-1"
-          >
+          <div class="mr-1">
             {{ selectedRecordsDisplayText }}
           </div>
 
           <b-button
-            v-if="!inlineEditing && options.selectable && selected.length"
+            v-if="!inlineEditing"
             size="sm"
             variant="outline-extra-light"
             class="text-primary border-0"
@@ -301,61 +279,12 @@
 
           <div class="d-flex align-items-center ml-auto gap-1">
             <automation-buttons
-              v-if="options.selectable && selected.length"
-              class="d-inline m-0"
+              class="d-inline m-0 mr-2"
               :buttons="options.selectionButtons"
               :module="recordListModule"
               :extra-event-args="{ selected, filter}"
               v-bind="$props"
               @refresh="refresh()"
-            />
-
-            <b-spinner
-              v-if="processingDirtyRecords === 'save'"
-              small
-              class="text-secondary"
-            />
-
-            <b-button
-              v-else-if="inlineEditing && dirtyRecordsCount > 0"
-              v-b-tooltip.noninteractive.hover="{ title: $t('recordList.tooltip.saveChanges'), boundary: 'body', delay: { show: 300 } }"
-              variant="outline-extra-light"
-              class="d-flex align-items-center justify-content-center border-0"
-              style="width: 2rem; height: 2rem;"
-              :disabled="!!processingDirtyRecords"
-              @click="handleSaveDirtyRecords()"
-            >
-              <font-awesome-icon
-                :icon="['fas', 'check']"
-                class="text-primary"
-              />
-            </b-button>
-
-            <b-spinner
-              v-if="processingDirtyRecords === 'deny'"
-              small
-              class="text-secondary"
-            />
-
-            <b-button
-              v-else-if="inlineEditing && dirtyRecordsCount > 0"
-              v-b-tooltip.noninteractive.hover="{ title: $t('recordList.tooltip.discardChanges'), boundary: 'body', delay: { show: 300 } }"
-              variant="outline-extra-light"
-              class="d-flex align-items-center justify-content-center border-0"
-              style="width: 2rem; height: 2rem;"
-              :disabled="!!processingDirtyRecords"
-              @click="handleDenyDirtyRecords()"
-            >
-              <font-awesome-icon
-                :icon="['fas', 'times']"
-                class="text-secondary"
-              />
-            </b-button>
-
-            <div
-              v-if="inlineEditing && dirtyRecordsCount > 0 && options.selectable && selected.length && ((options.bulkRecordEditEnabled && canUpdateSelectedRecords && !showingDeletedRecords) || (canDeleteSelectedRecords && !areAllRowsDeleted))"
-              class="border-left mx-1"
-              style="height: 1.5rem;"
             />
 
             <bulk-edit-modal
@@ -371,7 +300,6 @@
               <c-input-confirm
                 show-icon
                 :tooltip="$t('recordList.tooltip.deleteSelected')"
-                :button-style="{ width: '2rem', height: '2rem' }"
                 @confirmed="handleDeleteSelectedRecords()"
               />
             </template>
@@ -492,8 +420,8 @@
             <b-tr
               v-for="(item, index) in items"
               :key="`${index}${item.r.recordID}`"
-              :class="{ 'pointer': isRowClickable }"
-              :variant="inlineEditing && (dirtyInlineRecords[item.id] || item.r.deletedAt) ? 'warning' : ''"
+              :class="{ 'pointer': !(options.editable && editing), }"
+              :variant="inlineEditing && item.r.deletedAt ? 'warning' : ''"
               @click="handleRowClick(item)"
             >
               <b-td
@@ -538,275 +466,484 @@
                 v-for="field in fields"
                 :key="field.key"
               >
-                <field-editor
-                  v-if="field.moduleField.canUpdateRecordValue && field.editable && isFieldEditable(field.moduleField)"
-                  :field="field.moduleField"
-                  value-only
-                  :record="item.r"
-                  :module="module"
-                  :namespace="namespace"
-                  :errors="recordErrors(item, field)"
-                  class="mb-0"
-                  style="min-width: 250px;"
-                  @click.stop
-                  @change="onInlineFieldChange(item)"
-                />
-
-                <div
-                  v-else-if="field.moduleField.canReadRecordValue && !field.edit"
-                  class="d-flex mb-0 gap-1"
-                  style="min-width: 10rem;"
-                >
-                  <field-viewer
-                    :field="field.moduleField"
-                    value-only
-                    :record="item.r"
-                    :module="module"
-                    :namespace="namespace"
-                    :extra-options="options"
-                    include-styles
-                  />
-
-                  <div
-                    v-if="showInlineActions(field)"
-                    class="d-flex flex-nowrap align-items-start gap-1 inline-actions"
-                  >
-                    <b-button
-                      v-if="showInlineEdit(field)"
-                      v-b-tooltip.noninteractive.hover="{ title: $t('recordList.inlineEdit.button.title'), boundary: 'body' }"
-                      variant="outline-extra-light"
-                      size="sm"
-                      class="text-secondary border-0"
-                      @click.stop="editInlineField(item.r, field.key)"
-                    >
-                      <font-awesome-icon
-                        :icon="['fas', 'pen']"
-                      />
-                    </b-button>
-
-                    <b-button
-                      v-if="showInlineFilter(field)"
-                      v-b-tooltip.noninteractive.hover="{ title: $t('recordList.filterByValue'), boundary: 'body' }"
-                      variant="outline-extra-light"
-                      size="sm"
-                      class="text-secondary border-0"
-                      @click.stop="filterByValue(item.r, field)"
-                    >
-                      <font-awesome-icon
-                        :icon="['fas', 'filter']"
-                      />
-                    </b-button>
-                  </div>
+                <!-- Parent field: look up value from resolved parent records -->
+                <div v-if="field.isParentField">
+                  <template v-if="getParentRecordID(item.r) && resolvedParentRecords[getParentRecordID(item.r)]">
+                    <field-viewer
+                      :field="field.moduleField"
+                      value-only
+                      :record="resolvedParentRecords[getParentRecordID(item.r)]"
+                      :module="getModuleByID(field.parentModuleID)"
+                      :namespace="namespace"
+                      :extra-options="options"
+                      include-styles
+                    />
+                  </template>
+                  <template v-else>
+                    <!-- Parent record not loaded yet or link field is empty -->
+                    <span class="text-muted">—</span>
+                  </template>
                 </div>
 
-                <i
-                  v-else
-                  class="text-primary"
-                >
-                  {{ $t('field.noPermission') }}
-                </i>
+                <!-- Regular child field: existing rendering logic unchanged -->
+                <div v-else>
+                  <!-- Inline editor for supported field types -->
+                  <div
+                    v-if="inlineEditing && field.canEdit && showInlineEdit(field) && isInlineEditableFieldType(field.moduleField) && options.inlineRecordEditFullInline"
+                    class="d-flex flex-column align-items-start gap-1"
+                  >
+                    <!-- Field value display -->
+                    <div
+                      v-if="!isFieldChanged(item.id, field.key)"
+                      class="d-flex w-100"
+                    >
+                      <!-- Render appropriate input based on field type -->
+                      <div v-if="field.moduleField && field.moduleField && field.moduleField.kind === 'Select'">
+                        <c-input-select
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :options="field.moduleField.options"
+                          :reduce="o => o.value"
+                          :get-option-label="getOptionLabel"
+                          :get-option-key="getOptionKey"
+                          :placeholder="$t('kind.select.placeholder')"
+                          :selectable="isSelectable(field.moduleField)"
+                          :loading="false"
+                          class="w-100"
+                          @input="onInlineFieldInput(item.r, field.moduleField, $event)"
+                        />
+                      </div>
+                      <div v-else-if="field.moduleField && field.moduleField.kind === 'Checkbox'">
+                        <b-form-checkbox
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :switch="field.moduleField.options.switch"
+                          :labels="field.moduleField.options.switch ? checkboxLabel(field.moduleField) : {}"
+                          @change="onInlineFieldInput(item.r, field.moduleField, $event)"
+                        >
+                          {{ field.moduleField.options.label || '' }}
+                        </b-form-checkbox>
+                      </div>
+                      <div v-else-if="field.moduleField && field.moduleField.kind === 'Record'">
+                        <c-input-select
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :options="field.moduleField.options"
+                          :reduce="o => o.value"
+                          :get-option-label="getOptionLabel"
+                          :get-option-key="getOptionKey"
+                          :placeholder="$t('kind.record.suggestionPlaceholder')"
+                          :selectable="isSelectable(field.moduleField)"
+                          :loading="false"
+                          :clearable="false"
+                          :filterable="false"
+                          :searchable="true"
+                          class="w-100"
+                          @input="onInlineFieldInput(item.r, field.moduleField, $event)"
+                          @search="onInlineFieldSearch(item.r, field.moduleField, $event)"
+                        >
+                          <template #option="option">
+                            <field-viewer
+                              v-if="field.moduleField.options.labelField && option.values[field.moduleField.options.labelField.name]"
+                              :field="field.moduleField.options.labelField"
+                              :record="option"
+                              :namespace="namespace"
+                              disable-click
+                              value-only
+                            />
+                            <template v-else>
+                              {{ option.recordID }}
+                            </template>
+                          </template>
+                          <template #selected-option="option">
+                            <field-viewer
+                              v-if="field.moduleField.options.labelField && getRecordByID(option.label).values[field.moduleField.options.labelField.name]"
+                              :field="field.moduleField.options.labelField"
+                              :record="getRecordByID(option.label)"
+                              :namespace="namespace"
+                              disable-click
+                              value-only
+                            />
+                            <template v-else>
+                              {{ option.label }}
+                            </template>
+                          </template>
+                        </c-input-select>
+                      </div>
+                      <div v-else-if="field.moduleField && field.moduleField.kind === 'User'">
+                        <c-input-select
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :options="field.moduleField.options"
+                          :reduce="o => o.value"
+                          :get-option-label="getOptionLabel"
+                          :get-option-key="getOptionKey"
+                          :placeholder="$t('kind.user.suggestionPlaceholder')"
+                          :selectable="isSelectable(field.moduleField)"
+                          :loading="false"
+                          :clearable="field.moduleField.name !== 'ownedBy'"
+                          :filterable="false"
+                          :searchable="true"
+                          class="w-100"
+                          @input="onInlineFieldInput(item.r, field.moduleField, $event)"
+                          @search="onInlineFieldSearch(item.r, field.moduleField, $event)"
+                        >
+                          <template #option="option">
+                            <span v-if="option">{{ option.name || option.username || option.email || `<@${option.userID}>` }}</span>
+                            <span v-else>No user</span>
+                          </template>
+                          <template #selected-option="option">
+                            <span v-if="option">{{ option.name || option.username || option.email || `<@${option.userID}>` }}</span>
+                            <span v-else>No user</span>
+                          </template>
+                        </c-input-select>
+                      </div>
+                      <div v-else>
+                        <!-- Fallback to regular viewer -->
+                        <field-viewer
+                          :field="field.moduleField"
+                          value-only
+                          :record="item.r"
+                          :module="module"
+                          :namespace="namespace"
+                          :extra-options="options"
+                          include-styles
+                        />
+                      </div>
+                    </div>
+
+                    <!-- Show save button when field has changes -->
+                    <div
+                      v-else
+                      class="d-flex align-items-start gap-1"
+                    >
+                      <!-- Same input as above but with save button -->
+                      <div v-if="field.moduleField && field.moduleField && field.moduleField.kind === 'Select'">
+                        <c-input-select
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :options="field.moduleField.options"
+                          :reduce="o => o.value"
+                          :get-option-label="getOptionLabel"
+                          :get-option-key="getOptionKey"
+                          :placeholder="$t('kind.select.placeholder')"
+                          :selectable="isSelectable(field.moduleField)"
+                          :loading="false"
+                          class="flex-grow-1"
+                          @input="onInlineFieldInput(item.r, field.moduleField, $event)"
+                        />
+                      </div>
+                      <div v-else-if="field.moduleField && field.moduleField.kind === 'Checkbox'">
+                        <div class="d-flex align-items-center">
+                          <b-form-checkbox
+                            v-model="localValues[`${item.id}-${field.key}`]"
+                            :switch="field.moduleField.options.switch"
+                            :labels="field.moduleField.options.switch ? checkboxLabel(field.moduleField) : {}"
+                            @change="onInlineFieldInput(item.r, field.moduleField, $event)"
+                          >
+                            {{ field.moduleField.options.label || '' }}
+                          </b-form-checkbox>
+                        </div>
+                      </div>
+                      <div v-else-if="field.moduleField && field.moduleField.kind === 'Record'">
+                        <c-input-select
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :options="field.moduleField.options"
+                          :reduce="o => o.value"
+                          :get-option-label="getOptionLabel"
+                          :get-option-key="getOptionKey"
+                          :placeholder="$t('kind.record.suggestionPlaceholder')"
+                          :selectable="isSelectable(field.moduleField)"
+                          :loading="false"
+                          :clearable="false"
+                          :filterable="false"
+                          :searchable="true"
+                          class="flex-grow-1"
+                          @input="onInlineFieldInput(item.r, field.moduleField, $event)"
+                          @search="onInlineFieldSearch(item.r, field.moduleField, $event)"
+                        >
+                          <template #option="option">
+                            <field-viewer
+                              v-if="field.moduleField.options.labelField && option.values[field.moduleField.options.labelField.name]"
+                              :field="field.moduleField.options.labelField"
+                              :record="option"
+                              :namespace="namespace"
+                              disable-click
+                              value-only
+                            />
+                            <template v-else>
+                              {{ option.recordID }}
+                            </template>
+                          </template>
+                          <template #selected-option="option">
+                            <field-viewer
+                              v-if="field.moduleField.options.labelField && getRecordByID(option.label).values[field.moduleField.options.labelField.name]"
+                              :field="field.moduleField.options.labelField"
+                              :record="getRecordByID(option.label)"
+                              :namespace="namespace"
+                              disable-click
+                              value-only
+                            />
+                            <template v-else>
+                              {{ option.label }}
+                            </template>
+                          </template>
+                        </c-input-select>
+                      </div>
+                      <div v-else-if="field.moduleField && field.moduleField.kind === 'User'">
+                        <c-input-select
+                          v-model="localValues[`${item.id}-${field.key}`]"
+                          :options="field.moduleField.options"
+                          :reduce="o => o.value"
+                          :get-option-label="getOptionLabel"
+                          :get-option-key="getOptionKey"
+                          :placeholder="$t('kind.user.suggestionPlaceholder')"
+                          :selectable="isSelectable(field.moduleField)"
+                          :loading="false"
+                          :clearable="field.moduleField.name !== 'ownedBy'"
+                          :filterable="false"
+                          :searchable="true"
+                          class="flex-grow-1"
+                          @input="onInlineFieldInput(item.r, field.moduleField, $event)"
+                          @search="onInlineFieldSearch(item.r, field.moduleField, $event)"
+                        >
+                          <template #option="option">
+                            <span v-if="option">{{ option.name || option.username || option.email || `<@${option.userID}>` }}</span>
+                            <span v-else>No user</span>
+                          </template>
+                          <template #selected-option="option">
+                            <span v-if="option">{{ option.name || option.username || option.email || `<@${option.userID}>` }}</span>
+                            <span v-else>No user</span>
+                          </template>
+                        </c-input-select>
+                      </div>
+                      <div v-else>
+                        <div>{{ getFieldValue(item.r, field.moduleField) }}</div>
+                      </div>
+
+                      <!-- Save button -->
+                      <b-button
+                        variant="outline-success"
+                        size="sm"
+                        class="mt-1"
+                        @click.stop="saveInlineField(item.r, field.moduleField)"
+                      >
+                        <font-awesome-icon :icon="['fas', 'save']" />
+                      </b-button>
+                    </div>
+                  </div>
+
+                  <!-- Fallback to original behavior for non-inline-editable fields -->
+                  <div v-else>
+                    <field-editor
+                      v-if="field.moduleField.canUpdateRecordValue && field.editable"
+                      :field="field.moduleField"
+                      value-only
+                      :record="item.r"
+                      :module="module"
+                      :namespace="namespace"
+                      :errors="recordErrors(item, field)"
+                      class="mb-0"
+                      style="min-width: 250px;"
+                      @click.stop
+                    />
+
+                    <div
+                      v-else-if="field.moduleField.canReadRecordValue && !field.edit"
+                      class="d-flex mb-0 gap-1"
+                      style="min-width: 10rem;"
+                    >
+                      <field-viewer
+                        :field="field.moduleField"
+                        value-only
+                        :record="item.r"
+                        :module="module"
+                        :namespace="namespace"
+                        :extra-options="options"
+                        include-styles
+                      />
+
+                      <div
+                        v-if="showInlineActions(field)"
+                        class="d-flex flex-nowrap align-items-start gap-1 inline-actions"
+                      >
+                        <b-button
+                          v-if="showInlineEdit(field)"
+                          v-b-tooltip.noninteractive.hover="{ title: $t('recordList.inlineEdit.button.title'), boundary: 'body' }"
+                          variant="outline-extra-light"
+                          size="sm"
+                          class="text-secondary border-0"
+                          @click.stop="editInlineField(item.r, field.key)"
+                        >
+                          <font-awesome-icon
+                            :icon="['fas', 'pen']"
+                          />
+                        </b-button>
+
+                        <b-button
+                          v-if="showInlineFilter()"
+                          v-b-tooltip.noninteractive.hover="{ title: $t('recordList.filterByValue'), boundary: 'body' }"
+                          variant="outline-extra-light"
+                          size="sm"
+                          class="text-secondary border-0"
+                          @click.stop="filterByValue(item.r, field)"
+                        >
+                          <font-awesome-icon
+                            :icon="['fas', 'filter']"
+                          />
+                        </b-button>
+                      </div>
+                    </div>
+
+                    <i
+                      v-else
+                      class="text-primary"
+                    >
+                      {{ $t('field.noPermission') }}
+                    </i>
+                  </div>
+                </div>
               </b-td>
 
               <b-td
                 class="actions px-2"
-                :class="{ 'actions-visible': inlineEditing && !editing && showSaveAction(item) }"
                 @click.stop
               >
-                <div
-                  class="d-flex align-items-center justify-content-end gap-1"
-                  :class="{ 'mt-2': inlineEditing }"
+                <b-dropdown
+                  v-if="areActionsVisible(item.r)"
+                  boundary="viewport"
+                  variant="outline-extra-light"
+                  toggle-class="d-flex align-items-center justify-content-center text-primary border-0 py-2"
+                  no-caret
+                  dropleft
+                  menu-class="m-0"
                 >
-                  <b-spinner
-                    v-if="processingInlineRecords[item.id] === 'save'"
-                    small
-                    class="text-primary"
-                  />
-
-                  <b-button
-                    v-else-if="inlineEditing && !editing && showSaveAction(item)"
-                    v-b-tooltip.noninteractive.hover="{ title: $t('recordList.tooltip.saveChanges'), boundary: 'body', delay: { show: 300 } }"
-                    variant="outline-extra-light"
-                    class="d-flex align-items-center justify-content-center border-0"
-                    style="width: 2rem; height: 2rem;"
-                    :disabled="!!processingInlineRecords[item.id]"
-                    @click.stop="handleSaveInline(item, index)"
-                  >
+                  <template #button-content>
                     <font-awesome-icon
-                      :icon="['fas', 'check']"
-                      class="text-primary"
+                      :icon="['fas', 'ellipsis-v']"
                     />
-                  </b-button>
+                  </template>
 
-                  <b-spinner
-                    v-if="processingInlineRecords[item.id] === 'deny'"
-                    small
-                    class="text-secondary"
-                  />
-
-                  <b-button
-                    v-else-if="inlineEditing && !editing && showSaveAction(item)"
-                    v-b-tooltip.noninteractive.hover="{ title: $t('recordList.tooltip.discardChanges'), boundary: 'body', delay: { show: 300 } }"
-                    variant="outline-extra-light"
-                    class="d-flex align-items-center justify-content-center border-0"
-                    style="width: 2rem; height: 2rem;"
-                    :disabled="!!processingInlineRecords[item.id]"
-                    @click.stop="handleDenyInline(item, index)"
-                  >
-                    <font-awesome-icon
-                      :icon="['fas', 'times']"
-                      class="text-secondary"
-                    />
-                  </b-button>
-
-                  <div
-                    v-if="inlineEditing && !editing && showSaveAction(item) && areActionsVisible(item.r)"
-                    class="border-left mx-1"
-                    style="height: 1.5rem;"
-                  />
-
-                  <b-dropdown
-                    v-if="areActionsVisible(item.r)"
-                    boundary="viewport"
-                    variant="outline-extra-light"
-                    toggle-class="d-flex align-items-center justify-content-center border-0"
-                    :toggle-attrs="{ style: 'width: 2rem; height: 2rem;' }"
-                    no-caret
-                    dropleft
-                    menu-class="m-0"
-                  >
-                    <template #button-content>
+                  <template v-if="inlineEditing">
+                    <b-dropdown-item-button
+                      v-if="isCloneRecordActionVisible"
+                      @click="handleCloneInline(item.r)"
+                    >
                       <font-awesome-icon
-                        :icon="['fas', 'ellipsis-v']"
+                        :icon="['far', 'clone']"
                         class="text-primary"
                       />
-                    </template>
+                      {{ $t('recordList.record.tooltip.clone') }}
+                    </b-dropdown-item-button>
 
-                    <template v-if="inlineEditing && editing">
-                      <b-dropdown-item-button
-                        v-if="isCloneRecordActionVisible"
-                        @click="handleCloneInline(item.r)"
-                      >
-                        <font-awesome-icon
-                          :icon="['far', 'clone']"
-                          class="text-primary"
-                        />
-                        {{ $t('recordList.record.tooltip.clone') }}
-                      </b-dropdown-item-button>
+                    <c-input-confirm
+                      v-if="isInlineRestoreActionVisible(item.r)"
+                      :text="$t('recordList.record.tooltip.restore')"
+                      :icon="['fas', 'trash-restore']"
+                      show-icon
+                      borderless
+                      variant="link"
+                      variant-ok="warning"
+                      size="md"
+                      button-class="dropdown-item"
+                      icon-class="text-warning"
+                      class="w-100"
+                      @confirmed="handleRestoreInline(item, index)"
+                    />
 
-                      <c-input-confirm
-                        v-if="isInlineRestoreActionVisible(item.r)"
-                        :text="$t('recordList.record.tooltip.restore')"
-                        :icon="['fas', 'trash-restore']"
-                        show-icon
-                        borderless
-                        variant="link"
-                        variant-ok="warning"
-                        size="md"
-                        button-class="dropdown-item"
-                        icon-class="text-warning"
-                        class="w-100"
-                        @confirmed="handleRestoreInline(item, index)"
-                      />
-
-                      <!-- The user should be able to delete the record if it's not yet saved -->
-                      <b-dropdown-item-button
-                        v-else-if="isInlineDeleteActionVisible(item.r)"
-                        @click.prevent="handleDeleteInline(item, index)"
-                      >
-                        <font-awesome-icon
-                          :icon="['far', 'trash-alt']"
-                          class="text-danger"
-                        />
-                        {{ $t('recordList.record.tooltip.delete') }}
-                      </b-dropdown-item-button>
-                    </template>
-
-                    <template
-                      v-else
+                    <!-- The user should be able to delete the record if it's not yet saved -->
+                    <b-dropdown-item-button
+                      v-else-if="isInlineDeleteActionVisible(item.r)"
+                      @click.prevent="handleDeleteInline(item, index)"
                     >
-                      <b-dropdown-item
-                        v-if="isViewRecordActionVisible(item.r)"
-                        :to="viewRecordRoute(item.r.recordID)"
-                      >
-                        <font-awesome-icon
-                          :icon="['far', 'file-alt']"
-                          class="text-primary"
-                        />
-                        {{ $t('recordList.record.tooltip.view') }}
-                      </b-dropdown-item>
-
-                      <b-dropdown-item
-                        v-if="isEditRecordActionVisible(item.r)"
-                        :to="editRecordRoute(item.r.recordID)"
-                      >
-                        <font-awesome-icon
-                          :icon="['far', 'edit']"
-                          class="text-primary"
-                        />
-                        {{ $t('recordList.record.tooltip.edit') }}
-                      </b-dropdown-item>
-
-                      <b-dropdown-item-button
-                        v-if="isCloneRecordActionVisible"
-                        @click="handleCloneRecordAction(item.r.recordID, item.r.values)"
-                      >
-                        <font-awesome-icon
-                          :icon="['far', 'clone']"
-                          class="text-primary"
-                        />
-                        {{ $t('recordList.record.tooltip.clone') }}
-                      </b-dropdown-item-button>
-
-                      <b-dropdown-item-button
-                        v-if="isReminderActionVisible"
-                        @click="createReminder(item.r)"
-                      >
-                        <font-awesome-icon
-                          :icon="['far', 'bell']"
-                          class="text-primary"
-                        />
-                        {{ $t('recordList.record.tooltip.reminder') }}
-                      </b-dropdown-item-button>
-
-                      <c-permissions-button
-                        v-if="isRecordPermissionButtonVisible(item.r)"
-                        :resource="`corteza::compose:record/${item.r.namespaceID}/${item.r.moduleID}/${item.r.recordID}`"
-                        :target="item.r.recordID"
-                        :title="item.r.recordID"
-                        :button-label="$t('recordList.record.tooltip.permissions')"
-                        class="dropdown-item"
+                      <font-awesome-icon
+                        :icon="['far', 'trash-alt']"
+                        class="text-danger"
                       />
+                      {{ $t('recordList.record.tooltip.delete') }}
+                    </b-dropdown-item-button>
+                  </template>
 
-                      <c-input-confirm
-                        v-if="isDeleteActionVisible(item.r)"
-                        :text="$t('recordList.record.tooltip.delete')"
-                        show-icon
-                        borderless
-                        variant="link"
-                        size="md"
-                        button-class="dropdown-item"
-                        icon-class="text-danger"
-                        class="w-100"
-                        @confirmed="handleDeleteSelectedRecords(item.r.recordID)"
+                  <template
+                    v-else
+                  >
+                    <b-dropdown-item
+                      v-if="isViewRecordActionVisible(item.r)"
+                      :to="viewRecordRoute(item.r.recordID)"
+                    >
+                      <font-awesome-icon
+                        :icon="['far', 'file-alt']"
+                        class="text-primary"
                       />
+                      {{ $t('recordList.record.tooltip.view') }}
+                    </b-dropdown-item>
 
-                      <c-input-confirm
-                        v-else-if="isRestoreActionVisible(item.r)"
-                        :text="$t('recordList.record.tooltip.restore')"
-                        :icon="['fas', 'trash-restore']"
-                        show-icon
-                        borderless
-                        variant="link"
-                        variant-ok="warning"
-                        size="md"
-                        button-class="dropdown-item"
-                        icon-class="text-warning"
-                        class="w-100"
-                        @confirmed="handleRestoreSelectedRecords(item.r.recordID)"
+                    <b-dropdown-item
+                      v-if="isEditRecordActionVisible(item.r)"
+                      :to="editRecordRoute(item.r.recordID)"
+                    >
+                      <font-awesome-icon
+                        :icon="['far', 'edit']"
+                        class="text-primary"
                       />
-                    </template>
-                  </b-dropdown>
-                </div>
+                      {{ $t('recordList.record.tooltip.edit') }}
+                    </b-dropdown-item>
+
+                    <b-dropdown-item-button
+                      v-if="isCloneRecordActionVisible"
+                      @click="handleCloneRecordAction(item.r.recordID, item.r.values)"
+                    >
+                      <font-awesome-icon
+                        :icon="['far', 'clone']"
+                        class="text-primary"
+                      />
+                      {{ $t('recordList.record.tooltip.clone') }}
+                    </b-dropdown-item-button>
+
+                    <b-dropdown-item-button
+                      v-if="isReminderActionVisible"
+                      @click="createReminder(item.r)"
+                    >
+                      <font-awesome-icon
+                        :icon="['far', 'bell']"
+                        class="text-primary"
+                      />
+                      {{ $t('recordList.record.tooltip.reminder') }}
+                    </b-dropdown-item-button>
+
+                    <c-permissions-button
+                      v-if="isRecordPermissionButtonVisible(item.r)"
+                      :resource="`corteza::compose:record/${item.r.namespaceID}/${item.r.moduleID}/${item.r.recordID}`"
+                      :target="item.r.recordID"
+                      :title="item.r.recordID"
+                      :button-label="$t('recordList.record.tooltip.permissions')"
+                      class="dropdown-item"
+                    />
+
+                    <c-input-confirm
+                      v-if="isDeleteActionVisible(item.r)"
+                      :text="$t('recordList.record.tooltip.delete')"
+                      show-icon
+                      borderless
+                      variant="link"
+                      size="md"
+                      button-class="dropdown-item"
+                      icon-class="text-danger"
+                      class="w-100"
+                      @confirmed="handleDeleteSelectedRecords(item.r.recordID)"
+                    />
+
+                    <c-input-confirm
+                      v-else-if="isRestoreActionVisible(item.r)"
+                      :text="$t('recordList.record.tooltip.restore')"
+                      :icon="['fas', 'trash-restore']"
+                      show-icon
+                      borderless
+                      variant="link"
+                      variant-ok="warning"
+                      size="md"
+                      button-class="dropdown-item"
+                      icon-class="text-warning"
+                      class="w-100"
+                      @confirmed="handleRestoreSelectedRecords(item.r.recordID)"
+                    />
+                  </template>
+                </b-dropdown>
               </b-td>
             </b-tr>
           </draggable>
@@ -942,6 +1079,7 @@
             aria-controls="record-list"
             class="m-0 d-print-none"
             pills
+            :disabled="isProcessing"
             :value="getPagination.page"
             :per-page="getPagination.perPage"
             :total-rows="getPagination.count"
@@ -1067,7 +1205,7 @@ import BulkEditModal from 'corteza-webapp-compose/src/components/Public/Record/B
 import ExporterModal from 'corteza-webapp-compose/src/components/Public/Record/Exporter'
 import ImporterModal from 'corteza-webapp-compose/src/components/Public/Record/Importer'
 import { getItem, removeItem, setItem } from 'corteza-webapp-compose/src/lib/local-storage'
-import { evaluatePrefilter, formatActiveFilterOperator, isBetweenOperator, isFieldInFilter, queryToFilter, convertRecordListFilter, getFieldFilter } from 'corteza-webapp-compose/src/lib/record-filter'
+import { evaluatePrefilter, formatActiveFilterOperator, isBetweenOperator, isFieldInFilter, queryToFilter, convertRecordListFilter } from 'corteza-webapp-compose/src/lib/record-filter'
 import records from 'corteza-webapp-compose/src/mixins/records'
 import users from 'corteza-webapp-compose/src/mixins/users'
 import draggable from 'vuedraggable'
@@ -1104,10 +1242,6 @@ export default {
 
   data () {
     return {
-      inlineErrors: new validator.Validated(),
-      dirtyInlineRecords: {},
-      processingDirtyRecords: '',
-      processingInlineRecords: {},
       uniqueID: undefined,
 
       processing: false,
@@ -1142,6 +1276,13 @@ export default {
         initialRecord: {},
       },
 
+      // Track inline field changes per record
+      inlineFieldChanges: {},
+
+      // Track inline search/loading state per field
+      inlineFieldSearch: {},
+      inlineFieldLoading: {},
+
       sortBy: undefined,
       sortDirecton: undefined,
 
@@ -1175,7 +1316,9 @@ export default {
       processingTimeout: undefined,
       cancelled: false,
 
-      stayOnPage: undefined,
+      // NEW: Map of parentRecordID -> Record object
+      // Used to look up parent field values for display
+      resolvedParentRecords: {},
     }
   },
 
@@ -1184,6 +1327,194 @@ export default {
       getModuleByID: 'module/getByID',
       pages: 'page/set',
     }),
+
+    /**
+       * Computes the path for refField when it represents a multi-hop relationship
+       * Returns an array of field objects representing the path from record list module to current record module
+       */
+    refFieldPath () {
+      if (!this.options.refField || !this.recordListModule || !this.record) {
+        return null
+      }
+
+      const targetModuleID = this.record.moduleID
+      const startModuleID = this.recordListModule.moduleID
+
+      // If refField points directly to target, return just that field
+      const directField = this.recordListModule.fields.find(
+        f => f.kind === 'Record' && !f.isMulti && f.options && f.options.moduleID === targetModuleID && f.name === this.options.refField,
+      )
+      if (directField) {
+        return [directField]
+      }
+
+      // Otherwise, find the path using BFS
+      const visited = new Set()
+      const queue = [[startModuleID, []]] // [moduleID, pathSoFar]
+
+      while (queue.length > 0) {
+        const [currentModuleID, pathSoFar] = queue.shift()
+
+        if (visited.has(currentModuleID)) {
+          continue
+        }
+        visited.add(currentModuleID)
+
+        const module = this.getModuleByID(currentModuleID)
+        if (!module) {
+          continue
+        }
+
+        for (const field of module.fields) {
+          if (field.kind === 'Record' && !field.isMulti && field.options && field.options.moduleID) {
+            const nextModuleID = field.options.moduleID
+            const newPath = [...pathSoFar, field]
+
+            // If this field points to our target and matches our refField, we found the path
+            if (nextModuleID === targetModuleID && field.name === this.options.refField) {
+              return newPath
+            }
+
+            // Otherwise, continue searching
+            queue.push([nextModuleID, newPath])
+          }
+        }
+      }
+
+      // If we get here, no path was found
+      return null
+    },
+
+    /**
+     * Computes the grandparent/common field metadata dynamically
+     * This avoids relying on persisted options which may not be saved properly
+     *
+     * Returns an object with:
+     * - isGrandparent: true if this is a grandparent relationship (multi-hop via intermediate module)
+     * - isCommonField: true if this is a common/sibling field relationship
+     * - multiHopPath: array of field names for multi-hop traversal (for grandparent)
+     */
+    refFieldMeta () {
+      // If no refField or no record context, not applicable
+      if (!this.options.refField || !this.recordListModule || !this.record) {
+        return {
+          isGrandparent: false,
+          isCommonField: false,
+          multiHopPath: null,
+        }
+      }
+
+      const targetModuleID = this.record.moduleID
+      const refField = this.options.refField
+
+      // Find the refField in the record list module
+      const refFieldDef = this.recordListModule.fields.find(
+        f => f.kind === 'Record' && f.name === refField,
+      )
+
+      if (!refFieldDef || !refFieldDef.options || !refFieldDef.options.moduleID) {
+        return {
+          isGrandparent: false,
+          isCommonField: false,
+          multiHopPath: null,
+        }
+      }
+
+      const refModuleID = refFieldDef.options.moduleID
+
+      // ================================================
+      // 1. Check for DIRECT relationship first
+      // ================================================
+      // If the refField points directly to the page module (targetModuleID),
+      // this is a standard parent→child relationship. No multi-hop or common
+      // field logic needed — just filter by refField = currentRecord.recordID.
+      if (refModuleID === targetModuleID) {
+        return {
+          isGrandparent: false,
+          isCommonField: false,
+          multiHopPath: null,
+        }
+      }
+
+      // ================================================
+      // 2. Check for grandparent relationship (multi-hop)
+      // ================================================
+      // Strategy: traverse from the referenced module outward to see if we
+      // can reach the target module. If the path length > 1, it's a
+      // grandparent relationship.
+
+      const visited = new Set()
+      const queue = [[refModuleID, [refField]]] // [moduleID, pathSoFar]
+
+      while (queue.length > 0) {
+        const [currentModuleID, pathSoFar] = queue.shift()
+
+        if (visited.has(currentModuleID)) {
+          continue
+        }
+        visited.add(currentModuleID)
+
+        const module = this.getModuleByID(currentModuleID)
+        if (!module) {
+          continue
+        }
+
+        for (const field of module.fields) {
+          if (field.kind === 'Record' && !field.isMulti && field.options && field.options.moduleID) {
+            const nextModuleID = field.options.moduleID
+            const newPath = [...pathSoFar, field.name]
+
+            // If we reached the target module
+            if (nextModuleID === targetModuleID) {
+              // Path always has length >= 2 here (refField + at least one hop)
+              return {
+                isGrandparent: true,
+                isCommonField: false,
+                multiHopPath: newPath,
+              }
+            }
+
+            // Continue traversing
+            queue.push([nextModuleID, newPath])
+          }
+        }
+      }
+
+      // ================================================
+      // 3. Check for common/sibling field relationship
+      // ================================================
+      // The refField points to a module that is NOT the page module and
+      // NOT reachable via a grandparent chain.  Check whether the page
+      // module also links to the same module (sibling relationship).
+      const targetModule = this.getModuleByID(targetModuleID)
+      if (targetModule) {
+        // Collect modules the page module (target) links to — but NOT itself
+        const parentLinkedModuleIDs = new Set()
+
+        targetModule.fields.forEach(field => {
+          if (field.kind === 'Record' && field.options && field.options.moduleID) {
+            parentLinkedModuleIDs.add(field.options.moduleID)
+          }
+        })
+
+        // If the refField points to a module that the page module also links to,
+        // this is a common/sibling relationship
+        if (parentLinkedModuleIDs.has(refModuleID)) {
+          return {
+            isGrandparent: false,
+            isCommonField: true,
+            multiHopPath: null,
+          }
+        }
+      }
+
+      // Not a grandparent or common field relationship — treat as direct
+      return {
+        isGrandparent: false,
+        isCommonField: false,
+        multiHopPath: null,
+      }
+    },
 
     isFederated () {
       return Object.keys(this.recordListModule.labels || {}).includes('federation')
@@ -1240,10 +1571,6 @@ export default {
       return !this.options.hidePaging
     },
 
-    isRowClickable () {
-      return !this.inlineEditing && this.options.recordDisplayOption !== 'doNothing'
-    },
-
     showPerPageSelector () {
       return this.options.showRecordPerPageOption
     },
@@ -1256,7 +1583,7 @@ export default {
     },
 
     inlineEditing () {
-      return !!this.options.editable
+      return !!this.options.editable && !!this.editing
     },
 
     /**
@@ -1306,20 +1633,32 @@ export default {
     fields () {
       let fields = []
 
-      const editable = !this.inlineEditing
+      const editable = (!this.options.editable || !this.editing)
         ? []
         : this.options.editFields.map(({ name }) => name)
 
+      // Separate parent fields from child fields before filtering
+      const childFieldConfigs = (this.options.fields || []).filter(f => !f.isParentField)
+      const parentFieldConfigs = (this.options.fields || []).filter(f => f.isParentField)
+
       if (!this.options.hideConfigureFieldsButton && this.customConfiguredFields.length > 0) {
         fields = this.recordListModule.filterFields(this.customConfiguredFields)
-      } else if (this.options.fields.length > 0) {
-        fields = this.recordListModule.filterFields(this.options.fields)
-      } else {
-        // Record list block does not have any configured fields
-        // Use first five fields from the module.
+      } else if (childFieldConfigs.length > 0) {
+        fields = this.recordListModule.filterFields(childFieldConfigs)
+      } else if (this.options.fields.length > 0 && parentFieldConfigs.length === this.options.fields.length) {
+        // All fields are parent fields — no child fields configured, use first 5 as fallback
+        fields = [...this.recordListModule.fields.slice(0, 5), ...this.recordListModule.systemFields()]
+      } else if (!this.options.fields || this.options.fields.length === 0) {
         fields = [...this.recordListModule.fields.slice(0, 5), ...this.recordListModule.systemFields()]
       }
 
+      // If fields is still empty after the above conditions (e.g., customConfiguredFields had invalid IDs),
+      // fall back to first 5 fields and system fields to ensure the table has columns
+      if (fields.length === 0) {
+        fields = [...this.recordListModule.fields.slice(0, 5), ...this.recordListModule.systemFields()]
+      }
+
+      // Build configured child field column definitions (existing logic)
       const configured = fields.map(mf => ({
         key: mf.name,
         label: mf.isSystem ? this.$t(`field:system.${mf.name}`) : mf.label || mf.name,
@@ -1330,16 +1669,62 @@ export default {
         editable: !!editable.find(f => mf.name === f),
         canEdit: this.isFieldEditable(mf),
         required: this.inlineEditing && mf.isRequired,
+        isParentField: false,
       }))
 
-      const pre = []
-      const post = []
+      // Build parent field column definitions
+      // These don't exist in the child module so we construct them manually
+      const linkFieldDef = this.recordListModule.fields.find(f => f.name === this.options.refField)
+      const parentModule = (linkFieldDef && linkFieldDef.options && linkFieldDef.options.moduleID)
+        ? this.getModuleByID(linkFieldDef.options.moduleID)
+        : null
 
-      return [
-        ...pre,
-        ...configured,
-        ...post,
-      ]
+      const parentConfigured = parentFieldConfigs
+        .map(pf => {
+          const actualField = parentModule ? parentModule.fields.find(f => f.name === pf.originalName) : null
+          if (!actualField) {
+            return null
+          }
+          return {
+            ...pf,
+            key: pf.name,
+            moduleField: actualField,
+            sortable: false,
+            filterable: false,
+            tdClass: 'record-value',
+            editable: false,
+            canEdit: false,
+            required: false,
+            isParentField: true,
+            parentModuleID: pf.parentModuleID,
+            originalName: pf.originalName,
+          }
+        })
+        .filter(Boolean)
+
+      // Merge in the correct order based on options.fields order
+      // so the user's configured column order is respected
+      if (parentFieldConfigs.length > 0 && this.options.fields.length > 0) {
+        // Rebuild in the order the user configured
+        const allConfigured = [...configured, ...parentConfigured]
+        const orderedFields = []
+
+        this.options.fields.forEach(configField => {
+          const match = allConfigured.find(c => c.key === configField.name)
+          if (match) orderedFields.push(match)
+        })
+
+        // Add any that weren't in options.fields (shouldn't happen but safety net)
+        allConfigured.forEach(c => {
+          if (!orderedFields.find(o => o.key === c.key)) {
+            orderedFields.push(c)
+          }
+        })
+
+        return orderedFields
+      }
+
+      return [...configured, ...parentConfigured]
     },
 
     canDeleteSelectedRecords () {
@@ -1406,32 +1791,6 @@ export default {
       }).filter(({ filter }) => filter.length)
     },
 
-    // Groups consecutive AND-connected filter groups together for visual display
-    // Result: [ { groups: [G1, G2], connector: 'OR' }, { groups: [G3], connector: null } ]
-    groupedByConnector () {
-      const result = []
-      let currentAndGroup = []
-
-      this.groupRecordListFilter.forEach((group, idx) => {
-        const condition = group.groupCondition || 'OR'
-
-        if (idx === 0 || condition === 'AND') {
-          currentAndGroup.push({ ...group, originalIndex: idx })
-        } else {
-          if (currentAndGroup.length) {
-            result.push({ groups: currentAndGroup, connector: 'OR' })
-          }
-          currentAndGroup = [{ ...group, originalIndex: idx }]
-        }
-      })
-
-      if (currentAndGroup.length) {
-        result.push({ groups: currentAndGroup, connector: null })
-      }
-
-      return result
-    },
-
     listSummaries () {
       return [
         ...this.options.summaries.filter(s => s.metric && s.field && this.isUserRoleMember(s.roles)),
@@ -1456,8 +1815,23 @@ export default {
       })
     },
 
-    dirtyRecordsCount () {
-      return this.items.filter(item => this.showSaveAction(item)).length
+    /**
+     * Returns only the fields marked as parent fields from the configured field list.
+     * These have isParentField: true and a parentModuleID set.
+     */
+    parentFieldConfigs () {
+      if (!this.options.fields || !this.options.fields.length) {
+        return []
+      }
+      return this.options.fields.filter(f => f.isParentField && f.parentModuleID)
+    },
+
+    /**
+     * Returns the field name in the CHILD module that links to the parent module.
+     * This is options.refField — the reference field the user selected in the configurator.
+     */
+    parentLinkFieldName () {
+      return this.options.refField || null
     },
   },
 
@@ -1498,6 +1872,179 @@ export default {
     }
   },
 
+  // Helper methods for inline field editing
+  isInlineEditableFieldType (field) {
+    const kind = field.kind
+    // Support: Select (dropdown), Checkbox, Record, User
+    return ['Select', 'Checkbox', 'Record', 'User'].includes(kind)
+  },
+
+  // Check if field supports multi-select
+  isMultiSelect (field) {
+    return field.isMulti === true
+  },
+
+  // Get option key for select fields
+  getOptionKey (option, field) {
+    if (!option) return undefined
+
+    switch (field.kind) {
+      case 'Select':
+        return option.value
+      case 'Record':
+        return option.recordID
+      case 'User':
+        return option.userID
+      default:
+        return option.value || option
+    }
+  },
+
+  // Get option label for select fields
+  getOptionLabel (option, field) {
+    if (!option) return ''
+
+    switch (field.kind) {
+      case 'Select':
+        return option.text || option.label || option.value
+      case 'Record':
+        if (option.values && field.options && field.options.labelField) {
+          return option.values[field.options.labelField] || option.recordID
+        }
+        return option.recordID || option.label || option
+      case 'User':
+        return option.name || option.username || option.email || `<@${option.userID}>`
+      default:
+        return option.text || option.label || option.value || option
+    }
+  },
+
+  // Get checkbox labels
+  checkboxLabel (field) {
+    return {
+      on: field.options.trueLabel || this.$t('general:label.yes'),
+      off: field.options.falseLabel || this.$t('general:label.no'),
+    }
+  },
+
+  // Check if option is selectable
+  isSelectable (option, field) {
+    if (!option) return false
+
+    const currentValue = this.getFieldValueForSelect(field)
+
+    if (field.isMulti) {
+      return !field.options.isUniqueMultiValue || !currentValue.includes(this.getOptionKey(option, field))
+    } else {
+      return currentValue !== this.getOptionKey(option, field)
+    }
+  },
+
+  // Get current field value for select (returns value, not option object)
+  getFieldValueForSelect (field) {
+    // This method is used to get the current value for v-model binding
+    // Returns the raw value (ID or array of IDs)
+    return null // Placeholder - actual value is set in onInlineFieldInput
+  },
+
+  // Get raw field value from record
+  getFieldValue (record, field) {
+    if (!record || !field) return null
+
+    // Handle different field types
+    switch (field.kind) {
+      case 'Select':
+        return record.values[field.name] || null
+      case 'Checkbox':
+        return !!record.values[field.name]
+      case 'Record':
+      case 'User':
+        const val = record.values[field.name]
+        return val && val.value ? val.value : null
+      default:
+        return record.values[field.name] || null
+    }
+  },
+
+  // Check if field has pending changes
+  isFieldChanged (recordId, fieldKey) {
+    return this.inlineFieldChanges[recordId] &&
+          this.inlineFieldChanges[recordId][fieldKey] !== undefined
+  },
+
+  // Handle field input changes
+  onInlineFieldInput (record, field, event) {
+    const value = event.target.value || event.target.checked
+
+    // Initialize record changes if not exists
+    if (!this.inlineFieldChanges[record.id]) {
+      this.inlineFieldChanges[record.id] = {}
+    }
+
+    // Store the change
+    this.inlineFieldChanges[record.id][field.key] = value
+
+    // Emit change event if needed
+    this.$emit('field-change', { record, field, value })
+  },
+
+  // Get inline field value (with optional change tracking)
+  getInlineFieldValue (item, field, withChanges = false) {
+    if (withChanges && this.isFieldChanged(item.id, field.key)) {
+      return this.inlineFieldChanges[item.id][field.key]
+    }
+    return this.getFieldValue(item.r, field.moduleField)
+  },
+
+  // Handle field search for inline editing
+  async onInlineFieldSearch (record, field, event) {
+    const query = event.target.value || ''
+
+    // For User fields, trigger user search
+    if (field.moduleField && field.moduleField.kind === 'User') {
+      // This would typically trigger a search in the user store
+      // For now, we'll just emit an event - the actual implementation
+      // would depend on how user search is handled in the modal
+      this.$emit('user-search', { record, field, query })
+    }
+
+    // For Record fields, trigger record search
+    if (field.moduleField && field.moduleField.kind === 'Record') {
+      // This would typically trigger a search in the record store
+      this.$emit('record-search', { record, field, query })
+    }
+  },
+
+  // Save inline field changes
+  async saveInlineField (record, field) {
+    if (!this.isFieldChanged(record.id, field.key)) return
+
+    const newValue = this.inlineFieldChanges[record.id][field.key]
+
+    try {
+      // Update the record value
+      record.values[field.name] = newValue
+
+      // Persist to backend
+      await this.updateRecordSet([record])
+
+      // Clear changes for this field
+      delete this.inlineFieldChanges[record.id][field.key]
+
+      // Clean up empty record entries
+      if (Object.keys(this.inlineFieldChanges[record.id] || {}).length === 0) {
+        delete this.inlineFieldChanges[record.id]
+      }
+
+      // Emit success event
+      this.$emit('inline-field-saved', { record, field })
+    } catch (error) {
+      // Revert change on error
+      delete this.inlineFieldChanges[record.id][field.key]
+      throw error
+    }
+  },
+
   methods: {
     ...mapActions({
       loadPaginationRecords: 'ui/loadPaginationRecords',
@@ -1534,9 +2081,7 @@ export default {
       }
     },
 
-    refreshOnRelatedRecordsUpdate ({ moduleID, excludeUniqueID } = {}) {
-      if (excludeUniqueID === this.uniqueID) return
-
+    refreshOnRelatedRecordsUpdate ({ moduleID } = {}) {
       if (this.recordListModule.moduleID === moduleID) {
         this.refresh(true)
       } else {
@@ -1653,17 +2198,16 @@ export default {
       this.refresh(true)
     },
 
+    // Grabs errors specific to this record item
     recordErrors (item, field) {
       const id = `${item.id}:${field.key}`
-      const errors = new validator.Validated()
 
-      if (this.errors) {
-        errors.push(...this.errors.filterByMeta('id', item.id).filterByMeta('field', field.key).get())
+      if (!this.errors) {
+        this.$emit('errors', { errors: undefined, id })
+        return new validator.Validated()
       }
 
-      if (this.inlineErrors) {
-        errors.push(...this.inlineErrors.filterByMeta('id', item.id).filterByMeta('field', field.key).get())
-      }
+      const errors = this.errors.filterByMeta('id', item.id).filterByMeta('field', field.key)
 
       if (errors.set.length > 0) {
         this.$emit('errors', { errors, id })
@@ -1691,11 +2235,37 @@ export default {
 
       // Set record values that should be prefilled
       if (this.options.refField) {
-        const refField = this.recordListModule.fields.find(f => f.name === this.options.refField)
-        if (refField && refField.isMulti) {
-          r.values[this.options.refField] = [(this.record || {}).recordID]
+        // If there's no current record, we can't pre-fill refField values
+        if (!this.record) {
+          // Skip pre-filling when there's no record (e.g., creating new records without context)
+          // Don't throw error here as this is expected in some contexts
         } else {
-          r.values[this.options.refField] = (this.record || {}).recordID
+          // Use field value from current record for pre-filling
+          const refFieldName = this.options.refField
+          // Only pre-fill if the field has a value (not undefined/null)
+          if (this.record.values && this.record.values[refFieldName] !== undefined && this.record.values[refFieldName] !== null) {
+            const prefilledValue = this.record.values[refFieldName]
+
+            // Handle both direct refField and refFieldPath (for multi-hop relationships)
+            if (this.refFieldPath && this.refFieldPath.length > 0) {
+              // For multi-hop paths, we set the first field in the path
+              const firstField = this.refFieldPath[0]
+              if (firstField && firstField.isMulti) {
+                r.values[firstField.name] = [prefilledValue]
+              } else {
+                r.values[firstField.name] = prefilledValue
+              }
+            } else {
+              // Direct relationship or common field
+              const refField = this.recordListModule.fields.find(f => f.name === this.options.refField)
+              if (refField && refField.isMulti) {
+                r.values[this.options.refField] = [prefilledValue]
+              } else {
+                r.values[this.options.refField] = prefilledValue
+              }
+            }
+          }
+          // If field value is undefined/null, we don't pre-fill anything (leave as default)
         }
       }
 
@@ -1715,10 +2285,16 @@ export default {
       this.ctr = 0
       this.items = this.items.map(this.wrapRecord)
 
+      // For multi-hop refField paths, we need to pass the path information
+      // so the frontend can properly resolve the chained relationships
+      const refFieldData = this.refFieldPath
+        ? { path: this.refFieldPath.map(f => f.name) }
+        : this.options.refField
+
       resolve({
         items: this.items,
         module: this.recordListModule,
-        refField: this.options.refField,
+        refField: refFieldData,
         positionField: this.options.positionField,
         idPrefix: this.uniqueID,
       })
@@ -1732,6 +2308,11 @@ export default {
 
       // Find all required fields
       const req = new Set(this.recordListModule.fields.filter(({ isRequired = false }) => isRequired).map(({ name }) => name))
+
+      // If refField is configured, exclude it from required fields check
+      if (this.options.refField) {
+        req.delete(this.options.refField)
+      }
 
       // Check if all required fields are there
       for (const f of this.options.editFields) {
@@ -1762,290 +2343,10 @@ export default {
       this.items.splice(0, 0, this.wrapRecord(r))
     },
 
-    onInlineFieldChange (item) {
-      if (!this.dirtyInlineRecords[item.id]) {
-        this.$set(this.dirtyInlineRecords, item.id, true)
-      }
-    },
-
-    showSaveAction (item) {
-      if (!this.recordListModule) return false
-      const r = item.r
-      // If deleted, we can "save" to actually delete it, or if it has NoID we can just remove it
-      if (r.deletedAt) return true
-
-      const { canCreateRecord } = this.recordListModule
-      const { canUpdateRecord } = r
-
-      if (r.recordID === NoID) {
-        return canCreateRecord
-      }
-
-      // Check if dirty
-      if (!this.dirtyInlineRecords[item.id]) {
-        return false
-      }
-
-      return canUpdateRecord
-    },
-
-    async handleSaveInline (item, index) {
-      if (!this.recordListModule) return
-      this.$set(this.processingInlineRecords, item.id, 'save')
-
-      const isNew = item.r.recordID === NoID
-      let action = 'update'
-      if (item.r.deletedAt) {
-        action = 'delete'
-      } else if (isNew) {
-        action = 'create'
-      }
-
-      this.inlineErrors = this.inlineErrors.filter(e => e.meta.id !== item.id)
-
-      try {
-        // Handle deletion
-        if (item.r.deletedAt) {
-          if (isNew) {
-            this.items.splice(index, 1)
-            return
-          }
-          await this.$ComposeAPI.recordDelete(item.r)
-          this.items.splice(index, 1)
-          this.toastSuccess(this.$t('notification:record.deleteSuccess'))
-          const excludeUniqueID = Object.keys(this.dirtyInlineRecords).length > 0 ? this.uniqueID : undefined
-          this.$root.$emit('module-records-updated', { moduleID: this.recordListModule.moduleID, excludeUniqueID })
-          return
-        }
-
-        // Validate
-        const v = new compose.RecordValidator(this.recordListModule)
-
-        // We only want to validate updatable fields just like in mixins/records.js
-        const fields = this.recordListModule.fields
-          .filter(({ canReadRecordValue, canUpdateRecordValue }) => canReadRecordValue && canUpdateRecordValue)
-          .map(({ name }) => name)
-
-        const err = v.run(item.r, ...fields)
-
-        if (!err.valid()) {
-          const fieldNames = new Set(err.set.map(e => {
-            const f = this.recordListModule.fields.find(f => f.name === e.meta.field)
-            return f?.label || e.meta.field
-          }))
-
-          err.get().forEach(e => {
-            e.meta.id = item.id
-          })
-          this.inlineErrors.push(...err.get())
-
-          this.toastWarning(this.$t('notification:record.validationErrors', { fields: Array.from(fieldNames).join(', ') }))
-          return
-        }
-
-        let saved
-        if (isNew) {
-          saved = await this.$ComposeAPI.recordCreate(item.r)
-        } else {
-          saved = await this.$ComposeAPI.recordUpdate(item.r)
-        }
-
-        this.$delete(this.dirtyInlineRecords, item.id)
-
-        const newRecord = new compose.Record(this.recordListModule, saved)
-        this.items.splice(index, 1, this.wrapRecord(newRecord))
-
-        this.toastSuccess(this.$t(`notification:record.${isNew ? 'create' : 'update'}Success`))
-        const excludeUniqueID = Object.keys(this.dirtyInlineRecords).length > 0 ? this.uniqueID : undefined
-        this.$root.$emit('module-records-updated', { moduleID: this.recordListModule.moduleID, excludeUniqueID })
-      } catch (e) {
-        const { details = undefined } = e
-
-        if (details && Array.isArray(details) && details.length > 0) {
-          const errs = details.filter(d => !d.kind.includes('warning')).map(d => {
-            return { ...d, meta: { ...d.meta, id: item.id } }
-          })
-          this.inlineErrors.push(...errs)
-        }
-
-        this.toastErrorHandler(this.$t(`notification:record.${action}Failed`))(e)
-      } finally {
-        this.$delete(this.processingInlineRecords, item.id)
-      }
-    },
-
-    async handleDenyInline (item, index) {
-      if (!this.recordListModule) return
-
-      this.$set(this.processingInlineRecords, item.id, 'deny')
-      this.$delete(this.dirtyInlineRecords, item.id)
-      this.inlineErrors = this.inlineErrors.filter(e => e.meta.id !== item.id)
-
-      const isNew = item.r.recordID === NoID
-
-      if (isNew) {
-        this.items.splice(index, 1)
-        this.$delete(this.processingInlineRecords, item.id)
-      } else {
-        try {
-          const freshRecord = await this.$ComposeAPI.recordRead(item.r)
-          const clean = new compose.Record(this.recordListModule, freshRecord)
-          this.items.splice(index, 1, this.wrapRecord(clean))
-        } catch (e) {
-          this.toastErrorHandler(this.$t('notification:record.loadFailed'))(e)
-        } finally {
-          this.$delete(this.processingInlineRecords, item.id)
-        }
-      }
-    },
-
-    async handleSaveDirtyRecords () {
-      if (!this.recordListModule) return
-
-      const itemsToSave = this.items.filter(item => {
-        if (!this.showSaveAction(item)) return false
-        if (this.selected.length > 0) return this.selected.includes(item.id)
-        return true
-      })
-
-      if (!itemsToSave.length) return
-
-      this.processingDirtyRecords = 'save'
-      let hasError = false
-
-      // We only want to validate updatable fields just like in mixins/records.js
-      const fields = this.recordListModule.fields
-        .filter(({ canReadRecordValue, canUpdateRecordValue }) => canReadRecordValue && canUpdateRecordValue)
-        .map(({ name }) => name)
-
-      for (const item of itemsToSave) {
-        const isNew = item.r.recordID === NoID
-        let action = 'update'
-        if (item.r.deletedAt) {
-          action = 'delete'
-        } else if (isNew) {
-          action = 'create'
-        }
-
-        try {
-          const index = this.items.findIndex(i => i.id === item.id)
-          if (index === -1) continue
-
-          this.inlineErrors = this.inlineErrors.filter(e => e.meta.id !== item.id)
-
-          // Handle deletion
-          if (item.r.deletedAt) {
-            if (isNew) {
-              this.items.splice(index, 1)
-            } else {
-              await this.$ComposeAPI.recordDelete(item.r)
-              this.items.splice(index, 1)
-            }
-            this.$delete(this.dirtyInlineRecords, item.id)
-            continue
-          }
-
-          // Validate
-          const v = new compose.RecordValidator(this.recordListModule)
-          const err = v.run(item.r, ...fields)
-
-          if (!err.valid()) {
-            const fieldNames = new Set(err.set.map(e => {
-              const f = this.recordListModule.fields.find(f => f.name === e.meta.field)
-              return f?.label || e.meta.field
-            }))
-
-            err.get().forEach(e => {
-              e.meta.id = item.id
-            })
-            this.inlineErrors.push(...err.get())
-
-            throw new Error(this.$t('notification:record.validationErrors', { fields: Array.from(fieldNames).join(', ') }))
-          }
-
-          let saved
-          if (isNew) {
-            saved = await this.$ComposeAPI.recordCreate(item.r)
-          } else {
-            saved = await this.$ComposeAPI.recordUpdate(item.r)
-          }
-
-          this.$delete(this.dirtyInlineRecords, item.id)
-
-          const newRecord = new compose.Record(this.recordListModule, saved)
-          this.items.splice(index, 1, this.wrapRecord(newRecord))
-        } catch (e) {
-          hasError = true
-
-          const { details = undefined } = e
-          if (details && Array.isArray(details) && details.length > 0) {
-            const errs = details.filter(d => !d.kind.includes('warning')).map(d => {
-              return { ...d, meta: { ...d.meta, id: item.id } }
-            })
-            this.inlineErrors.push(...errs)
-          }
-
-          this.toastErrorHandler(this.$t(`notification:record.${action}Failed`))(e)
-        }
-      }
-
-      this.processingDirtyRecords = ''
-
-      if (!hasError) {
-        this.selected = []
-        this.toastSuccess(this.$t('notification:record.saveSuccess'))
-        const excludeUniqueID = Object.keys(this.dirtyInlineRecords).length > 0 ? this.uniqueID : undefined
-        this.$root.$emit('module-records-updated', { moduleID: this.recordListModule.moduleID, excludeUniqueID })
-      }
-    },
-
-    async handleDenyDirtyRecords () {
-      if (!this.recordListModule) return
-
-      const itemsToDeny = this.items.filter(item => {
-        if (!this.showSaveAction(item)) return false
-        if (this.selected.length > 0) return this.selected.includes(item.id)
-        return true
-      })
-
-      if (!itemsToDeny.length) return
-
-      this.processingDirtyRecords = 'deny'
-      let hasError = false
-
-      for (const item of itemsToDeny) {
-        try {
-          const index = this.items.findIndex(i => i.id === item.id)
-          if (index === -1) continue
-
-          const isNew = item.r.recordID === NoID
-          this.$delete(this.dirtyInlineRecords, item.id)
-          this.inlineErrors = this.inlineErrors.filter(e => e.meta.id !== item.id)
-
-          if (isNew) {
-            this.items.splice(index, 1)
-          } else {
-            const freshRecord = await this.$ComposeAPI.recordRead(item.r)
-            const clean = new compose.Record(this.recordListModule, freshRecord)
-            this.items.splice(index, 1, this.wrapRecord(clean))
-          }
-        } catch (e) {
-          hasError = true
-          this.toastErrorHandler(this.$t('notification:record.loadFailed'))(e)
-        }
-      }
-
-      this.processingDirtyRecords = ''
-
-      if (!hasError) {
-        this.selected = []
-      }
-    },
-
     // Sanitizes record list config and
     // prepares prefilter
     prepRecordList () {
-      const { moduleID, presort, prefilter, editable, refField, positionField, perPage } = this.options
+      const { moduleID, presort, prefilter, perPage } = this.options
 
       // Validate props
       if (!moduleID || !this.recordListModule) {
@@ -2068,45 +2369,67 @@ export default {
       /* eslint-disable no-template-curly-in-string */
       if (!this.record) {
         if ((prefilter || '').includes('${record')) {
-          throw Error(this.$t('record.invalidRecordVar'))
-        }
-
-        if ((prefilter || '').includes('${ownerID}')) {
-          throw Error(this.$t('record.invalidOwnerVar'))
+          this.disableBlock = true
+          return
         }
       }
 
-      // Sorting
-      let sort = presort || 'createdAt DESC'
-
-      if (editable && positionField) {
-        sort = `${positionField}`
-      }
-
+      // Build filter
       const filter = []
 
-      // Initial filter
+      // Process prefilter
       if (prefilter) {
-        const pf = evaluatePrefilter(prefilter, {
-          record: this.record,
-          user: this.$auth.user || {},
-          recordID: (this.record || {}).recordID || NoID,
-          ownerID: (this.record || {}).ownedBy || NoID,
-          userID: (this.$auth.user || {}).userID || NoID,
-        })
-        filter.push(`(${pf})`)
+      // Replace variables
+        const pf = prefilter
+          .replace(/\${recordID}/g, this.record ? this.record.recordID : 'null')
+          .replace(/\${ownerID}/g, this.record ? this.record.ownedBy || this.$auth.user.ownedBy || '' : 'null')
+          .replace(/\${userID}/g, this.$auth.user ? this.$auth.user.userID : 'null')
+
+        // Evaluate filter
+        try {
+          evaluatePrefilter(this.recordListModule, this.record, pf).forEach(f => {
+            filter.push(`(${f})`)
+          })
+        } catch (e) {
+        // If there's an error evaluating the prefilter, we should log it but not break the whole thing
+          console.warn('Error evaluating prefilter:', e)
+        }
       }
 
-      if (refField) {
+      // Handle refField - support direct, multi-hop, grandparent, and common field relationships
+      if (this.options.refField) {
         if (!this.record) {
-          throw Error(this.$t('record.invalidRecordVar'))
-        }
-
-        const refFieldObj = this.recordListModule.fields.find(f => f.name === refField)
-        if (refFieldObj && refFieldObj.isMulti) {
-          filter.push(getFieldFilter(refField, 'Record', this.record.recordID, 'IN'))
+          // no-op: skip when no record context
         } else {
-          filter.push(getFieldFilter(refField, 'Record', this.record.recordID, '='))
+          const meta = this.refFieldMeta || {}
+
+          if (meta.isGrandparent && meta.multiHopPath && meta.multiHopPath.length >= 2) {
+            // Grandparent: traverse the hop chain using current record's ID
+            const fieldNames = meta.multiHopPath.join(', ')
+            const gpFilter = `@multi-hop(${fieldNames}, ${this.record.recordID})`
+            filter.push(gpFilter)
+          } else if (meta.isCommonField) {
+            // Sibling/common field: both the child module and the page module
+            // share a link to the same third module. Use the value from the
+            // current record's field to filter.
+            const refFieldName = this.options.refField
+            const fieldValue = this.record.values
+              ? this.record.values[refFieldName]
+              : undefined
+
+            if (fieldValue !== undefined && fieldValue !== null) {
+              const quoted = typeof fieldValue === 'string' ? `'${fieldValue}'` : fieldValue
+              const cfFilter = `(${refFieldName} = ${quoted})`
+              filter.push(cfFilter)
+            }
+          } else {
+            // Standard direct relationship: the refField is a Record field in the
+            // child module that points to the page module (or an intermediate module).
+            // The child records store the parent's recordID in this field, so we
+            // filter by: refField = currentRecord.recordID
+            const directFilter = `(${this.options.refField} = ${this.record.recordID})`
+            filter.push(directFilter)
+          }
         }
       }
 
@@ -2114,7 +2437,7 @@ export default {
 
       this.filter = {
         limit: this.recordsPerPage,
-        sort,
+        sort: presort || 'createdAt DESC',
       }
     },
 
@@ -2146,7 +2469,7 @@ export default {
       this.processing = true
 
       const { namespaceID, moduleID } = this.filter || {}
-      const { filter, filterRaw, timezone, resolveRefs } = e
+      const { filter, filterRaw, timezone } = e
       e = {
         ...e,
         namespaceID,
@@ -2176,7 +2499,6 @@ export default {
           filter: this.selectedAllRecords ? this.bulkQuery : filter,
           jwt: this.$auth.accessToken,
           timezone: timezone ? timezone.tzCode : undefined,
-          resolveRefs,
         },
       })
 
@@ -2185,11 +2507,7 @@ export default {
     },
 
     handleRowClick ({ r: { recordID } }) {
-      if (this.options.recordDisplayOption === 'doNothing') {
-        return
-      }
-
-      if (this.inlineEditing || (!this.recordPageID && !this.options.rowViewUrl)) {
+      if ((this.options.editable && this.editing) || (!this.recordPageID && !this.options.rowViewUrl)) {
         return
       }
 
@@ -2250,7 +2568,7 @@ export default {
       this.refresh(true)
     },
 
-    async goToPage (page) {
+    goToPage (page) {
       if (page >= 1) {
         this.filter.pageCursor = (this.pagination.pages[page - 1] || {}).cursor
         this.pagination.page = page
@@ -2262,8 +2580,7 @@ export default {
           this.pagination.page = 1
         }
       }
-
-      return this.refresh()
+      this.refresh()
     },
 
     handleSelectAllOnPage ({ isChecked }) {
@@ -2281,7 +2598,7 @@ export default {
     },
 
     handleRestoreSelectedRecords (recordID) {
-      if (this.inlineEditing && this.editing) {
+      if (this.inlineEditing) {
         const sel = new Set(this.selected)
         this.items.forEach((item, index) => {
           if (sel.has(item.id)) {
@@ -2311,7 +2628,7 @@ export default {
     },
 
     handleDeleteSelectedRecords (recordID) {
-      if (this.inlineEditing && this.editing) {
+      if (this.inlineEditing) {
         const sel = new Set(this.selected)
         for (let i = 0; i < this.items.length; i++) {
           if (sel.has(this.items[i].id)) {
@@ -2370,15 +2687,9 @@ export default {
       this.selected = []
 
       // Compute query based on query, prefilter and recordListFilter
-      let searchFields = []
-      if (this.options.searchableFields.length > 0) {
-        searchFields = this.recordListModule.filterFields(this.options.searchableFields)
-      } else {
-        // Default to visible fields if no searchable fields are configured
-        searchFields = this.fields.map(({ moduleField }) => moduleField)
-      }
-
-      const query = queryToFilter(this.query, this.prefilter, searchFields, this.groupRecordListFilter)
+      // Filter out parent fields as they don't exist in the child module
+      const childFields = this.fields.filter(f => !f.isParentField)
+      const query = queryToFilter(this.query, this.prefilter, childFields.map(({ moduleField }) => moduleField), this.groupRecordListFilter)
 
       const { moduleID, namespaceID } = this.recordListModule
 
@@ -2407,75 +2718,71 @@ export default {
       const { response, cancel } = this.$ComposeAPI.recordListCancellable({ ...this.filter, moduleID, namespaceID, query, ...paginationOptions, summaries })
       this.abortableRequests.push(cancel)
 
-      return Promise.all([response(), new Promise(resolve => setTimeout(resolve, 300))])
-        .then(([{ set, filter, summaries = {} }]) => {
-          const records = set.map(r => new compose.Record(r, this.recordListModule))
+      return response().then(({ set, filter, summaries = {} }) => {
+        const records = set.map(r => new compose.Record(r, this.recordListModule))
 
-          this.updateRecordSet(records)
+        this.updateRecordSet(records)
 
-          this.filter = { ...this.filter, ...filter }
-          this.filter.nextPage = filter.nextPage
-          this.filter.prevPage = filter.prevPage
+        this.filter = { ...this.filter, ...filter }
+        this.filter.nextPage = filter.nextPage
+        this.filter.prevPage = filter.prevPage
 
-          if (resetPagination) {
-            this.summaries = summaries
+        if (resetPagination) {
+          this.summaries = summaries
 
-            let count = this.pagination.count || 0
+          let count = this.pagination.count || 0
 
-            if (paginationOptions.incTotal) {
-              count = filter.total || 0
-              this.filter.incTotal = false
-            }
+          if (paginationOptions.incTotal) {
+            count = filter.total || 0
+            this.filter.incTotal = false
+          }
 
-            if (paginationOptions.incPageNavigation) {
-              const pages = filter.pageNavigation || []
-              this.pagination.pages = pages
+          if (paginationOptions.incPageNavigation) {
+            const pages = filter.pageNavigation || []
+            this.pagination.pages = pages
 
-              if (!paginationOptions.incTotal) {
-                if (pages.length > 1) {
-                  const lastPageCount = pages[pages.length - 1].items
-                  count = ((pages.length - 1) * this.recordsPerPage) + lastPageCount
-                } else {
-                  count = records.length
-                }
+            if (!paginationOptions.incTotal) {
+              if (pages.length > 1) {
+                const lastPageCount = pages[pages.length - 1].items
+                count = ((pages.length - 1) * this.recordsPerPage) + lastPageCount
+              } else {
+                count = records.length
               }
-
-              this.filter.incPageNavigation = false
             }
 
-            this.pagination.count = count
-            this.pagination.page = 1
+            this.filter.incPageNavigation = false
           }
 
-          if (this.stayOnPage) {
-            const goToPageNumber = this.stayOnPage
-            this.stayOnPage = undefined
-            return this.goToPage(goToPageNumber)
-          }
+          this.pagination.count = count
+          this.pagination.page = 1
+        }
 
-          // Extract user IDs from record values and load all users
-          const fields = this.fields.filter(f => f.moduleField).map(f => f.moduleField)
+        // Extract user IDs from record values and load all users
+        const fields = this.fields.filter(f => f.moduleField).map(f => f.moduleField)
 
-          return Promise.all([
-            this.fetchUsers(fields, records),
-            this.fetchRecords(namespaceID, fields, records),
-          ]).then(() => {
-            this.dirtyInlineRecords = {}
-            this.inlineErrors = new validator.Validated()
-            this.processingInlineRecords = {}
-            this.items = records.map(r => this.wrapRecord(r))
-            this.processing = false
-          })
-        }).catch((e) => {
-          if (!axios.isCancel(e)) {
-            this.toastErrorHandler(this.$t('notification:record.listLoadFailed'))(e)
-          } else {
-            this.cancelled = true
-          }
-          this.processing = false
-        }).finally(() => {
-          this.cancelled = false
+        return Promise.all([
+          this.fetchUsers(fields, records),
+          this.fetchRecords(namespaceID, fields, records),
+          // Only fetch parent records if parent fields feature is enabled
+          this.options.includeParentFields ? this.fetchParentRecords(namespaceID, records) : Promise.resolve(),
+        ]).then(() => {
+          this.items = records.map(r => this.wrapRecord(r))
         })
+      }).catch((e) => {
+        if (!axios.isCancel(e)) {
+          this.toastErrorHandler(this.$t('notification:record.listLoadFailed'))(e)
+        } else {
+          this.cancelled = true
+        }
+      }).finally(() => {
+        if (!this.cancelled) {
+          this.processingTimeout = setTimeout(() => {
+            this.processing = false
+          }, 300)
+        } else {
+          this.cancelled = false
+        }
+      })
     },
 
     getStorageRecordListFilter () {
@@ -2647,11 +2954,11 @@ export default {
     },
 
     isInlineRestoreActionVisible ({ deletedAt }) {
-      return !this.options.hideRecordDeleteButton && !!deletedAt
+      return !!deletedAt
     },
 
     isInlineDeleteActionVisible ({ recordID, canDeleteRecord, deletedAt }) {
-      return !this.options.hideRecordDeleteButton && !deletedAt && (canDeleteRecord || recordID === NoID)
+      return !deletedAt && (canDeleteRecord || recordID === NoID)
     },
 
     isViewRecordActionVisible ({ canReadRecord }) {
@@ -2667,15 +2974,15 @@ export default {
     },
 
     isDeleteActionVisible ({ deletedAt, canDeleteRecord }) {
-      return !this.options.hideRecordDeleteButton && !deletedAt && canDeleteRecord
+      return !deletedAt && canDeleteRecord
     },
 
     isRestoreActionVisible ({ canUndeleteRecord }) {
-      return !this.options.hideRecordDeleteButton && canUndeleteRecord
+      return canUndeleteRecord
     },
 
     areActionsVisible (record) {
-      if (this.inlineEditing && this.editing) {
+      if (this.inlineEditing) {
         return [
           this.isCloneRecordActionVisible,
           this.isInlineDeleteActionVisible(record),
@@ -2752,8 +3059,8 @@ export default {
       return this.options.inlineRecordEditEnabled && field.canEdit && !this.showingDeletedRecords && isfieldInlineEditable()
     },
 
-    showInlineFilter (field) {
-      return this.options.inlineValueFiltering && !this.options.hideFiltering && field.filterable
+    showInlineFilter () {
+      return this.options.filterPresets.length > 0
     },
 
     onInlineEditClose () {
@@ -2801,21 +3108,10 @@ export default {
     },
 
     removeFilter (groupIndex, filterIndex) {
-      // Remove the filter from the group
-      if (this.recordListFilter[groupIndex]) {
-        this.recordListFilter[groupIndex].filter = (this.recordListFilter[groupIndex].filter || []).filter((_, index) => index !== filterIndex)
+      this.recordListFilter = this.groupRecordListFilter
+      this.recordListFilter[groupIndex].filter = (this.recordListFilter[groupIndex].filter || []).filter((_, index) => index !== filterIndex)
 
-        // If the group is now empty, remove the entire group
-        if (!this.recordListFilter[groupIndex].filter.length) {
-          // If this was the first group and there's a next group, clear its groupCondition
-          if (groupIndex === 0 && this.recordListFilter[1]) {
-            this.recordListFilter[1].groupCondition = 'OR'
-          }
-          this.recordListFilter.splice(groupIndex, 1)
-        }
-      }
-
-      // If no filters left, reset completely
+      // If this was the last filter, reset to empty (same as resetFilter)
       const hasAnyFilters = this.recordListFilter.some(group => group.filter && group.filter.length > 0)
       if (!hasAnyFilters) {
         this.onFilter()
@@ -2908,7 +3204,7 @@ export default {
       this.showCustomSummariesModal = false
       this.processingTimeout = undefined
       this.cancelled = false
-      this.stayOnPage = undefined
+      this.resolvedParentRecords = {}
     },
 
     abortRequests () {
@@ -2921,12 +3217,116 @@ export default {
       })
     },
 
-    refreshAndResetPagination ({ stayOnPage = true } = {}) {
-      if (stayOnPage) {
-        this.stayOnPage = this.pagination.page
+    refreshAndResetPagination () {
+      this.refresh(true)
+    },
+
+    /**
+     * Extract the parent record ID from a child record's link field.
+     * Handles both plain string IDs and objects with recordID property.
+     *
+     * @param {Object} childRecord - the child record
+     * @returns {string|null} the parent record ID
+     */
+    getParentRecordID (childRecord) {
+      if (!this.parentLinkFieldName) return null
+      const val = childRecord.values[this.parentLinkFieldName]
+      if (!val) return null
+      // Handle both plain string ID and object with recordID property
+      if (typeof val === 'string') return val
+      if (typeof val === 'object') {
+        if (val.recordID) return val.recordID
+        if (val.value) return String(val.value)
+      }
+      return String(val)
+    },
+    async fetchParentRecords (namespaceID, childRecords) {
+      const MAX_PARENT_IDS = 200
+
+      if (!this.options.includeParentFields || !this.parentLinkFieldName || !this.parentFieldConfigs.length) {
+        return
       }
 
-      this.refresh(true)
+      // Find the link field definition in the child module
+      const linkField = this.recordListModule.fields.find(f => f.name === this.parentLinkFieldName)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return
+      }
+
+      const parentModuleID = linkField.options.moduleID
+
+      // Collect all unique parent record IDs from child records
+      // record.values[linkFieldName] holds the linked record's ID as a string
+      const parentRecordIDs = new Set()
+      childRecords.forEach(record => {
+        const val = record.values[this.parentLinkFieldName]
+        if (val && val !== '0') {
+          // Handle both string and array (multi-value) cases
+          if (Array.isArray(val)) {
+            val.forEach(v => v && parentRecordIDs.add(v))
+          } else {
+            parentRecordIDs.add(val)
+          }
+        }
+      })
+
+      if (parentRecordIDs.size === 0) {
+        return
+      }
+
+      // Build a query using OR-based equality checks.
+      // The backend's query parser does not support the IN operator on single-value
+      // fields like recordID (see dialect.go opHandlerIn), so we use OR chains instead:
+      //   recordID = 'id1' OR recordID = 'id2' OR recordID = 'id3'
+      const idList = [...parentRecordIDs].slice(0, MAX_PARENT_IDS)
+      if (parentRecordIDs.size > MAX_PARENT_IDS) {
+        console.warn(`[RecordList] Truncating parent record fetch to ${MAX_PARENT_IDS} of ${parentRecordIDs.size} IDs`)
+      }
+      const query = idList.map(id => `recordID = '${id}'`).join(' OR ')
+
+      try {
+        // Use recordListCancellable pattern to match existing codebase
+        const { response } = this.$ComposeAPI.recordListCancellable({
+          namespaceID,
+          moduleID: parentModuleID,
+          query,
+          limit: parentRecordIDs.size,
+        })
+        const { set } = await response()
+
+        // Get the parent module definition so we can construct proper Record objects
+        const parentModule = this.getModuleByID(parentModuleID)
+
+        // Build a lookup map: parentRecordID -> Record object
+        const resolved = {}
+        set.forEach(r => {
+          const record = parentModule
+            ? new compose.Record(r, parentModule)
+            : r
+          resolved[r.recordID] = record
+        })
+
+        // Replace the whole object so Vue 2 reactivity picks up the change
+        this.resolvedParentRecords = { ...resolved }
+
+        // Resolve any Record-kind / User-kind fields inside the parent records
+        // so that the field-viewer can display their labels instead of raw IDs.
+        if (parentModule) {
+          const parentRecords = Object.values(resolved)
+          // Only resolve fields the user actually selected for display
+          const selectedParentFields = this.parentFieldConfigs
+            .map(pf => parentModule.fields.find(f => f.name === pf.originalName))
+            .filter(Boolean)
+
+          await Promise.all([
+            this.fetchRecords(namespaceID, selectedParentFields, parentRecords),
+            this.fetchUsers(selectedParentFields, parentRecords),
+          ])
+        }
+      } catch (e) {
+        console.warn('[RecordList] Failed to fetch parent records:', e)
+        // Non-fatal — rows will just show empty for parent fields
+      }
     },
 
     destroyEvents () {
@@ -3050,10 +3450,8 @@ th {
 
 tr:hover td.actions {
   opacity: 1;
-
-  &:not(.actions-visible) {
-    background-color: var(--light);
-  }
+  z-index: 1;
+  background-color: var(--light);
 }
 
 .inline-actions {
@@ -3094,11 +3492,6 @@ tr:hover .inline-actions {
     transition: opacity 0.25s;
     width: 1%;
     font-family: var(--font-regular) !important;
-    z-index: 3;
-
-    &.actions-visible {
-      opacity: 1;
-    }
   }
 
   tbody {

--- a/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
@@ -95,11 +95,14 @@
             <b-col
               v-if="onRecordPage"
               cols="12"
+              lg="6"
             >
-              <b-form-group>
+              <b-form-group
+                :label="$t('recordList.parentFields.enable')"
+                label-class="text-primary"
+              >
                 <c-input-checkbox
                   v-model="options.includeParentFields"
-                  :label="$t('recordList.parentFields.enable')"
                   switch
                   :labels="checkboxLabel"
                 />

--- a/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/client/web/compose/src/components/PageBlocks/RecordListConfigurator.vue
@@ -84,10 +84,26 @@
             >
               <field-picker
                 :module="recordListModule"
+                :extra-module="parentModuleConfig.extraModule"
+                :extra-module-fields="parentModuleConfig.extraModuleFields"
                 :fields.sync="options.fields"
                 class="mb-3"
                 style="height: 50vh;"
               />
+            </b-col>
+
+            <b-col
+              v-if="onRecordPage"
+              cols="12"
+            >
+              <b-form-group>
+                <c-input-checkbox
+                  v-model="options.includeParentFields"
+                  :label="$t('recordList.parentFields.enable')"
+                  switch
+                  :labels="checkboxLabel"
+                />
+              </b-form-group>
             </b-col>
 
             <b-col
@@ -102,6 +118,7 @@
                 <c-input-select
                   v-model="options.refField"
                   :options="parentFields"
+                  label="label"
                   :placeholder="$t('general.label.none')"
                   :reduce="f => f.name"
                 />
@@ -171,7 +188,8 @@
             <field-picker
               :module="recordListModule"
               :fields.sync="options.editFields"
-              :field-subset="editableFieldSubset"
+              :field-subset="options.fields"
+              disable-system-fields
               style="height: 50vh;"
             />
           </b-form-group>
@@ -235,23 +253,6 @@
               lg="6"
             >
               <b-form-group
-                :label="$t('recordList.record.prefilterHideSearch')"
-                label-class="text-primary"
-              >
-                <c-input-checkbox
-                  v-model="options.hideSearch"
-                  switch
-                  invert
-                  :labels="checkboxLabel"
-                />
-              </b-form-group>
-            </b-col>
-
-            <b-col
-              cols="12"
-              lg="6"
-            >
-              <b-form-group
                 :label="$t('recordList.record.filterHide')"
                 label-class="text-primary"
               >
@@ -265,28 +266,19 @@
             </b-col>
 
             <b-col
-              v-if="!options.hideSearch"
-              lg="6"
               cols="12"
+              lg="6"
             >
               <b-form-group
-                :label="$t('recordList.record.searchableFields')"
+                :label="$t('recordList.record.prefilterHideSearch')"
                 label-class="text-primary"
               >
-                <column-picker
-                  size="sm"
-                  variant="light"
-                  :module="recordListModule"
-                  :fields="options.searchableFields"
-                  :field-subset="queryableFields"
-                  @updateFields="onUpdateSearchableFields"
-                >
-                  {{ $t('recordList.record.configureSearchableFields') }}
-                </column-picker>
-
-                <b-form-text class="text-secondary small">
-                  {{ $t('recordList.record.searchableFieldsFootnote') }}
-                </b-form-text>
+                <c-input-checkbox
+                  v-model="options.hideSearch"
+                  switch
+                  invert
+                  :labels="checkboxLabel"
+                />
               </b-form-group>
             </b-col>
           </b-row>
@@ -852,6 +844,26 @@
               lg="6"
             >
               <b-form-group
+                :label="$t('recordList.inlineEdit.fullInline')"
+                label-class="text-primary"
+                :disabled="!options.inlineRecordEditEnabled"
+              >
+                <c-input-checkbox
+                  v-model="options.inlineRecordEditFullInline"
+                  switch
+                  :labels="checkboxLabel"
+                />
+                <b-form-text class="text-secondary small">
+                  {{ $t('recordList.inlineEdit.fullInlineDescription') }}
+                </b-form-text>
+              </b-form-group>
+            </b-col>
+
+            <b-col
+              cols="12"
+              lg="6"
+            >
+              <b-form-group
                 :label="$t('recordList.inlineEdit.allowAddField')"
                 label-class="text-primary"
               >
@@ -957,18 +969,14 @@
                   {{ $t('recordList.hideRecordCloneButton') }}
                 </b-form-checkbox>
 
-                <b-form-checkbox v-model="options.hideRecordReminderButton">
-                  {{ $t('recordList.hideRecordReminderButton') }}
-                </b-form-checkbox>
-
                 <b-form-checkbox
                   v-model="options.hideRecordPermissionsButton"
                 >
                   {{ $t('recordList.hideRecordPermissionsButton') }}
                 </b-form-checkbox>
 
-                <b-form-checkbox v-model="options.hideRecordDeleteButton">
-                  {{ $t('recordList.hideRecordDeleteButton') }}
+                <b-form-checkbox v-model="options.hideRecordReminderButton">
+                  {{ $t('recordList.hideRecordReminderButton') }}
                 </b-form-checkbox>
               </b-form-group>
             </b-col>
@@ -1042,7 +1050,6 @@ export default {
         { value: 'sameTab', text: this.$t('recordList.record.openInSameTab') },
         { value: 'newTab', text: this.$t('recordList.record.openInNewTab') },
         { value: 'modal', text: this.$t('recordList.record.openInModal') },
-        { value: 'doNothing', text: this.$t('recordList.record.doNothing') },
       ]
     },
 
@@ -1092,16 +1099,208 @@ export default {
     },
 
     parentFields () {
-      if (this.recordListModule) {
-        return this.recordListModule.fields.filter(({ kind, options }) => {
-          if (kind === 'Record' && this.record) {
-            return options.moduleID === this.record.moduleID
-          }
+      if (!this.recordListModule) {
+        return []
+      }
 
-          return false
+      const targetModuleID = (this.record && this.record.moduleID) || (this.page && this.page.moduleID)
+
+      if (!targetModuleID) {
+        return []
+      }
+
+      const resultFields = []
+
+      const visitedModules = new Set()
+
+      const findPathsToTarget = (currentModuleID, currentPath = []) => {
+        if (visitedModules.has(currentModuleID)) {
+          return
+        }
+        visitedModules.add(currentModuleID)
+
+        const module = this.getModuleByID(currentModuleID)
+        if (!module) {
+          return
+        }
+
+        module.fields.forEach(field => {
+          if (field.kind === 'Record' && !field.isMulti && field.options && field.options.moduleID) {
+            const nextModuleID = field.options.moduleID
+
+            if (nextModuleID === targetModuleID) {
+              // Add all fields in the path plus this field
+              resultFields.push(...currentPath.map(f => ({ ...f, isCommonField: false })), {
+                ...field,
+                isCommonField: false,
+                label: field.name,
+              })
+              return
+            }
+
+            findPathsToTarget(nextModuleID, [...currentPath, field])
+          }
         })
       }
-      return []
+
+      // Start searching from the record list's module
+      findPathsToTarget(this.recordListModule.moduleID)
+
+      // ==============================================================
+      // PART 1.5: Grandparent relationships (reverse traversal)
+      // Instead of asking "what does target point to?", we ask "what points to target?"
+      //
+      // Relationship: grandparent <- parent <- child <- recordListModule
+      // The recordListModule field points to child, child points to parent, parent points to grandparent
+      // But we traverse from recordListModule outward to find the chain to target
+      // ==============================================================
+
+      const grandparentFields = []
+
+      // Strategy: For each Record field in the record list module, traverse outward
+      // and check if we can reach the target module through any chain
+      // We need to find chains where: recordListModule.field -> ... -> targetModule
+      // And if the chain length > 1, it's a grandparent relationship
+
+      const findAllPathsToTarget = (startModuleID, path = []) => {
+        const visited = new Set()
+        const results = []
+
+        const traverse = (currentModuleID, currentPath) => {
+          if (visited.has(currentModuleID)) return
+          visited.add(currentModuleID)
+
+          const currentModule = this.getModuleByID(currentModuleID)
+          if (!currentModule) return
+
+          // Check all Record fields in this module
+          currentModule.fields.forEach(field => {
+            if (field.kind !== 'Record' || field.isMulti || !field.options || !field.options.moduleID) {
+              return
+            }
+
+            const nextModuleID = field.options.moduleID
+            const newPath = [...currentPath, { field: field.name, moduleID: nextModuleID }]
+
+            // If we reached the target
+            if (nextModuleID === targetModuleID) {
+              results.push({
+                fieldName: path[0]?.field || field.name, // The first field in the chain (from record list module)
+                fullPath: newPath,
+                isGrandparent: newPath.length > 1, // More than 1 hop = grandparent
+              })
+              return
+            }
+
+            // Continue traversing
+            traverse(nextModuleID, newPath)
+          })
+        }
+
+        traverse(startModuleID, path)
+        return results
+      }
+
+      // Check each Record field in the record list module
+      this.recordListModule.fields.forEach(field => {
+        if (field.kind !== 'Record' || field.isMulti || !field.options || !field.options.moduleID) {
+          return
+        }
+
+        const paths = findAllPathsToTarget(field.options.moduleID, [{ field: field.name, moduleID: field.options.moduleID }])
+
+        paths.forEach(pathResult => {
+          if (pathResult.isGrandparent) {
+            const multiHopPath = pathResult.fullPath.map(p => p.field)
+
+            grandparentFields.push({
+              ...field,
+              isCommonField: false,
+              isGrandparent: true,
+              label: `${field.name} (${this.$t('recordList.refField.grandparent')})`,
+              multiHopPath,
+            })
+          }
+        })
+      })
+
+      // Add grandparent fields to result
+      resultFields.push(...grandparentFields)
+
+      // ==============================================================
+      // PART 2: Common Fields (sibling relationship)
+      // Find fields in the record list module that point to the same module
+      // as the current page's module (the "parent" module).
+      //
+      // Logic:
+      // - Get all Record-kind fields from the current page's module (parent)
+      // - Get all Record-kind fields from the record list module (child)
+      // - Find fields in the child module that point to the SAME module
+      //   as any field in the parent module
+      // This identifies "sibling" records that share the same parent reference
+      // ==============================================================
+
+      // Get all modules that the parent module links to
+      const parentModule = this.getModuleByID(targetModuleID)
+      const parentLinkedModuleIDs = new Set()
+
+      if (parentModule) {
+        parentModule.fields.forEach(field => {
+          if (field.kind === 'Record' && field.options && field.options.moduleID) {
+            parentLinkedModuleIDs.add(field.options.moduleID)
+          }
+        })
+      }
+
+      // Also include the parent module itself (for direct parent-child relationships)
+      parentLinkedModuleIDs.add(targetModuleID)
+
+      // Find fields in the record list module that point to any of those modules
+      const commonFields = this.recordListModule.fields
+        .filter(field => {
+          // Must be a Record field
+          if (field.kind !== 'Record') return false
+
+          // Must have options and moduleID
+          if (!field.options || !field.options.moduleID) return false
+
+          // Include fields that point to the parent module directly
+          // OR to a module that the parent module also links to (sibling relationship)
+          return parentLinkedModuleIDs.has(field.options.moduleID)
+        })
+        .map(field => ({
+          ...field,
+          isCommonField: true,
+          // Add indicator in label to distinguish from hierarchical fields
+          label: `${field.name} (${this.$t('recordList.refField.commonField')})`,
+        }))
+
+      // Combine both results
+      // Remove duplicates from hierarchical results while preserving order
+      // IMPORTANT: Prioritize grandparent fields over non-grandparent fields
+      const uniqueFields = []
+      const fieldIds = new Set()
+
+      // First pass: add all grandparent fields (they take priority)
+      const allFields = [...grandparentFields, ...resultFields]
+
+      allFields.forEach(field => {
+        const fieldId = `${field.name}-${field.options?.moduleID}`
+        if (!fieldIds.has(fieldId)) {
+          fieldIds.add(fieldId)
+          uniqueFields.push(field)
+        }
+      })
+
+      // Remove common fields that are already in hierarchical results
+      const filteredCommonFields = commonFields.filter(field => {
+        const fieldId = `${field.name}-${field.options?.moduleID}`
+        return !fieldIds.has(fieldId)
+      })
+
+      const finalResult = [...uniqueFields, ...filteredCommonFields]
+
+      return finalResult
     },
 
     positionFields () {
@@ -1111,8 +1310,55 @@ export default {
       return []
     },
 
+    /**
+     * Configuration for passing parent module fields to the field picker
+     * Returns the parent module and its fields when the feature is enabled
+     */
+    parentModuleConfig () {
+      if (!this.options.includeParentFields || !this.options.refField) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      if (!this.recordListModule) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      const linkField = this.recordListModule.fields.find(f => f.name === this.options.refField)
+      if (!linkField || linkField.kind !== 'Record' || !linkField.options || !linkField.options.moduleID) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      const parentModule = this.getModuleByID(linkField.options.moduleID)
+      if (!parentModule) {
+        return {
+          extraModule: null,
+          extraModuleFields: [],
+        }
+      }
+
+      return {
+        extraModule: {
+          moduleID: parentModule.moduleID,
+          name: parentModule.name,
+        },
+        extraModuleFields: parentModule.fields.map(f => ({
+          ...f,
+          originalName: f.name,
+        })),
+      }
+    },
+
     isInlineEditorAllowed () {
-      return !!this.recordListModule
+      return this.recordListModule && (this.onRecordPage || this.options.editable)
     },
 
     summaryMetrics () {
@@ -1125,30 +1371,6 @@ export default {
         { value: 'notEmptyCount', label: this.$t('recordList.summaries.metrics.notEmptyCount.label') },
         { value: 'uniqueCount', label: this.$t('recordList.summaries.metrics.uniqueCount.label') },
       ]
-    },
-
-    queryableFields () {
-      if (!this.recordListModule) {
-        return []
-      }
-
-      return [
-        ...this.recordListModule.fields,
-        ...this.recordListModule.systemFields(),
-      ].filter(f => f.isQueryable)
-    },
-
-    editableFieldSubset () {
-      if (!this.recordListModule) {
-        return []
-      }
-
-      return this.options.fields.length
-        ? this.options.fields
-        : [
-            ...this.recordListModule.fields,
-            this.recordListModule.systemFields().find(f => f.name === 'ownedBy'),
-          ]
     },
   },
 
@@ -1167,14 +1389,14 @@ export default {
     },
 
     'options.editable' (value) {
-      this.options.editFields = value ? [...this.editableFieldSubset] : []
+      this.options.editFields = []
       this.options.positionField = undefined
 
       if (value) {
+        this.options.hideRecordEditButton = true
+        this.options.hideRecordViewButton = true
         let f = null
-        if (this.module && this.module.moduleID) {
-          f = this.recordListModule.fields.find(({ options: { moduleID } }) => moduleID === this.module.moduleID)
-        }
+        if (this.module && this.module.moduleID) f = this.recordListModule.fields.find(({ options: { moduleID } }) => moduleID === this.module.moduleID)
         this.options.refField = f ? f.name : undefined
       } else {
         this.options.refField = undefined
@@ -1192,6 +1414,62 @@ export default {
 
     'options.fields' (fields) {
       this.options.editFields = this.options.editFields.filter(a => fields.some(b => a.name === b.name))
+    },
+
+    'options.includeParentFields' (newVal) {
+      if (!newVal) {
+        if (this.options.fields && this.options.fields.length) {
+          this.options.fields = this.options.fields.filter(f => !f.isParentField)
+        }
+      }
+    },
+
+    'options.refField' (newRefField, oldRefField) {
+      if (!newRefField) {
+        this.options.isGrandparent = undefined
+        this.options.isCommonField = undefined
+        this.options.multiHopPath = undefined
+        if (this.options.fields && this.options.fields.length) {
+          this.options.fields = this.options.fields.filter(f => !f.isParentField)
+        }
+        return
+      }
+
+      if (newRefField === oldRefField) {
+        return
+      }
+
+      // Clear parent fields when refField changes (parent module may have changed)
+      if (this.options.fields && this.options.fields.length) {
+        this.options.fields = this.options.fields.filter(f => !f.isParentField)
+      }
+
+      const selectedField = this.parentFields.find(f => f.name === newRefField)
+      if (selectedField) {
+        this.options.isGrandparent = selectedField.isGrandparent
+        this.options.isCommonField = selectedField.isCommonField
+        this.options.multiHopPath = selectedField.multiHopPath
+      } else {
+        this.options.isGrandparent = undefined
+        this.options.isCommonField = undefined
+        this.options.multiHopPath = undefined
+      }
+    },
+
+    parentFields: {
+      handler (fields) {
+        if (!this.options.refField) return
+        const isValid = fields.some(f => f.name === this.options.refField)
+        if (!isValid) {
+          this.options.isGrandparent = undefined
+          this.options.isCommonField = undefined
+          this.options.multiHopPath = undefined
+          if (this.options.fields && this.options.fields.length) {
+            this.options.fields = this.options.fields.filter(f => !f.isParentField)
+          }
+        }
+      },
+      deep: true,
     },
   },
 
@@ -1283,10 +1561,6 @@ export default {
 
     onUpdateInlineEditableFields (fields = []) {
       this.options.inlineEditFields = fields.map(f => f.fieldID && f.fieldID !== NoID ? f.fieldID : f.name).filter(f => !!f)
-    },
-
-    onUpdateSearchableFields (fields = []) {
-      this.options.searchableFields = fields.map(f => f.fieldID && f.fieldID !== NoID ? f.fieldID : f.name).filter(f => !!f)
     },
 
     onUpdateTextWrapOption (fields = []) {

--- a/client/web/compose/src/views/Admin/Pages/Builder.vue
+++ b/client/web/compose/src/views/Admin/Pages/Builder.vue
@@ -56,6 +56,13 @@
           />
         </b-button>
 
+        <page-translator
+          :page.sync="trPage"
+          :page-layout.sync="layout"
+          button-variant="primary"
+          style="margin-left:2px;"
+        />
+
         <b-button
           v-b-tooltip.noninteractive.hover="{ title: $t('tooltip.edit.page'), boundary: 'body' }"
           variant="primary"
@@ -67,13 +74,6 @@
             :icon="['far', 'edit']"
           />
         </b-button>
-
-        <page-translator
-          :page.sync="trPage"
-          :page-layout.sync="layout"
-          button-variant="primary"
-          style="margin-left:2px;"
-        />
       </b-button-group>
     </portal>
 
@@ -91,7 +91,7 @@
       @item-updated="onBlockUpdated"
     >
       <template
-        slot-scope="{ blockIndex, block, resizing }"
+        slot-scope="{ index, block, resizing }"
       >
         <div
           :data-test-id="`block-${block.kind}`"
@@ -118,7 +118,7 @@
                 data-test-id="button-edit"
                 variant="outline-light"
                 class="border-0"
-                @click="editBlock(blockIndex)"
+                @click="editBlock(index)"
               >
                 <font-awesome-icon
                   :icon="['far', 'edit']"
@@ -129,7 +129,7 @@
                 v-b-tooltip.noninteractive.hover="{ title: $t('tooltip.clone.block'), boundary: 'body' }"
                 variant="outline-light"
                 class="border-0"
-                @click="cloneBlock(blockIndex)"
+                @click="cloneBlock(index)"
               >
                 <font-awesome-icon
                   :icon="['far', 'clone']"
@@ -140,7 +140,7 @@
                 v-b-tooltip.noninteractive.hover="{ title: $t('tooltip.copy.block'), boundary: 'body' }"
                 variant="outline-light"
                 class="border-0"
-                @click="copyBlock(blockIndex)"
+                @click="copyBlock(index)"
               >
                 <font-awesome-icon
                   :icon="['far', 'copy']"
@@ -154,7 +154,7 @@
               link
               size="md"
               class="ml-1"
-              @confirmed="deleteBlock(blockIndex)"
+              @confirmed="deleteBlock(index)"
             />
           </div>
 
@@ -165,7 +165,7 @@
             }"
             :page="page"
             :blocks="usedBlocks"
-            :block-index="blockIndex"
+            :block-index="index"
             :block="block"
             :module="module"
             :record="record"
@@ -912,26 +912,26 @@ export default {
       }
 
       // Inline record lists
-      const hasInvalidRecordList = this.usedBlocks.some(b => {
+      this.usedBlocks.forEach((b, index) => {
         if (b.kind === 'RecordList' && b.options.editable) {
           const recordListModule = this.getModuleByID(b.options.moduleID)
-          if (!recordListModule) return false
           const req = new Set(recordListModule.fields.filter(({ isRequired = false }) => isRequired).map(({ name }) => name))
+
+          // If refField is configured, exclude it from required fields check
+          if (b.options.refField) {
+            req.delete(b.options.refField)
+          }
 
           // Check if all required fields are there
           for (const f of b.options.editFields) {
             req.delete(f.name)
           }
 
-          return req.size > 0
+          if (req.size) {
+            this.toastErrorHandler(this.$t('notification:page.saveFailedRequired'))()
+          }
         }
-        return false
       })
-
-      if (hasInvalidRecordList) {
-        this.toastErrorHandler(this.$t('notification:page.saveFailedRequired'))()
-        return
-      }
 
       this.processing = true
 

--- a/client/web/compose/src/views/Layout.vue
+++ b/client/web/compose/src/views/Layout.vue
@@ -228,6 +228,12 @@ export default {
 
     logo () {
       const ns = this.currentNamespace
+
+      // Namespace is on a route but hasn't loaded yet — don't flash the default logo
+      if (!ns && this.$route.params.slug) {
+        return ''
+      }
+
       if (ns && ns.meta && ns.meta.logoEnabled && ns.meta.logo) {
         return ns.meta.logo
       }

--- a/client/web/compose/src/views/Layout.vue
+++ b/client/web/compose/src/views/Layout.vue
@@ -228,12 +228,6 @@ export default {
 
     logo () {
       const ns = this.currentNamespace
-
-      // Namespace is on a route but hasn't loaded yet — don't flash the default logo
-      if (!ns && this.$route.params.slug) {
-        return ''
-      }
-
       if (ns && ns.meta && ns.meta.logoEnabled && ns.meta.logo) {
         return ns.meta.logo
       }

--- a/lib/js/src/compose/types/page-block/record-list.ts
+++ b/lib/js/src/compose/types/page-block/record-list.ts
@@ -101,6 +101,9 @@ export interface Options {
   textStyles: {
     wrappedFields: Array<string>
   }
+
+  // Parent fields feature
+  includeParentFields: boolean;
 }
 
 const defaults: Readonly<Options> = Object.freeze({
@@ -168,6 +171,9 @@ const defaults: Readonly<Options> = Object.freeze({
   textStyles: {
     wrappedFields: [],
   },
+
+  // Parent fields feature
+  includeParentFields: false,
 })
 
 export class PageBlockRecordList extends PageBlock {
@@ -256,6 +262,7 @@ export class PageBlockRecordList extends PageBlock {
       'showRecordPerPageOption',
       'openRecordInEditMode',
       'customSummaries',
+      'includeParentFields',
     )
 
     if (o.selectionButtons) {

--- a/lib/js/src/compose/types/page-block/record.ts
+++ b/lib/js/src/compose/types/page-block/record.ts
@@ -23,6 +23,8 @@ interface Options {
   horizontalFieldLayoutEnabled: boolean;
   recordFieldLayoutOption: string;
   inlineRecordEditAllowAddField: boolean;
+  includeParentFields: boolean;
+  parentField: string | null;
 }
 
 const defaults: Readonly<Options> = Object.freeze({
@@ -39,6 +41,8 @@ const defaults: Readonly<Options> = Object.freeze({
   inlineRecordEditAllowAddField: false,
   horizontalFieldLayoutEnabled: false,
   recordFieldLayoutOption: 'default',
+  includeParentFields: false,
+  parentField: null,
 })
 
 export class PageBlockRecord extends PageBlock {
@@ -54,8 +58,8 @@ export class PageBlockRecord extends PageBlock {
   applyOptions (o?: Partial<Options>): void {
     if (!o) return
 
-    Apply(this.options, o, String, 'magnifyOption', 'recordSelectorDisplayOption', 'recordSelectorAddRecordDisplayOption', 'referenceField', 'referenceModuleID', 'recordFieldLayoutOption')
-    Apply(this.options, o, Boolean, 'recordSelectorShowAddRecordButton', 'inlineRecordEditEnabled', 'horizontalFieldLayoutEnabled', 'inlineRecordEditAllowAddField', 'clearConditionalFieldsOnHide')
+    Apply(this.options, o, String, 'magnifyOption', 'recordSelectorDisplayOption', 'recordSelectorAddRecordDisplayOption', 'referenceField', 'referenceModuleID', 'recordFieldLayoutOption', 'parentField')
+    Apply(this.options, o, Boolean, 'recordSelectorShowAddRecordButton', 'inlineRecordEditEnabled', 'horizontalFieldLayoutEnabled', 'inlineRecordEditAllowAddField', 'clearConditionalFieldsOnHide', 'includeParentFields')
 
     if (o.fields) {
       this.options.fields = o.fields

--- a/locale/en/corteza-webapp-compose/block.yaml
+++ b/locale/en/corteza-webapp-compose/block.yaml
@@ -768,6 +768,17 @@ recordRevisions:
       invalid-module-id: Field does not contain a valid module ID.
     fields:
       label: Fields to display in record revisions changes
+      show-all:
+        label: Show changes for all fields
+      columns:
+        label:
+          label: Label
+        kind:
+          label: Type
+        displayed-fields:
+          label: Show
+        expanded-references:
+          label: Expand references
 
 socialFeed:
   label: Twitter feed

--- a/locale/en/corteza-webapp-compose/block.yaml
+++ b/locale/en/corteza-webapp-compose/block.yaml
@@ -26,7 +26,7 @@ automation:
   noScripts: There are no manual scripts compatible with this page block
   removeAll: Remove all
   searchPlaceholder: Filter available scripts by label, script name and description
-  stepID: "Starting step ID: {{stepID}}"
+  stepID: 'Starting step ID: {{stepID}}'
   variants:
     primary: Primary
     secondary: Secondary
@@ -140,12 +140,6 @@ content:
   ok: Ok
   label: Content
   urlPlaceholder: https://example.tld
-  emojiPicker:
-    search: Search
-    searchResults: Search Results
-    frequentlyUsed: Frequently Used
-    noResults: No emojis found
-    quickReactions: Quick Reactions
 file:
   label: File
   preview:
@@ -292,7 +286,7 @@ record:
   invalidRecordVar: Can not use ${record...} variable in non-record pages
   label: Record
   listLoadFailed: Could not load record list
-  moduleOrPageNotSet: "RecordList block error: module or page option not set"
+  moduleOrPageNotSet: 'RecordList block error: module or page option not set'
   moduleMismatch: Module incompatible, module mismatch
   horizontalFormLayout: Horizontal form layout
   inlineEdit:
@@ -331,6 +325,9 @@ record:
       performance: Using conditional fields will impact performance
   recordSelectorCanAddRecord: Can add records via record selector
   recordSelectorAddRecordDisplayOption: When adding a record via record selector
+  parentFields:
+    enable: Include parent fields
+    field: Parent link field
 recordList:
   noModule: No module selected
   addRecord: Add
@@ -365,8 +362,6 @@ recordList:
     filter:
       label: Drill down filter
   tooltip:
-    saveChanges: Save changes
-    discardChanges: Discard changes
     deleteSelected: Delete selected records
     performance:
       impact: Using this feature will impact performance
@@ -414,15 +409,13 @@ recordList:
     inRange: Date range
     includeQuery: Filter by search query
     json: JSON Export
-    limitations: "CSV export limitation: only the first value in the multi value fields will be exported"
+    limitations: 'CSV export limitation: only the first value in the multi value fields will be exported'
     rangeBy: Set range by
-    recordCount: "{{count}} records ready for export"
-    selectFields: "Select fields you want to export:"
+    recordCount: '{{count}} records ready for export'
+    selectFields: 'Select fields you want to export:'
     selection: Selected records
     specifyTimezone: Export to timezone
     timezonePlaceholder: Select timezone
-    resolveRefs: Include record selector values
-    resolveRefsNote: When include record selector values is checked, all record fields include the record label next to the identifier.
     datePresetUndefined: Unknown date preset
   federated: Federated
   fields: Module fields
@@ -430,7 +423,7 @@ recordList:
     addField: Add new filter field
     byValue: Filter records based on field value
     addFilterToPreset: Save as preset
-    nil: "NULL"
+    nil: 'NULL'
     conditions:
       and: AND
       or: OR
@@ -453,7 +446,7 @@ recordList:
     fieldValuePlaceholder: Input field filter
     including: Including
     label: Filter
-    note: "Note: If Field value is undefined, the filter will look for records where that field value is undefined."
+    note: 'Note: If Field value is undefined, the filter will look for records where that field value is undefined.'
     only: Only
     operators:
       like: Like
@@ -474,7 +467,7 @@ recordList:
     reset: Reset Filter
     filters:
       label: Filters
-      active: "Active filters:"
+      active: 'Active filters:'
     name:
       label: Name
       placeholder: Filter name
@@ -486,17 +479,16 @@ recordList:
   hideRecordPermissionsButton: Hide record permissions button
   hideRecordReminderButton: Hide record reminder button
   hideRecordViewButton: Hide view record button
-  hideRecordDeleteButton: Hide delete record button
   hideConfigureFieldsButton: Users will be able to configure which fields to display
   enableRecordPageNavigation: Users will be able to navigate to previous/next record
   import:
-    dropzoneFileAdded: "{{name}} was uploaded and is ready for import ({{count}} record)"
-    dropzoneFileAdded_plural: "{{name}} was uploaded and is ready for import ({{count}} records)"
+    dropzoneFileAdded: '{{name}} was uploaded and is ready for import ({{count}} record)'
+    dropzoneFileAdded_plural: '{{name}} was uploaded and is ready for import ({{count}} records)'
     dropzoneLabel: Click or drop file here to upload (.csv or JSON)
-    failed: "Something went wrong during the import. Please try again: {{failReason}}"
+    failed: 'Something went wrong during the import. Please try again: {{failReason}}'
     fileColumns: File columns
-    hasRequiredFileFields: "This module has required file upload fields"
-    matchFields: "Match imported columns with existing ones"
+    hasRequiredFileFields: 'This module has required file upload fields'
+    matchFields: 'Match imported columns with existing ones'
     moduleFields: Module fields
     onError: If any record fails to import
     onErrorFail: Cancel import
@@ -538,14 +530,14 @@ recordList:
   label: Record list
   modulePlaceholder: Select a module
   moduleFootnote: Modules without a {{0}} can only be used in a record list as an inline editor
-  moduleFieldsFootnote: If no fields are selected, the default fields will be shown
+  moduleFieldsFootnote : If no fields are selected, the default fields will be shown
   noRecords: There are no records matching your request
   pagination:
     next: Next
     prev: Previous
-    showing: "{{from}} - {{to}} of {{count}} records"
+    showing: '{{from}} - {{to}} of {{count}} records'
     single_one: One record
-    single_other: "{{count}} records"
+    single_other: '{{count}} records'
     recordsPerPage: Per page
     selectLabel: Select an option
   positionField:
@@ -554,17 +546,17 @@ recordList:
     label: Record sort field
   preview:
     addRecordButton: Add record button
-    bePaged: "{{0}} be paged."
-    isDisabled: "{{0}} is disabled."
-    isEnabled: "{{0}} is enabled."
-    isHidden: "{{0}} is hidden."
-    isShown: "{{0}} is shown"
+    bePaged: '{{0}} be paged.'
+    isDisabled: '{{0}} is disabled.'
+    isEnabled: '{{0}} is enabled.'
+    isHidden: '{{0}} is hidden.'
+    isShown: '{{0}} is shown'
     moduleNotSelected: Block with table of records, module not selected.
-    recordFromModule: "Showing records from {{0}} module with columns: {{1}}"
-    recordsPerPage: "{{0}} records are shown per page."
+    recordFromModule: 'Showing records from {{0}} module with columns: {{1}}'
+    recordsPerPage: '{{0}} records are shown per page.'
     resultsCan: Results can
     resultsCant: Results can not
-    resultsPrefiltered: "Results are prefiltered:"
+    resultsPrefiltered: 'Results are prefiltered:'
     searchInput: Search inputbox
     sorting: Sorting
     tableHeader: Table header
@@ -603,13 +595,9 @@ recordList:
     showRecordPerPageOption: User will be able to select records per page
     showDeletedRecordsOption: Show option to see deleted records
     setCustomFilterPresets: User will be able to set custom filter presets
-    searchableFields: Searchable fields
-    searchableFieldsFootnote: If no fields are selected, the search will be performed on all available visible fields
-    configureSearchableFields: Select fields that will be used for search
     openInSameTab: Open record in the same tab
     openInNewTab: Open record in a new tab
     openInModal: Open record in a modal
-    doNothing: Do nothing
     createInSameTab: Create record in the same tab
     createInNewTab: Create record in a new tab
     createInModal: Create record in a modal
@@ -632,9 +620,16 @@ recordList:
   refField:
     footnote: Field that links records with the parent record
     label: Parent field
+    commonField: Common
+  parentFields:
+    enable: Include parent fields
+    field: Parent link field
+    footnote: Select which parent field links to this record list
+    parentIndicator: Parent
+    hideModuleLabel: Hide parent module label
   selectable: Users will be able to select records
-  selected: "{{count}} of {{total}} records selected"
-  selectedFromAllPages: "All {{count}} records from all pages selected"
+  selected: '{{count}} of {{total}} records selected'
+  selectedFromAllPages: 'All {{count}} records from all pages selected'
   selectAllRecords: Select all records on all pages
   unselectAllRecords: Clear selection
   sort:
@@ -705,7 +700,7 @@ recordOrganizer:
     placeholder: Field that will hold the record position
     label: Record sort field
   preview:
-    label: "Record Organizer block for module {{0}}. Label field {{1}}, Description field {{2}}. Value setting field: {{3}}, Sorted by position field: {{4}}."
+    label: 'Record Organizer block for module {{0}}. Label field {{1}}, Description field {{2}}. Value setting field: {{3}}, Sorted by position field: {{4}}.'
     moduleNotSelected: Record Organizer module not selected
   addNewRecord: + Add
 
@@ -748,15 +743,21 @@ recordRevisions:
   configurator:
     label: Record revisions
     preload: Preload record revisions
-    sortDirection:
-      label: Sort direction
-      footnote: Sort revisions by when they were created
-      desc: Newest first
-      asc: Oldest first
     errors:
       invalid-module-id: Field does not contain a valid module ID.
     fields:
-      label: Fields to display in record revisions changes
+      label: Configure fields to display in record revisions changes
+      show-all:
+        label: Show changes for all fields
+      columns:
+        label:
+          label: Label
+        kind:
+          label: Type
+        displayed-fields:
+          label: Show
+        expanded-references:
+          label: Expand references
 
 socialFeed:
   label: Twitter feed
@@ -787,7 +788,7 @@ comment:
   title:
     placeholder: Title
   content:
-    placeholder: Write your message here...
+    placeholder: Comment here...
   submit: Submit
   noComments: No comments yet
   load:
@@ -801,24 +802,8 @@ comment:
   referenceField:
     label: Reference field
     footnote: Field that links comments with the parent record
-  attachmentField:
-    label: Attachment field
-    footnote: Field used to store comment attachments
-  reactionsField:
-    label: Reactions field
-    footnote: Field used to store comment reactions
   today: Today
   yesterday: Yesterday
-  tooltip:
-    reply: Reply
-    edit: Edit
-    attach: Attach file
-  emojiPicker:
-    search: Search
-    searchResults: Search Results
-    frequentlyUsed: Frequently Used
-    noResults: No emojis found
-    quickReactions: Quick Reactions
 navigation:
   chart: Charts
   colorPicker: Choose a color
@@ -968,7 +953,7 @@ geometry:
     topLeft: Bounds top left
     lowerRight: Bounds lower right
   tooltip:
-    goToCurrentLocation: Go to current location
+      goToCurrentLocation: Go to current location
 
 tabs:
   label: Tabs
@@ -1012,9 +997,6 @@ tabs:
         label: Title
       block:
         label: Block
-      lazy:
-        label: Lazy load
-        tooltip: When enabled, the tab content will only be rendered when the tab is first activated
   tooltip:
     edit: Edit block
     clone: Clone block & tab

--- a/locale/en/corteza-webapp-compose/block.yaml
+++ b/locale/en/corteza-webapp-compose/block.yaml
@@ -26,7 +26,7 @@ automation:
   noScripts: There are no manual scripts compatible with this page block
   removeAll: Remove all
   searchPlaceholder: Filter available scripts by label, script name and description
-  stepID: 'Starting step ID: {{stepID}}'
+  stepID: "Starting step ID: {{stepID}}"
   variants:
     primary: Primary
     secondary: Secondary
@@ -140,6 +140,12 @@ content:
   ok: Ok
   label: Content
   urlPlaceholder: https://example.tld
+  emojiPicker:
+    search: Search
+    searchResults: Search Results
+    frequentlyUsed: Frequently Used
+    noResults: No emojis found
+    quickReactions: Quick Reactions
 file:
   label: File
   preview:
@@ -286,7 +292,7 @@ record:
   invalidRecordVar: Can not use ${record...} variable in non-record pages
   label: Record
   listLoadFailed: Could not load record list
-  moduleOrPageNotSet: 'RecordList block error: module or page option not set'
+  moduleOrPageNotSet: "RecordList block error: module or page option not set"
   moduleMismatch: Module incompatible, module mismatch
   horizontalFormLayout: Horizontal form layout
   inlineEdit:
@@ -362,6 +368,8 @@ recordList:
     filter:
       label: Drill down filter
   tooltip:
+    saveChanges: Save changes
+    discardChanges: Discard changes
     deleteSelected: Delete selected records
     performance:
       impact: Using this feature will impact performance
@@ -409,13 +417,15 @@ recordList:
     inRange: Date range
     includeQuery: Filter by search query
     json: JSON Export
-    limitations: 'CSV export limitation: only the first value in the multi value fields will be exported'
+    limitations: "CSV export limitation: only the first value in the multi value fields will be exported"
     rangeBy: Set range by
-    recordCount: '{{count}} records ready for export'
-    selectFields: 'Select fields you want to export:'
+    recordCount: "{{count}} records ready for export"
+    selectFields: "Select fields you want to export:"
     selection: Selected records
     specifyTimezone: Export to timezone
     timezonePlaceholder: Select timezone
+    resolveRefs: Include record selector values
+    resolveRefsNote: When include record selector values is checked, all record fields include the record label next to the identifier.
     datePresetUndefined: Unknown date preset
   federated: Federated
   fields: Module fields
@@ -423,7 +433,7 @@ recordList:
     addField: Add new filter field
     byValue: Filter records based on field value
     addFilterToPreset: Save as preset
-    nil: 'NULL'
+    nil: "NULL"
     conditions:
       and: AND
       or: OR
@@ -446,7 +456,7 @@ recordList:
     fieldValuePlaceholder: Input field filter
     including: Including
     label: Filter
-    note: 'Note: If Field value is undefined, the filter will look for records where that field value is undefined.'
+    note: "Note: If Field value is undefined, the filter will look for records where that field value is undefined."
     only: Only
     operators:
       like: Like
@@ -467,7 +477,7 @@ recordList:
     reset: Reset Filter
     filters:
       label: Filters
-      active: 'Active filters:'
+      active: "Active filters:"
     name:
       label: Name
       placeholder: Filter name
@@ -479,16 +489,17 @@ recordList:
   hideRecordPermissionsButton: Hide record permissions button
   hideRecordReminderButton: Hide record reminder button
   hideRecordViewButton: Hide view record button
+  hideRecordDeleteButton: Hide delete record button
   hideConfigureFieldsButton: Users will be able to configure which fields to display
   enableRecordPageNavigation: Users will be able to navigate to previous/next record
   import:
-    dropzoneFileAdded: '{{name}} was uploaded and is ready for import ({{count}} record)'
-    dropzoneFileAdded_plural: '{{name}} was uploaded and is ready for import ({{count}} records)'
+    dropzoneFileAdded: "{{name}} was uploaded and is ready for import ({{count}} record)"
+    dropzoneFileAdded_plural: "{{name}} was uploaded and is ready for import ({{count}} records)"
     dropzoneLabel: Click or drop file here to upload (.csv or JSON)
-    failed: 'Something went wrong during the import. Please try again: {{failReason}}'
+    failed: "Something went wrong during the import. Please try again: {{failReason}}"
     fileColumns: File columns
-    hasRequiredFileFields: 'This module has required file upload fields'
-    matchFields: 'Match imported columns with existing ones'
+    hasRequiredFileFields: "This module has required file upload fields"
+    matchFields: "Match imported columns with existing ones"
     moduleFields: Module fields
     onError: If any record fails to import
     onErrorFail: Cancel import
@@ -530,14 +541,14 @@ recordList:
   label: Record list
   modulePlaceholder: Select a module
   moduleFootnote: Modules without a {{0}} can only be used in a record list as an inline editor
-  moduleFieldsFootnote : If no fields are selected, the default fields will be shown
+  moduleFieldsFootnote: If no fields are selected, the default fields will be shown
   noRecords: There are no records matching your request
   pagination:
     next: Next
     prev: Previous
-    showing: '{{from}} - {{to}} of {{count}} records'
+    showing: "{{from}} - {{to}} of {{count}} records"
     single_one: One record
-    single_other: '{{count}} records'
+    single_other: "{{count}} records"
     recordsPerPage: Per page
     selectLabel: Select an option
   positionField:
@@ -546,17 +557,17 @@ recordList:
     label: Record sort field
   preview:
     addRecordButton: Add record button
-    bePaged: '{{0}} be paged.'
-    isDisabled: '{{0}} is disabled.'
-    isEnabled: '{{0}} is enabled.'
-    isHidden: '{{0}} is hidden.'
-    isShown: '{{0}} is shown'
+    bePaged: "{{0}} be paged."
+    isDisabled: "{{0}} is disabled."
+    isEnabled: "{{0}} is enabled."
+    isHidden: "{{0}} is hidden."
+    isShown: "{{0}} is shown"
     moduleNotSelected: Block with table of records, module not selected.
-    recordFromModule: 'Showing records from {{0}} module with columns: {{1}}'
-    recordsPerPage: '{{0}} records are shown per page.'
+    recordFromModule: "Showing records from {{0}} module with columns: {{1}}"
+    recordsPerPage: "{{0}} records are shown per page."
     resultsCan: Results can
     resultsCant: Results can not
-    resultsPrefiltered: 'Results are prefiltered:'
+    resultsPrefiltered: "Results are prefiltered:"
     searchInput: Search inputbox
     sorting: Sorting
     tableHeader: Table header
@@ -595,9 +606,13 @@ recordList:
     showRecordPerPageOption: User will be able to select records per page
     showDeletedRecordsOption: Show option to see deleted records
     setCustomFilterPresets: User will be able to set custom filter presets
+    searchableFields: Searchable fields
+    searchableFieldsFootnote: If no fields are selected, the search will be performed on all available visible fields
+    configureSearchableFields: Select fields that will be used for search
     openInSameTab: Open record in the same tab
     openInNewTab: Open record in a new tab
     openInModal: Open record in a modal
+    doNothing: Do nothing
     createInSameTab: Create record in the same tab
     createInNewTab: Create record in a new tab
     createInModal: Create record in a modal
@@ -621,6 +636,7 @@ recordList:
     footnote: Field that links records with the parent record
     label: Parent field
     commonField: Common
+    grandparent: Grandparent
   parentFields:
     enable: Include parent fields
     field: Parent link field
@@ -628,8 +644,8 @@ recordList:
     parentIndicator: Parent
     hideModuleLabel: Hide parent module label
   selectable: Users will be able to select records
-  selected: '{{count}} of {{total}} records selected'
-  selectedFromAllPages: 'All {{count}} records from all pages selected'
+  selected: "{{count}} of {{total}} records selected"
+  selectedFromAllPages: "All {{count}} records from all pages selected"
   selectAllRecords: Select all records on all pages
   unselectAllRecords: Clear selection
   sort:
@@ -700,7 +716,7 @@ recordOrganizer:
     placeholder: Field that will hold the record position
     label: Record sort field
   preview:
-    label: 'Record Organizer block for module {{0}}. Label field {{1}}, Description field {{2}}. Value setting field: {{3}}, Sorted by position field: {{4}}.'
+    label: "Record Organizer block for module {{0}}. Label field {{1}}, Description field {{2}}. Value setting field: {{3}}, Sorted by position field: {{4}}."
     moduleNotSelected: Record Organizer module not selected
   addNewRecord: + Add
 
@@ -743,21 +759,15 @@ recordRevisions:
   configurator:
     label: Record revisions
     preload: Preload record revisions
+    sortDirection:
+      label: Sort direction
+      footnote: Sort revisions by when they were created
+      desc: Newest first
+      asc: Oldest first
     errors:
       invalid-module-id: Field does not contain a valid module ID.
     fields:
-      label: Configure fields to display in record revisions changes
-      show-all:
-        label: Show changes for all fields
-      columns:
-        label:
-          label: Label
-        kind:
-          label: Type
-        displayed-fields:
-          label: Show
-        expanded-references:
-          label: Expand references
+      label: Fields to display in record revisions changes
 
 socialFeed:
   label: Twitter feed
@@ -788,7 +798,7 @@ comment:
   title:
     placeholder: Title
   content:
-    placeholder: Comment here...
+    placeholder: Write your message here...
   submit: Submit
   noComments: No comments yet
   load:
@@ -802,8 +812,24 @@ comment:
   referenceField:
     label: Reference field
     footnote: Field that links comments with the parent record
+  attachmentField:
+    label: Attachment field
+    footnote: Field used to store comment attachments
+  reactionsField:
+    label: Reactions field
+    footnote: Field used to store comment reactions
   today: Today
   yesterday: Yesterday
+  tooltip:
+    reply: Reply
+    edit: Edit
+    attach: Attach file
+  emojiPicker:
+    search: Search
+    searchResults: Search Results
+    frequentlyUsed: Frequently Used
+    noResults: No emojis found
+    quickReactions: Quick Reactions
 navigation:
   chart: Charts
   colorPicker: Choose a color
@@ -953,7 +979,7 @@ geometry:
     topLeft: Bounds top left
     lowerRight: Bounds lower right
   tooltip:
-      goToCurrentLocation: Go to current location
+    goToCurrentLocation: Go to current location
 
 tabs:
   label: Tabs
@@ -997,6 +1023,9 @@ tabs:
         label: Title
       block:
         label: Block
+      lazy:
+        label: Lazy load
+        tooltip: When enabled, the tab content will only be rendered when the tab is first activated
   tooltip:
     edit: Edit block
     clone: Clone block & tab

--- a/server/compose/rest/handlers/record.go
+++ b/server/compose/rest/handlers/record.go
@@ -10,10 +10,11 @@ package handlers
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/cortezaproject/corteza/server/compose/rest/request"
 	"github.com/cortezaproject/corteza/server/pkg/api"
 	"github.com/go-chi/chi/v5"
-	"net/http"
 )
 
 type (
@@ -38,6 +39,7 @@ type (
 		TriggerScript(context.Context, *request.RecordTriggerScript) (interface{}, error)
 		TriggerScriptOnList(context.Context, *request.RecordTriggerScriptOnList) (interface{}, error)
 		Revisions(context.Context, *request.RecordRevisions) (interface{}, error)
+		MultiHopQuery(context.Context, *request.RecordMultiHopQuery) (interface{}, error)
 	}
 
 	// HTTP API interface
@@ -61,6 +63,7 @@ type (
 		TriggerScript       func(http.ResponseWriter, *http.Request)
 		TriggerScriptOnList func(http.ResponseWriter, *http.Request)
 		Revisions           func(http.ResponseWriter, *http.Request)
+		MultiHopQuery       func(http.ResponseWriter, *http.Request)
 	}
 )
 
@@ -370,6 +373,22 @@ func NewRecord(h RecordAPI) *Record {
 
 			api.Send(w, r, value)
 		},
+		MultiHopQuery: func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			params := request.NewRecordMultiHopQuery()
+			if err := params.Fill(r); err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			value, err := h.MultiHopQuery(r.Context(), params)
+			if err != nil {
+				api.Send(w, r, err)
+				return
+			}
+
+			api.Send(w, r, value)
+		},
 	}
 }
 
@@ -395,5 +414,6 @@ func (h Record) MountRoutes(r chi.Router, middlewares ...func(http.Handler) http
 		r.Post("/namespace/{namespaceID}/module/{moduleID}/record/{recordID}/trigger", h.TriggerScript)
 		r.Post("/namespace/{namespaceID}/module/{moduleID}/record/trigger", h.TriggerScriptOnList)
 		r.Get("/namespace/{namespaceID}/module/{moduleID}/record/{recordID}/revisions", h.Revisions)
+		r.Post("/namespace/{namespaceID}/module/{moduleID}/record/multi-hop-query", h.MultiHopQuery)
 	})
 }

--- a/server/compose/rest/record.go
+++ b/server/compose/rest/record.go
@@ -720,7 +720,6 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 	return func(w http.ResponseWriter, req *http.Request) {
 		if len(r.Fields) == 0 {
 			http.Error(w, "no record value fields provided", http.StatusBadRequest)
-			return
 		}
 
 		fx := make(map[string]bool)
@@ -755,13 +754,15 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			return
 		}
 
+		w.Header().Add("Content-Type", contentType)
+		w.Header().Add("Content-Disposition", "attachment"+filename)
+
 		var nodes envoyx.NodeSet
 		nodes, _, err = envoySvc.Decode(ctx, envoyx.DecodeParams{
 			Type: envoyx.DecodeTypeStore,
 			Params: map[string]any{
-				"storer":      service.DefaultStore,
-				"dal":         dal.Service(),
-				"resolveRefs": r.GetResolveRefs(),
+				"storer": service.DefaultStore,
+				"dal":    dal.Service(),
 			},
 			Filter: map[string]envoyx.ResourceFilter{
 				composeEnvoy.ComposeRecordDatasourceAuxType: {
@@ -791,7 +792,6 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			},
 		})
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
@@ -804,12 +804,8 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			},
 		}, nil, nodes...)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		w.Header().Add("Content-Type", contentType)
-		w.Header().Add("Content-Disposition", "attachment"+filename)
 
 		mapping := make([]envoyx.MapEntry, 0, len(r.Fields))
 		for _, f := range r.Fields {
@@ -829,13 +825,10 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			FieldMapping: mapping,
 		}, gg)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		if err = ctrl.record.RecordExport(ctx, *rf); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		err = ctrl.record.RecordExport(ctx, *rf)
 	}, err
 }
 
@@ -890,15 +883,9 @@ func (ctrl *Record) TriggerScriptOnList(ctx context.Context, r *request.RecordTr
 func (ctrl *Record) Revisions(ctx context.Context, r *request.RecordRevisions) (interface{}, error) {
 	var (
 		makeRev = func() dal.ValueSetter { return &revisions.Revision{} }
-		sorting filter.Sorting
-		err     error
 	)
 
-	if sorting, err = filter.NewSorting(r.Sort); err != nil {
-		return nil, err
-	}
-
-	iter, err := ctrl.record.SearchRevisions(ctx, r.NamespaceID, r.ModuleID, r.RecordID, sorting)
+	iter, err := ctrl.record.SearchRevisions(ctx, r.NamespaceID, r.ModuleID, r.RecordID)
 	if err != nil {
 		return nil, err
 	}
@@ -921,6 +908,30 @@ func (ctrl *Record) Revisions(ctx context.Context, r *request.RecordRevisions) (
 
 		return
 	}, err
+}
+
+func (ctrl *Record) MultiHopQuery(ctx context.Context, r *request.RecordMultiHopQuery) (interface{}, error) {
+	var (
+		m   *types.Module
+		err error
+	)
+
+	if m, err = ctrl.module.FindByID(ctx, r.NamespaceID, r.ModuleID); err != nil {
+		return nil, err
+	}
+
+	// Build the multi-hop filter
+	// Note: IntermediateFields will be determined by the backend based on the module hierarchy
+	filter := types.MultiHopFilter{
+		TargetField:   r.RefField,
+		TargetValue:   r.RefValue,
+		OriginalQuery: r.Query,
+	}
+
+	// Execute the multi-hop query
+	rr, f, err := ctrl.record.FindByMultiHop(ctx, r.NamespaceID, r.ModuleID, filter, r.Limit, r.Sort)
+
+	return ctrl.makeFilterPayloadN(ctx, m, rr, nil, &f, err)
 }
 
 func (ctrl Record) makeBulkPayload(ctx context.Context, m *types.Module, dd *types.RecordValueErrorSet, err error, rr ...*types.Record) (*recordPayload, error) {

--- a/server/compose/rest/record.go
+++ b/server/compose/rest/record.go
@@ -720,6 +720,7 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 	return func(w http.ResponseWriter, req *http.Request) {
 		if len(r.Fields) == 0 {
 			http.Error(w, "no record value fields provided", http.StatusBadRequest)
+			return
 		}
 
 		fx := make(map[string]bool)
@@ -753,9 +754,6 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			http.Error(w, "unsupported format ("+r.Ext+")", http.StatusBadRequest)
 			return
 		}
-
-		w.Header().Add("Content-Type", contentType)
-		w.Header().Add("Content-Disposition", "attachment"+filename)
 
 		var nodes envoyx.NodeSet
 		nodes, _, err = envoySvc.Decode(ctx, envoyx.DecodeParams{
@@ -792,6 +790,7 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			},
 		})
 		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
@@ -804,8 +803,12 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			},
 		}, nil, nodes...)
 		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		w.Header().Add("Content-Type", contentType)
+		w.Header().Add("Content-Disposition", "attachment"+filename)
 
 		mapping := make([]envoyx.MapEntry, 0, len(r.Fields))
 		for _, f := range r.Fields {
@@ -825,10 +828,13 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			FieldMapping: mapping,
 		}, gg)
 		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		err = ctrl.record.RecordExport(ctx, *rf)
+		if err = ctrl.record.RecordExport(ctx, *rf); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	}, err
 }
 

--- a/server/compose/rest/request/record.go
+++ b/server/compose/rest/request/record.go
@@ -11,14 +11,15 @@ package request
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cortezaproject/corteza/server/compose/types"
-	"github.com/cortezaproject/corteza/server/pkg/payload"
-	"github.com/go-chi/chi/v5"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/cortezaproject/corteza/server/compose/types"
+	"github.com/cortezaproject/corteza/server/pkg/payload"
+	"github.com/go-chi/chi/v5"
 )
 
 // dummy vars to prevent
@@ -230,11 +231,6 @@ type (
 		//
 		// Wrap multi value fields in brachets
 		WrapMultiValue string
-
-		// ResolveRefs GET parameter
-		//
-		//
-		ResolveRefs bool
 	}
 
 	RecordExec struct {
@@ -536,10 +532,47 @@ type (
 		//
 		// ID
 		RecordID uint64 `json:",string"`
+	}
 
-		// Sort GET parameter
+	RecordMultiHopQuery struct {
+		// NamespaceID PATH parameter
 		//
-		// Sort order
+		// Namespace ID
+		NamespaceID uint64 `json:",string"`
+
+		// ModuleID PATH parameter
+		//
+		// Module ID
+		ModuleID uint64 `json:",string"`
+
+		// RefField POST parameter
+		//
+		// Reference field name (e.g., "clientJobID")
+		RefField string
+
+		// RefValue POST parameter
+		//
+		// Reference field value (e.g., "12345")
+		RefValue string
+
+		// Hops POST parameter
+		//
+		// Number of hops (1 = grandparent, 2 = great-grandparent, etc.)
+		Hops uint
+
+		// Query POST parameter
+		//
+		// Additional filter query
+		Query string
+
+		// Limit POST parameter
+		//
+		// Limit
+		Limit uint
+
+		// Sort POST parameter
+		//
+		// Sort items
 		Sort string
 	}
 )
@@ -1110,7 +1143,6 @@ func (r RecordExport) Auditable() map[string]interface{} {
 		"timezone":            r.Timezone,
 		"multiValueDelimiter": r.MultiValueDelimiter,
 		"wrapMultiValue":      r.WrapMultiValue,
-		"resolveRefs":         r.ResolveRefs,
 	}
 }
 
@@ -1159,11 +1191,6 @@ func (r RecordExport) GetWrapMultiValue() string {
 	return r.WrapMultiValue
 }
 
-// Auditable returns all auditable/loggable parameters
-func (r RecordExport) GetResolveRefs() bool {
-	return r.ResolveRefs
-}
-
 // Fill processes request and fills internal variables
 func (r *RecordExport) Fill(req *http.Request) (err error) {
 
@@ -1202,12 +1229,6 @@ func (r *RecordExport) Fill(req *http.Request) (err error) {
 		}
 		if val, ok := tmp["wrapMultiValue"]; ok && len(val) > 0 {
 			r.WrapMultiValue, err = val[0], nil
-			if err != nil {
-				return err
-			}
-		}
-		if val, ok := tmp["resolveRefs"]; ok && len(val) > 0 {
-			r.ResolveRefs, err = payload.ParseBool(val[0]), nil
 			if err != nil {
 				return err
 			}
@@ -2562,7 +2583,6 @@ func (r RecordRevisions) Auditable() map[string]interface{} {
 		"namespaceID": r.NamespaceID,
 		"moduleID":    r.ModuleID,
 		"recordID":    r.RecordID,
-		"sort":        r.Sort,
 	}
 }
 
@@ -2581,25 +2601,8 @@ func (r RecordRevisions) GetRecordID() uint64 {
 	return r.RecordID
 }
 
-// Auditable returns all auditable/loggable parameters
-func (r RecordRevisions) GetSort() string {
-	return r.Sort
-}
-
 // Fill processes request and fills internal variables
 func (r *RecordRevisions) Fill(req *http.Request) (err error) {
-
-	{
-		// GET params
-		tmp := req.URL.Query()
-
-		if val, ok := tmp["sort"]; ok && len(val) > 0 {
-			r.Sort, err = val[0], nil
-			if err != nil {
-				return err
-			}
-		}
-	}
 
 	{
 		var val string
@@ -2619,6 +2622,201 @@ func (r *RecordRevisions) Fill(req *http.Request) (err error) {
 
 		val = chi.URLParam(req, "recordID")
 		r.RecordID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return err
+}
+
+// NewRecordMultiHopQuery request
+func NewRecordMultiHopQuery() *RecordMultiHopQuery {
+	return &RecordMultiHopQuery{}
+}
+
+// Auditable returns all auditable/loggable parameters
+func (r RecordMultiHopQuery) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"namespaceID": r.NamespaceID,
+		"moduleID":    r.ModuleID,
+		"refField":    r.RefField,
+		"refValue":    r.RefValue,
+		"hops":        r.Hops,
+		"query":       r.Query,
+		"limit":       r.Limit,
+		"sort":        r.Sort,
+	}
+}
+
+// GetNamespaceID returns NamespaceID parameter
+func (r RecordMultiHopQuery) GetNamespaceID() uint64 {
+	return r.NamespaceID
+}
+
+// GetModuleID returns ModuleID parameter
+func (r RecordMultiHopQuery) GetModuleID() uint64 {
+	return r.ModuleID
+}
+
+// GetRefField returns RefField parameter
+func (r RecordMultiHopQuery) GetRefField() string {
+	return r.RefField
+}
+
+// GetRefValue returns RefValue parameter
+func (r RecordMultiHopQuery) GetRefValue() string {
+	return r.RefValue
+}
+
+// GetHops returns Hops parameter
+func (r RecordMultiHopQuery) GetHops() uint {
+	return r.Hops
+}
+
+// GetQuery returns Query parameter
+func (r RecordMultiHopQuery) GetQuery() string {
+	return r.Query
+}
+
+// GetLimit returns Limit parameter
+func (r RecordMultiHopQuery) GetLimit() uint {
+	return r.Limit
+}
+
+// GetSort returns Sort parameter
+func (r RecordMultiHopQuery) GetSort() string {
+	return r.Sort
+}
+
+// Fill processes request and fills internal variables
+func (r *RecordMultiHopQuery) Fill(req *http.Request) (err error) {
+
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		err = json.NewDecoder(req.Body).Decode(r)
+
+		switch {
+		case err == io.EOF:
+			err = nil
+		case err != nil:
+			return fmt.Errorf("error parsing http request body: %w", err)
+		}
+	}
+
+	{
+		// Caching 32MB to memory, the rest to disk
+		if err = req.ParseMultipartForm(32 << 20); err != nil && err != http.ErrNotMultipart {
+			return err
+		} else if err == nil {
+			// Multipart params
+
+			if val, ok := req.MultipartForm.Value["refField"]; ok && len(val) > 0 {
+				r.RefField, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
+
+			if val, ok := req.MultipartForm.Value["refValue"]; ok && len(val) > 0 {
+				r.RefValue, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
+
+			if val, ok := req.MultipartForm.Value["hops"]; ok && len(val) > 0 {
+				r.Hops, err = payload.ParseUint(val[0]), nil
+				if err != nil {
+					return err
+				}
+			}
+
+			if val, ok := req.MultipartForm.Value["query"]; ok && len(val) > 0 {
+				r.Query, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
+
+			if val, ok := req.MultipartForm.Value["limit"]; ok && len(val) > 0 {
+				r.Limit, err = payload.ParseUint(val[0]), nil
+				if err != nil {
+					return err
+				}
+			}
+
+			if val, ok := req.MultipartForm.Value["sort"]; ok && len(val) > 0 {
+				r.Sort, err = val[0], nil
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	{
+		if err = req.ParseForm(); err != nil {
+			return err
+		}
+
+		// POST params
+
+		if val, ok := req.Form["refField"]; ok && len(val) > 0 {
+			r.RefField, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["refValue"]; ok && len(val) > 0 {
+			r.RefValue, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["hops"]; ok && len(val) > 0 {
+			r.Hops, err = payload.ParseUint(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["query"]; ok && len(val) > 0 {
+			r.Query, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["limit"]; ok && len(val) > 0 {
+			r.Limit, err = payload.ParseUint(val[0]), nil
+			if err != nil {
+				return err
+			}
+		}
+
+		if val, ok := req.Form["sort"]; ok && len(val) > 0 {
+			r.Sort, err = val[0], nil
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	{
+		var val string
+		// path params
+
+		val = chi.URLParam(req, "namespaceID")
+		r.NamespaceID, err = payload.ParseUint64(val), nil
+		if err != nil {
+			return err
+		}
+
+		val = chi.URLParam(req, "moduleID")
+		r.ModuleID, err = payload.ParseUint64(val), nil
 		if err != nil {
 			return err
 		}

--- a/server/compose/service/record.go
+++ b/server/compose/service/record.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cortezaproject/corteza/server/pkg/envoyx"
 	"github.com/cortezaproject/corteza/server/pkg/filter"
-	"github.com/cortezaproject/corteza/server/pkg/ql"
 	"github.com/cortezaproject/corteza/server/pkg/revisions"
 	"github.com/spf13/cast"
 
@@ -122,8 +121,9 @@ type (
 		Report(ctx context.Context, namespaceID, moduleID uint64, metrics, dimensions, filter string) (any, error)
 		Find(ctx context.Context, filter types.RecordFilter) (set types.RecordSet, f types.RecordFilter, err error)
 		FindN(ctx context.Context, filter types.RecordFilter) (set types.RecordSet, stats map[string]types.RecordSummary, f types.RecordFilter, err error)
+		FindByMultiHop(ctx context.Context, namespaceID, moduleID uint64, filter types.MultiHopFilter, limit uint, sort string) (set types.RecordSet, f types.RecordFilter, err error)
 		SearchSensitive(ctx context.Context) (set []types.SensitiveRecordSet, err error)
-		SearchRevisions(ctx context.Context, namespaceID, moduleID, recordID uint64, sorting filter.Sorting) (dal.Iterator, error)
+		SearchRevisions(ctx context.Context, namespaceID, moduleID, recordID uint64) (dal.Iterator, error)
 		RecordExport(context.Context, types.RecordFilter) error
 		RecordImport(context.Context, error) error
 
@@ -397,17 +397,25 @@ func (svc record) Find(ctx context.Context, filter types.RecordFilter) (set type
 			return RecordErrNotAllowedToSearch()
 		}
 
-		// Validate field-level permissions for filter query
-		if err = svc.validateFilterFieldPermissions(ctx, svc.ac, m, filter.Query); err != nil {
-			return err
-		}
-
-		// Validate field-level permissions for sort expression
-		if err = svc.validateSortFieldPermissions(ctx, svc.ac, m, filter.Sort); err != nil {
-			return err
-		}
-
 		filter.Check = ComposeRecordFilterChecker(ctx, svc.ac, m)
+
+		// Check for multi-hop filters in the query
+		multiHopFilters, cleanQuery := types.ParseMultiHopFilter(filter.Query)
+
+		if len(multiHopFilters) > 0 {
+			// Resolve multi-hop filters and construct new query
+			resolvedQuery, err := svc.resolveMultiHopFilters(ctx, filter.NamespaceID, multiHopFilters)
+			if err != nil {
+				return err
+			}
+
+			// Combine resolved query with clean query
+			if cleanQuery != "" {
+				filter.Query = fmt.Sprintf("%s AND %s", cleanQuery, resolvedQuery)
+			} else {
+				filter.Query = resolvedQuery
+			}
+		}
 
 		if set, f, err = dalutils.ComposeRecordsList(ctx, svc.dal, m, filter); err != nil {
 			return err
@@ -427,6 +435,105 @@ func (svc record) Find(ctx context.Context, filter types.RecordFilter) (set type
 	return set, f, svc.recordAction(ctx, aProps, RecordActionSearch, err)
 }
 
+// resolveMultiHopFilters resolves multi-hop filters by traversing intermediate modules
+// and constructing a query with resolved record IDs
+func (svc record) resolveMultiHopFilters(ctx context.Context, namespaceID uint64, filters []types.MultiHopFilter) (string, error) {
+	if len(filters) == 0 {
+		return "", nil
+	}
+
+	var queries []string
+
+	for _, filter := range filters {
+		// Start with the target value
+		currentValue := filter.TargetValue
+
+		// If no intermediate fields are specified, we need to determine them
+		// based on the module hierarchy
+		if len(filter.IntermediateFields) == 0 {
+			// This case should not occur in normal operation as frontend always provides at least one intermediate field
+			// For safety, return empty query to avoid incorrect results
+			return "", nil
+		}
+
+		// Traverse intermediate fields in reverse order
+		for i := len(filter.IntermediateFields) - 1; i >= 0; i-- {
+			fieldName := filter.IntermediateFields[i]
+
+			// Build a query to find records with this field value
+			query := fmt.Sprintf("%s = '%s'", fieldName, currentValue)
+
+			// Find the module that contains this field
+			modules, _, err := svc.module.Find(ctx, types.ModuleFilter{NamespaceID: namespaceID})
+			if err != nil {
+				return "", err
+			}
+
+			var intermediateIDs []string
+			var foundModule bool
+
+			// Find the first module that has this field
+			for _, mod := range modules {
+				// Check if this module has the field
+				if mod.Fields.FindByName(fieldName) == nil {
+					continue
+				}
+
+				foundModule = true
+
+				// Query records in this module
+				moduleFilter := types.RecordFilter{
+					ModuleID:    mod.ID,
+					NamespaceID: namespaceID,
+					Query:       query,
+				}
+
+				records, _, err := dalutils.ComposeRecordsList(ctx, svc.dal, mod, moduleFilter)
+				if err != nil {
+					continue // Skip modules that fail
+				}
+
+				// Collect record IDs
+				for _, rec := range records {
+					intermediateIDs = append(intermediateIDs, strconv.FormatUint(rec.ID, 10))
+				}
+
+				// Break after finding the first module with the field
+				break
+			}
+
+			if !foundModule || len(intermediateIDs) == 0 {
+				// No module found or no records -> cannot resolve filter, return empty query
+				// This will result in no records being returned, which is safer than incorrect results
+				return "", nil
+			}
+
+			// Update current value to be the list of IDs
+			currentValue = strings.Join(intermediateIDs, ",")
+
+			// If we have more intermediate fields to process, currentValue must be a single ID
+			// If it's a list, we cannot continue (would require additional hops)
+			if i > 0 && strings.Contains(currentValue, ",") {
+				// Cannot traverse further with a list of IDs (would require additional hops)
+				// Return empty query to avoid incorrect results
+				return "", nil
+			}
+		}
+
+		// Build the final query for this filter
+		if strings.Contains(currentValue, ",") {
+			// Multiple IDs
+			queries = append(queries, fmt.Sprintf("%s IN (%s)", filter.TargetField, currentValue))
+		} else {
+			// Single ID
+			queries = append(queries, fmt.Sprintf("%s = '%s'", filter.TargetField, currentValue))
+		}
+	}
+
+	// Combine all queries with AND
+	return strings.Join(queries, " AND "), nil
+}
+
 func (svc record) FindN(ctx context.Context, filter types.RecordFilter) (set types.RecordSet, stats map[string]types.RecordSummary, f types.RecordFilter, err error) {
 	var (
 		m      *types.Module
@@ -442,17 +549,25 @@ func (svc record) FindN(ctx context.Context, filter types.RecordFilter) (set typ
 			return RecordErrNotAllowedToSearch()
 		}
 
-		// Validate field-level permissions for filter query
-		if err = svc.validateFilterFieldPermissions(ctx, svc.ac, m, filter.Query); err != nil {
-			return err
-		}
-
-		// Validate field-level permissions for sort expression
-		if err = svc.validateSortFieldPermissions(ctx, svc.ac, m, filter.Sort); err != nil {
-			return err
-		}
-
 		filter.Check = ComposeRecordFilterChecker(ctx, svc.ac, m)
+
+		// Check for multi-hop filters in the query (same as Find method)
+		multiHopFilters, cleanQuery := types.ParseMultiHopFilter(filter.Query)
+
+		if len(multiHopFilters) > 0 {
+			// Resolve multi-hop filters and construct new query
+			resolvedQuery, err := svc.resolveMultiHopFilters(ctx, filter.NamespaceID, multiHopFilters)
+			if err != nil {
+				return err
+			}
+
+			// Combine resolved query with clean query
+			if cleanQuery != "" {
+				filter.Query = fmt.Sprintf("%s AND %s", cleanQuery, resolvedQuery)
+			} else {
+				filter.Query = resolvedQuery
+			}
+		}
 
 		if set, stats, f, err = dalutils.ComposeRecordsListN(ctx, svc.dal, m, filter); err != nil {
 			return err
@@ -470,6 +585,77 @@ func (svc record) FindN(ctx context.Context, filter types.RecordFilter) (set typ
 	}()
 
 	return set, stats, f, svc.recordAction(ctx, aProps, RecordActionSearch, err)
+}
+
+// FindByMultiHop finds records using multi-hop filter for grandparent/great-grandparent relationships
+func (svc record) FindByMultiHop(ctx context.Context, namespaceID, moduleID uint64, filter types.MultiHopFilter, limit uint, sort string) (set types.RecordSet, f types.RecordFilter, err error) {
+	var (
+		m      *types.Module
+		aProps = &recordActionProps{}
+	)
+
+	err = func() error {
+		// Parse the multi-hop filter to get the target module and query
+		multiHopFilters, _ := types.ParseMultiHopFilter(filter.OriginalQuery)
+		if len(multiHopFilters) == 0 {
+			return fmt.Errorf("invalid multi-hop filter: no filters found")
+		}
+
+		// For now, we'll use the first multi-hop filter
+		// In a more advanced implementation, we could handle multiple filters
+		mhFilter := multiHopFilters[0]
+
+		// Resolve the multi-hop filter to get the final query
+		resolvedQuery, err := svc.resolveMultiHopFilters(ctx, namespaceID, []types.MultiHopFilter{mhFilter})
+		if err != nil {
+			return err
+		}
+
+		// Load the target module
+		if m, err = loadModule(ctx, svc.store, namespaceID, moduleID); err != nil {
+			return err
+		}
+
+		if !svc.ac.CanSearchRecordsOnModule(ctx, m) {
+			return RecordErrNotAllowedToSearch()
+		}
+
+		// Build the record filter
+		recordFilter := types.RecordFilter{
+			ModuleID:    moduleID,
+			NamespaceID: namespaceID,
+			Query:       resolvedQuery,
+		}
+
+		if limit > 0 {
+			recordFilter.Limit = limit
+		}
+
+		if sort != "" {
+			if err = recordFilter.Sort.Set(sort); err != nil {
+				return err
+			}
+		}
+
+		recordFilter.Check = ComposeRecordFilterChecker(ctx, svc.ac, m)
+
+		// Execute the query
+		if set, f, err = dalutils.ComposeRecordsList(ctx, svc.dal, m, recordFilter); err != nil {
+			return err
+		}
+
+		_ = set.Walk(func(r *types.Record) error {
+			r.SetModule(m)
+			r.Values = svc.sanitizer.RunXSS(m, r.Values)
+			return nil
+		})
+
+		ComposeRecordFilterAC(ctx, svc.ac, m, set...)
+
+		return nil
+	}()
+
+	return set, f, svc.recordAction(ctx, aProps, RecordActionSearch, err)
 }
 
 // SearchSensitive returns stripped down records for all namespaces/modules where fields define a sensitivity level
@@ -573,7 +759,7 @@ func (svc record) searchSensitive(ctx context.Context, userID uint64, namespace 
 }
 
 // SearchRevisions returns iterator for revisions of a record
-func (svc record) SearchRevisions(ctx context.Context, namespaceID, moduleID, recordID uint64, sorting filter.Sorting) (dal.Iterator, error) {
+func (svc record) SearchRevisions(ctx context.Context, namespaceID, moduleID, recordID uint64) (dal.Iterator, error) {
 	var (
 		aProps = &recordActionProps{record: &types.Record{NamespaceID: namespaceID, ModuleID: moduleID, ID: recordID}}
 
@@ -601,7 +787,7 @@ func (svc record) SearchRevisions(ctx context.Context, namespaceID, moduleID, re
 			return RecordErrNotAllowedToSearchRevisions()
 		}
 
-		iter, err = svc.revisions.search(ctx, rec, sorting)
+		iter, err = svc.revisions.search(ctx, rec, filter.Sorting{})
 		return
 	}()
 
@@ -1122,11 +1308,7 @@ func RecordValueUpdateOpCheck(ctx context.Context, ac recordValueAccessControlle
 		}
 
 		if v.IsUpdated() && !ac.CanUpdateRecordValueOnModuleField(ctx, f) {
-			rve.Push(types.RecordValueError{
-				Kind:    "updateDenied",
-				Meta:    map[string]interface{}{"field": v.Name},
-				Message: locale.Global().T(ctx, "compose", "record-field.errors.updateDenied"),
-			})
+			rve.Push(types.RecordValueError{Kind: "updateDenied", Meta: map[string]interface{}{"field": v.Name, "value": v.Value}})
 		}
 
 		return nil
@@ -2628,118 +2810,4 @@ func (rr recordReportEntry) SetValue(n string, pos uint, v any) error {
 	rr[n] = v
 
 	return nil
-}
-
-// validateFilterFieldPermissions checks if the user is allowed to filter requested fields
-func (svc record) validateFilterFieldPermissions(ctx context.Context, ac recordValueAccessController, m *types.Module, query string) error {
-	if query == "" {
-		return nil
-	}
-
-	// Parse the filter query to extract field symbols
-	parser := ql.NewParser()
-	ast, err := parser.Parse(query)
-	if err != nil {
-		// If parsing fails, let it pass through - the DAL layer will handle the error
-		// @todo not sure if I am a fan of this
-		return nil
-	}
-
-	symbols := ast.CollectUniqueSymbols()
-	if len(symbols) == 0 {
-		return nil
-	}
-
-	// Build a set of module field names for quick lookup
-	moduleFieldNames := make(map[string]bool)
-	for _, f := range m.Fields {
-		moduleFieldNames[f.Name] = true
-	}
-
-	// System fields that are always filterable (not module-specific fields)
-	systemFields := svc.systemExprFields()
-
-	// Check each symbol in the filter query
-	for _, symbol := range symbols {
-		// Skip system fields as they're always accessible
-		if systemFields[symbol] {
-			continue
-		}
-
-		// Skip symbols that aren't module fields (could be functions, operators, etc.)
-		if !moduleFieldNames[symbol] {
-			continue
-		}
-
-		// Find the field and check permission
-		field := m.Fields.FindByName(symbol)
-		if field == nil {
-			continue
-		}
-
-		if !ac.CanReadRecordValueOnModuleField(ctx, field) {
-			return RecordErrNotAllowedToFilterByField(&recordActionProps{field: symbol})
-		}
-	}
-
-	return nil
-}
-
-// validateFilterFieldPermissions checks if the user is allowed to sort requested fields
-func (svc record) validateSortFieldPermissions(ctx context.Context, ac recordValueAccessController, m *types.Module, sort filter.SortExprSet) error {
-	if len(sort) == 0 {
-		return nil
-	}
-
-	// Build a set of module field names for quick lookup
-	moduleFieldNames := make(map[string]bool)
-	for _, f := range m.Fields {
-		moduleFieldNames[f.Name] = true
-	}
-
-	// System fields that are always sortable
-	systemFields := svc.systemExprFields()
-
-	for _, sort := range sort {
-		fieldName := sort.Column
-
-		// Skip system fields
-		if systemFields[fieldName] {
-			continue
-		}
-
-		// Skip non-module fields
-		if !moduleFieldNames[fieldName] {
-			continue
-		}
-
-		// Find the field and check permission
-		field := m.Fields.FindByName(fieldName)
-		if field == nil {
-			continue
-		}
-
-		if !ac.CanReadRecordValueOnModuleField(ctx, field) {
-			return RecordErrNotAllowedToSortByField(&recordActionProps{field: fieldName})
-		}
-	}
-
-	return nil
-}
-
-func (svc record) systemExprFields() map[string]bool {
-	return map[string]bool{
-		"recordID":    true,
-		"id":          true,
-		"ID":          true,
-		"moduleID":    true,
-		"namespaceID": true,
-		"ownedBy":     true,
-		"createdAt":   true,
-		"createdBy":   true,
-		"updatedAt":   true,
-		"updatedBy":   true,
-		"deletedAt":   true,
-		"deletedBy":   true,
-	}
 }

--- a/server/compose/types/record.go
+++ b/server/compose/types/record.go
@@ -3,7 +3,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cortezaproject/corteza/server/pkg/filter"
@@ -122,6 +124,23 @@ type (
 
 		Records []SensitiveRecord
 	}
+
+	// MultiHopFilter represents a parsed multi-hop filter expression
+	// Used for grandparent/great-grandparent reference field queries
+	// Syntax: @multi-hop(field1, field2, ..., targetValue)
+	// Example: @multi-hop(clientJobID, clientID, 12345)
+	// This means: find all records where clientJobID is in the set of IDs
+	// where clientID = 12345 (from the intermediate module)
+	MultiHopFilter struct {
+		// TargetField is the field in the target module (e.g., "clientJobID")
+		TargetField string
+		// IntermediateFields are the fields to traverse (e.g., ["clientID"])
+		IntermediateFields []string
+		// TargetValue is the value to match at the end of the chain (e.g., "12345")
+		TargetValue string
+		// OriginalQuery is the original query string for reference
+		OriginalQuery string
+	}
 )
 
 const (
@@ -134,6 +153,80 @@ const (
 	DateOnlyLayout = "2006-01-02"
 	TimeOnlyLayout = "15:04:05"
 )
+
+// ParseMultiHopFilter parses a query string to extract multi-hop filter expressions
+// Returns a slice of MultiHopFilter and the remaining query string with multi-hop filters removed
+// Syntax: @multi-hop(field1, field2, ..., targetValue)
+// Example: @multi-hop(clientJobID, clientID, 12345)
+func ParseMultiHopFilter(query string) (filters []MultiHopFilter, cleanQuery string) {
+	filters = make([]MultiHopFilter, 0)
+	cleanQuery = query
+
+	// Regex to match @multi-hop(field1, field2, ..., targetValue)
+	// Matches: @multi-hop(field1, field2, ..., value)
+	// where value can be quoted or unquoted
+	re := regexp.MustCompile(`@multi-hop\(([^)]+)\)`)
+	matches := re.FindAllStringSubmatch(query, -1)
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+
+		// Extract the content inside parentheses
+		content := match[1]
+		parts := strings.Split(content, ",")
+
+		if len(parts) < 2 {
+			// Need at least one field and one value
+			continue
+		}
+
+		// Last part is the target value
+		targetValue := strings.TrimSpace(parts[len(parts)-1])
+		// Remove quotes if present
+		if len(targetValue) >= 2 && targetValue[0] == '"' && targetValue[len(targetValue)-1] == '"' {
+			targetValue = targetValue[1 : len(targetValue)-1]
+		}
+
+		// First part is the target field
+		targetField := strings.TrimSpace(parts[0])
+
+		// Middle parts are intermediate fields
+		intermediateFields := make([]string, 0)
+		for i := 1; i < len(parts)-1; i++ {
+			field := strings.TrimSpace(parts[i])
+			if field != "" {
+				intermediateFields = append(intermediateFields, field)
+			}
+		}
+
+		filter := MultiHopFilter{
+			TargetField:        targetField,
+			IntermediateFields: intermediateFields,
+			TargetValue:        targetValue,
+			OriginalQuery:      match[0],
+		}
+
+		filters = append(filters, filter)
+
+		// Remove the multi-hop filter from the clean query
+		cleanQuery = strings.Replace(cleanQuery, match[0], "", 1)
+	}
+
+	// Clean up orphaned operators that may be left after removing @multi-hop tokens
+	// This handles cases like "(name = 'test') AND @multi-hop(...)" becoming "(name = 'test') AND "
+	orphanedOpPattern := regexp.MustCompile(`\s+(AND|OR)\s*$`)
+	cleanQuery = orphanedOpPattern.ReplaceAllString(cleanQuery, "")
+
+	orphanedOpPatternStart := regexp.MustCompile(`^\s*(AND|OR)\s+`)
+	cleanQuery = orphanedOpPatternStart.ReplaceAllString(cleanQuery, "")
+
+	// Clean up extra whitespace
+	cleanQuery = strings.TrimSpace(cleanQuery)
+
+	return
+}
 
 func (f RecordFilter) ToConstraintedFilter(c map[string][]any) filter.Filter {
 	return filter.Generic(

--- a/server/pkg/ql/parser.go
+++ b/server/pkg/ql/parser.go
@@ -190,12 +190,15 @@ func (p *Parser) parseIdent(t Token) (list parserNode, err error) {
 
 	i := Ident{Value: t.literal}
 
-	if p.peekToken(1).Is(DOT) {
+	// Handle nested field paths of any depth: field1.field2.field3...
+	for p.peekToken(1).Is(DOT) {
 		p.nextToken()
 		i.Value += "."
 		l2 := p.nextToken()
 		if l2.Is(IDENT) {
 			i.Value += l2.literal
+		} else {
+			return nil, fmt.Errorf("unexpected token after '.' in identifier: %v", l2)
 		}
 	}
 


### PR DESCRIPTION
# The following changes are implemented
Improvement on record list linking / filtering:

linking on common records ie Seeing sibling records
multihop parental linking, ie displaying a list of grand children records
Improvement for both record lists and records:

Allow displaying parent module fields inline with the child’s fields.

for example a person record with the generic person details, you then have a client contact record with client specific data, you don’t want full separation on a page of this data it should be displayed inline

https://github.com/cortezaproject/corteza/issues/2312

# Changes in the user interface:

for the Filed picker enhancement there is a bool switch to add the parent modules fields to the list, and for the record block a additional drop down is added 


<img width="1145" height="559" alt="image" src="https://github.com/user-attachments/assets/547d3a4c-b16d-4109-b5d7-33510205dc3e" />



from a record page we can now add a record list for a sibling 

<img width="579" height="706" alt="image" src="https://github.com/user-attachments/assets/65f28896-1151-4f97-88ec-41e3eb9580f1" />

the configurator will realise it is a "common" parent filter and not a direct link
<img width="567" height="141" alt="image" src="https://github.com/user-attachments/assets/85a48ddd-3195-4f0e-9c84-af7b7a8938a7" />


the grandparent record page can now display multihop childrem
<img width="642" height="753" alt="image" src="https://github.com/user-attachments/assets/1cdbcd79-c53b-4f38-bebf-46ab10e2fcef" />




# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
