### PR TITLE
Feature - File Uniqueness Checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .run
 node_modules
 ignore
+.kilo*
+.claude*

--- a/client/web/compose/src/components/ModuleFields/Configurator/File.vue
+++ b/client/web/compose/src/components/ModuleFields/Configurator/File.vue
@@ -35,6 +35,52 @@
       </b-form-checkbox>
     </b-form-group>
 
+    <hr>
+
+    <h5 class="mb-2">
+      {{ $t('kind.file.view.uniqueness.section') }}
+    </h5>
+
+    <b-form-group class="mt-2">
+      <b-form-checkbox
+        v-model="f.options.enforceUniqueness"
+        @change="onEnforceUniquenessChange"
+      >
+        {{ $t('kind.file.view.uniqueness.enforce') }}
+      </b-form-checkbox>
+    </b-form-group>
+
+    <b-form-group
+      v-if="f.options.enforceUniqueness"
+      :label="$t('kind.file.view.uniqueness.conflictActionLabel')"
+      label-class="text-primary"
+      class="mt-2"
+    >
+      <b-form-select
+        v-model="f.options.conflictAction"
+        :options="conflictActionOptions"
+      />
+    </b-form-group>
+
+    <b-form-group
+      v-if="f.options.enforceUniqueness"
+      :label="$t('kind.file.view.uniqueness.targetModuleLabel')"
+      :description="$t('kind.file.view.uniqueness.targetModuleDescription')"
+      label-class="text-primary"
+      class="mt-2"
+    >
+      <c-input-select
+        v-model="f.options.targetModuleID"
+        :options="moduleOptions"
+        label="name"
+        :reduce="m => m.moduleID"
+        :placeholder="$t('kind.file.view.uniqueness.targetModulePlaceholder')"
+        :clearable="true"
+      />
+    </b-form-group>
+
+    <hr>
+
     <b-form-group
       :description="$t('kind.file.view.modeFootnote')"
       :label="$t('kind.file.view.modeLabel')"
@@ -196,8 +242,9 @@
 
 <script>
 import base from './base'
+import { mapGetters } from 'vuex'
 import { components } from '@cortezaproject/corteza-vue'
-const { CInputColorPicker } = components
+const { CInputColorPicker, CInputSelect } = components
 
 export default {
   i18nOptions: {
@@ -206,11 +253,30 @@ export default {
 
   components: {
     CInputColorPicker,
+    CInputSelect,
   },
 
   extends: base,
 
   computed: {
+    ...mapGetters({
+      modules: 'module/set',
+    }),
+
+    moduleOptions () {
+      const nsID = this.namespace && this.namespace.namespaceID
+      return (this.modules || []).filter(m => !nsID || m.namespaceID === nsID)
+    },
+
+    conflictActionOptions () {
+      return [
+        { value: 'alert', text: this.$t('kind.file.view.uniqueness.actions.alert') },
+        { value: 'modal', text: this.$t('kind.file.view.uniqueness.actions.modal') },
+        { value: 'newTab', text: this.$t('kind.file.view.uniqueness.actions.newTab') },
+        { value: 'sameTab', text: this.$t('kind.file.view.uniqueness.actions.sameTab') },
+      ]
+    },
+
     modes () {
       return [
         { value: 'list', text: this.$t('kind.file.view.list') },
@@ -225,6 +291,15 @@ export default {
 
     themeSettings () {
       return this.$Settings.get('ui.studio.themes', [])
+    },
+  },
+
+  methods: {
+    onEnforceUniquenessChange (val) {
+      if (!val) {
+        this.f.options.conflictAction = 'alert'
+        this.f.options.targetModuleID = ''
+      }
     },
   },
 }

--- a/client/web/compose/src/components/ModuleFields/Editor/File.vue
+++ b/client/web/compose/src/components/ModuleFields/Editor/File.vue
@@ -154,11 +154,105 @@ export default {
   },
 
   methods: {
-    appendAttachment ({ attachmentID } = {}) {
+    appendAttachment (response, _file) {
+      if (response && response.duplicate) {
+        this.handleDuplicate(response)
+        return
+      }
+
+      const { attachmentID } = response || {}
       if (this.field.isMulti) {
         this.value = [attachmentID, ...this.value]
       } else {
         this.value = attachmentID
+      }
+    },
+
+    handleDuplicate (response) {
+      const {
+        existingRecordID,
+        conflictAction,
+        recordPageID,
+        namespaceSlug,
+        namespaceID,
+      } = response
+
+      // getByUrlPart in the namespace store accepts either slug or namespaceID,
+      // so fall back to namespaceID when the namespace has no slug set.
+      const nsUrlPart = namespaceSlug || namespaceID
+
+      // canNavigate requires a resolved record and page. Namespace is always
+      // available (we always have at least namespaceID from the response).
+      const canNavigate = existingRecordID && existingRecordID !== '0' &&
+        recordPageID && recordPageID !== '0'
+
+      const routeParams = canNavigate
+        ? {
+            name: 'page.record',
+            params: {
+              recordID: existingRecordID,
+              pageID: recordPageID,
+              slug: nsUrlPart,
+            },
+          }
+        : null
+
+      const showModal = () => {
+        this.$root.$emit('show-record-modal', {
+          recordID: existingRecordID,
+          recordPageID,
+          edit: false,
+        })
+      }
+
+      const action = canNavigate ? conflictAction : 'alert'
+
+      switch (action) {
+        case 'modal':
+          showModal()
+          break
+
+        case 'newTab': {
+          const resolved = this.$router.resolve(routeParams)
+          window.open(resolved.href, '_blank')
+          break
+        }
+
+        case 'sameTab':
+          this.$router.push(routeParams)
+          break
+
+        case 'alert':
+        default: {
+          const h = this.$createElement
+          const vNodeMsg = h('div', [
+            h('span', this.$t('notification:field.duplicateAlert', { recordID: existingRecordID })),
+            existingRecordID && existingRecordID !== '0' && recordPageID && recordPageID !== '0'
+              ? h(
+                  'b-button',
+                  {
+                    props: { variant: 'link', size: 'sm' },
+                    on: {
+                      click: () => {
+                        this.$root.$emit('bv::hide::toast', 'duplicate-file-alert')
+                        showModal()
+                      },
+                    },
+                    class: 'p-0 ml-2',
+                  },
+                  this.$t('notification:field.openRecord'),
+                )
+              : null,
+          ])
+          this.$bvToast.toast([vNodeMsg], {
+            id: 'duplicate-file-alert',
+            title: this.$t('notification:general.warning'),
+            variant: 'warning',
+            solid: true,
+            toaster: 'b-toaster-top-right',
+          })
+          break
+        }
       }
     },
 

--- a/client/web/compose/src/components/ModuleFields/Editor/File.vue
+++ b/client/web/compose/src/components/ModuleFields/Editor/File.vue
@@ -229,19 +229,19 @@ export default {
             h('span', this.$t('notification:field.duplicateAlert', { recordID: existingRecordID })),
             existingRecordID && existingRecordID !== '0' && recordPageID && recordPageID !== '0'
               ? h(
-                  'b-button',
-                  {
-                    props: { variant: 'link', size: 'sm' },
-                    on: {
-                      click: () => {
-                        this.$root.$emit('bv::hide::toast', 'duplicate-file-alert')
-                        showModal()
-                      },
+                'b-button',
+                {
+                  props: { variant: 'link', size: 'sm' },
+                  on: {
+                    click: () => {
+                      this.$root.$emit('bv::hide::toast', 'duplicate-file-alert')
+                      showModal()
                     },
-                    class: 'p-0 ml-2',
                   },
-                  this.$t('notification:field.openRecord'),
-                )
+                  class: 'p-0 ml-2',
+                },
+                this.$t('notification:field.openRecord'),
+              )
               : null,
           ])
           this.$bvToast.toast([vNodeMsg], {

--- a/lib/js/src/compose/types/module-field/file.ts
+++ b/lib/js/src/compose/types/module-field/file.ts
@@ -28,7 +28,10 @@ interface FileOptions extends Options {
   clickToView?: boolean;
   enableDownload?: boolean;
   multiDelimiter: string;
-  enableWebcam?: boolean
+  enableWebcam?: boolean;
+  enforceUniqueness: boolean;
+  conflictAction: string;
+  targetModuleID: string;
 }
 
 const defaults = (): Readonly<FileOptions> => Object.freeze({
@@ -51,6 +54,9 @@ const defaults = (): Readonly<FileOptions> => Object.freeze({
   enableDownload: true,
   multiDelimiter: '\n',
   enableWebcam: false,
+  enforceUniqueness: false,
+  conflictAction: 'alert',
+  targetModuleID: '',
 })
 
 export class ModuleFieldFile extends ModuleField {
@@ -68,8 +74,8 @@ export class ModuleFieldFile extends ModuleField {
     super.applyOptions(o)
 
     Apply(this.options, o, Number, 'maxSize')
-    Apply(this.options, o, Boolean, 'allowImages', 'allowDocuments', 'inline', 'hideFileName', 'clickToView', 'enableDownload', 'enableWebcam')
-    Apply(this.options, o, String, 'mimetypes', 'height', 'width', 'maxHeight', 'maxWidth', 'borderRadius', 'margin', 'backgroundColor')
+    Apply(this.options, o, Boolean, 'allowImages', 'allowDocuments', 'inline', 'hideFileName', 'clickToView', 'enableDownload', 'enableWebcam', 'enforceUniqueness')
+    Apply(this.options, o, String, 'mimetypes', 'height', 'width', 'maxHeight', 'maxWidth', 'borderRadius', 'margin', 'backgroundColor', 'conflictAction', 'targetModuleID')
 
     // Legacy
     if (o.mode === 'single') {

--- a/locale/en/corteza-webapp-compose/field.yaml
+++ b/locale/en/corteza-webapp-compose/field.yaml
@@ -67,6 +67,18 @@ kind:
       px: px
       clickToView: Click to view file
       description: 'Add unit after value to set it. For example: 50px or 50%'
+      uniqueness:
+        section: File uniqueness
+        enforce: Enforce file uniqueness
+        conflictActionLabel: Action on duplicate
+        targetModuleLabel: Check uniqueness against
+        targetModuleDescription: Leave empty to check within this module
+        targetModulePlaceholder: Select a module...
+        actions:
+          modal: Open record in modal
+          newTab: Open record in new tab
+          sameTab: Open record in same tab
+          alert: Show alert with clickable link
   number:
     exampleFormat: Format
     exampleInput: Input

--- a/locale/en/corteza-webapp-compose/notification.yaml
+++ b/locale/en/corteza-webapp-compose/notification.yaml
@@ -38,6 +38,8 @@ field:
   missingRequired: Missing value on required field
   unknownFieldKind: 'Error: Unknown field kind "{{kind}}", no viewer component found.'
   unsupportedKind: Unsupported field kind {{kind}}
+  duplicateAlert: 'Duplicate file: this file already exists in record #{{recordID}}.'
+  openRecord: Open record
 field-datetime:
   valueNotFuture: Past value on future only field
   valueNotPast: Future value on past only field

--- a/server/compose/attachment.cue
+++ b/server/compose/attachment.cue
@@ -46,6 +46,15 @@ attachment: {
 				omitSetter: true
 				omitGetter: true
 			}
+			hash: {
+				dal: { type: "Text", nullable: true }
+			}
+			rel_module: {
+				ident: "moduleID"
+				goType: "uint64"
+				storeIdent: "rel_module"
+				dal: { type: "ID" }
+			}
 			created_at: schema.SortableTimestampNowField
 			updated_at: schema.SortableTimestampNilField
 			deleted_at: schema.SortableTimestampNilField
@@ -54,6 +63,9 @@ attachment: {
 		indexes: {
 			"primary": { attribute: "id" }
 			"namespace": { attribute: "namespace_id" },
+			"hash_module": {
+				fields: [{ attribute: "hash" }, { attribute: "rel_module" }]
+			}
 		}
 	}
 
@@ -65,6 +77,7 @@ attachment: {
 			record_id: { goType: "uint64", ident: "recordID" }
 			module_id: { goType: "uint64", ident: "moduleID" }
 			field_name: { }
+			hash: { }
 		}
 
 		byValue: ["kind", "namespace_id"]

--- a/server/compose/model/models.gen.go
+++ b/server/compose/model/models.gen.go
@@ -77,6 +77,18 @@ var Attachment = &dal.Model{
 		},
 
 		&dal.Attribute{
+			Ident: "Hash",
+			Type:  &dal.TypeText{Nullable: true},
+			Store: &dal.CodecAlias{Ident: "hash"},
+		},
+
+		&dal.Attribute{
+			Ident: "ModuleID",
+			Type:  &dal.TypeID{},
+			Store: &dal.CodecAlias{Ident: "rel_module"},
+		},
+
+		&dal.Attribute{
 			Ident: "CreatedAt", Sortable: true,
 			Type: &dal.TypeTimestamp{
 				DefaultCurrentTimestamp: true, Timezone: true, Precision: -1,
@@ -105,6 +117,20 @@ var Attachment = &dal.Model{
 			Fields: []*dal.IndexField{
 				{
 					AttributeIdent: "NamespaceID",
+				},
+			},
+		},
+
+		&dal.Index{
+			Ident: "compose_attachment_hash_module",
+			Type:  "BTREE",
+
+			Fields: []*dal.IndexField{
+				{
+					AttributeIdent: "Hash",
+				},
+				{
+					AttributeIdent: "ModuleID",
 				},
 			},
 		},

--- a/server/compose/rest/record.go
+++ b/server/compose/rest/record.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cortezaproject/corteza/server/pkg/corredor"
 	"github.com/cortezaproject/corteza/server/pkg/dal"
 	"github.com/cortezaproject/corteza/server/pkg/envoyx"
+	"github.com/cortezaproject/corteza/server/pkg/errors"
 	"github.com/cortezaproject/corteza/server/pkg/filter"
 	"github.com/cortezaproject/corteza/server/pkg/revisions"
 	"github.com/cortezaproject/corteza/server/store"
@@ -28,6 +29,17 @@ import (
 )
 
 type (
+	duplicateAttachmentPayload struct {
+		Duplicate            bool   `json:"duplicate"`
+		ExistingAttachmentID string `json:"existingAttachmentID"`
+		ExistingRecordID     string `json:"existingRecordID"`
+		ModuleID             string `json:"moduleID"`
+		NamespaceID          string `json:"namespaceID"`
+		ConflictAction       string `json:"conflictAction"`
+		RecordPageID         string `json:"recordPageID"`
+		NamespaceSlug        string `json:"namespaceSlug"`
+	}
+
 	recordBulkPatchRecord struct {
 		Record      *types.Record              `json:"record"`
 		Error       error                      `json:"error,omitempty"`
@@ -384,6 +396,22 @@ func (ctrl *Record) Upload(ctx context.Context, r *request.RecordUpload) (interf
 		r.FieldName,
 	)
 
+	if err != nil {
+		var dup *service.DuplicateAttachmentError
+		if errors.As(err, &dup) {
+			return &duplicateAttachmentPayload{
+				Duplicate:            true,
+				ExistingAttachmentID: strconv.FormatUint(dup.ExistingAttachmentID, 10),
+				ExistingRecordID:     strconv.FormatUint(dup.ExistingRecordID, 10),
+				ModuleID:             strconv.FormatUint(dup.ModuleID, 10),
+				NamespaceID:          strconv.FormatUint(dup.NamespaceID, 10),
+				ConflictAction:       dup.ConflictAction,
+				RecordPageID:         strconv.FormatUint(dup.RecordPageID, 10),
+				NamespaceSlug:        dup.NamespaceSlug,
+			}, nil
+		}
+	}
+
 	return makeAttachmentPayload(ctx, a, err)
 }
 
@@ -720,7 +748,6 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 	return func(w http.ResponseWriter, req *http.Request) {
 		if len(r.Fields) == 0 {
 			http.Error(w, "no record value fields provided", http.StatusBadRequest)
-			return
 		}
 
 		fx := make(map[string]bool)
@@ -754,6 +781,9 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			http.Error(w, "unsupported format ("+r.Ext+")", http.StatusBadRequest)
 			return
 		}
+
+		w.Header().Add("Content-Type", contentType)
+		w.Header().Add("Content-Disposition", "attachment"+filename)
 
 		var nodes envoyx.NodeSet
 		nodes, _, err = envoySvc.Decode(ctx, envoyx.DecodeParams{
@@ -791,7 +821,6 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			},
 		})
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
@@ -804,12 +833,8 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			},
 		}, nil, nodes...)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		w.Header().Add("Content-Type", contentType)
-		w.Header().Add("Content-Disposition", "attachment"+filename)
 
 		mapping := make([]envoyx.MapEntry, 0, len(r.Fields))
 		for _, f := range r.Fields {
@@ -829,13 +854,10 @@ func (ctrl *Record) Export(ctx context.Context, r *request.RecordExport) (interf
 			FieldMapping: mapping,
 		}, gg)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		if err = ctrl.record.RecordExport(ctx, *rf); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		err = ctrl.record.RecordExport(ctx, *rf)
 	}, err
 }
 

--- a/server/compose/service/attachment.go
+++ b/server/compose/service/attachment.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/cortezaproject/corteza/server/compose/dalutils"
@@ -15,6 +16,7 @@ import (
 	"github.com/cortezaproject/corteza/server/pkg/actionlog"
 	"github.com/cortezaproject/corteza/server/pkg/auth"
 	"github.com/cortezaproject/corteza/server/pkg/errors"
+	"github.com/cortezaproject/corteza/server/pkg/filter"
 	"github.com/cortezaproject/corteza/server/pkg/objstore"
 	"github.com/cortezaproject/corteza/server/store"
 	systemService "github.com/cortezaproject/corteza/server/system/service"
@@ -412,6 +414,13 @@ func (svc attachment) CreateRecordAttachment(ctx context.Context, namespaceID ui
 			}
 		}
 
+		var (
+			enforceUniqueness bool
+			conflictAction    string
+			targetModuleIDStr string
+			fileHash          string
+		)
+
 		{
 			// Verify size and type of the uploaded record attachment
 			// Max size & allowed mime-types are pulled from the current settings
@@ -435,6 +444,15 @@ func (svc attachment) CreateRecordAttachment(ctx context.Context, namespaceID ui
 				allowedTypes = strings.Split(aux, ",")
 			}
 
+			enforceUniqueness = f.Options.Bool("enforceUniqueness")
+			conflictAction = f.Options.String("conflictAction")
+			switch conflictAction {
+			case "modal", "newTab", "sameTab", "alert":
+			default:
+				conflictAction = "alert"
+			}
+			targetModuleIDStr = f.Options.String("targetModuleID")
+
 			if maxSize > 0 && maxSize < size {
 				return AttachmentErrTooLarge().Apply(
 					errors.Meta("size", size),
@@ -449,10 +467,92 @@ func (svc attachment) CreateRecordAttachment(ctx context.Context, namespaceID ui
 			}
 		}
 
+		if enforceUniqueness {
+			// Determine which module to check for duplicates
+			checkModuleID := moduleID
+			if targetModuleIDStr != "" {
+				if parsed, perr := strconv.ParseUint(targetModuleIDStr, 10, 64); perr == nil && parsed > 0 {
+					checkModuleID = parsed
+				}
+			}
+
+			// Validate the target module exists and is accessible, cache for later use
+			var checkModule *types.Module
+			if checkModuleID != moduleID {
+				var checkModErr error
+				_, checkModule, checkModErr = loadModuleCombo(ctx, s, namespaceID, checkModuleID)
+				if checkModErr != nil {
+					return errors.InvalidData("invalid target module for uniqueness check").Wrap(checkModErr)
+				}
+			}
+
+			// Hash file content; extractMimetype leaves fh at position 0
+			fileHash, err = hashFileContent(fh)
+			if err != nil {
+				return errors.Internal("failed to hash file content").Wrap(err)
+			}
+			// Reset for svc.create which reads fh again
+			if _, err = fh.Seek(0, 0); err != nil {
+				return errors.Internal("failed to seek file after hashing").Wrap(err)
+			}
+
+			// Search for an existing non-deleted attachment with the same hash in the target module
+			existing, _, err := store.SearchComposeAttachments(ctx, s, types.AttachmentFilter{
+				NamespaceID: namespaceID,
+				Kind:        types.RecordAttachment,
+				ModuleID:    checkModuleID,
+				Hash:        fileHash,
+				Deleted:     filter.StateExcluded,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(existing) > 0 {
+				dup := existing[0]
+
+				// Search for the record in the target module, not the current module
+				searchModule := m
+				if checkModule != nil {
+					searchModule = checkModule
+				}
+				existingRecordID := findRecordIDByAttachmentID(ctx, svc.dal, searchModule, dup.ID)
+
+				// Resolve namespace slug — ns is already loaded above via loadModuleCombo
+				namespaceSlug := ""
+				if ns != nil {
+					namespaceSlug = ns.Slug
+				}
+
+				// Resolve record page for the target module
+				recordPageID := uint64(0)
+				pages, _, pErr := store.SearchComposePages(ctx, s, types.PageFilter{
+					NamespaceID: namespaceID,
+					ModuleID:    checkModuleID,
+					Deleted:     filter.StateExcluded,
+				})
+				if pErr == nil && len(pages) == 1 {
+					recordPageID = pages[0].ID
+				}
+
+				return &DuplicateAttachmentError{
+					ExistingAttachmentID: dup.ID,
+					ExistingRecordID:     existingRecordID,
+					ModuleID:             checkModuleID,
+					NamespaceID:          namespaceID,
+					ConflictAction:       conflictAction,
+					RecordPageID:         recordPageID,
+					NamespaceSlug:        namespaceSlug,
+				}
+			}
+		}
+
 		att = &types.Attachment{
 			NamespaceID: namespaceID,
 			Name:        strings.TrimSpace(name),
 			Kind:        types.RecordAttachment,
+			ModuleID:    moduleID,
+			Hash:        fileHash,
 		}
 
 		return svc.create(ctx, s, name, size, fh, att)
@@ -712,6 +812,39 @@ func (attachment) checkMimeType(test *mimetype.MIME, vv ...string) bool {
 	}
 
 	return false
+}
+
+// findRecordIDByAttachmentID searches records in the given module for the first
+// record whose File field value matches the given attachment ID.
+//
+// It scans all File-kind fields on the module because in cross-module scenarios
+// the source field name does not exist on the target module.
+// Returns 0 if no matching record is found (non-fatal).
+func findRecordIDByAttachmentID(ctx context.Context, dal dalDater, m *types.Module, attachmentID uint64) uint64 {
+	attachmentIDStr := strconv.FormatUint(attachmentID, 10)
+
+	// Build an OR query across every File field in the module
+	var clauses []string
+	for _, f := range m.Fields {
+		if f.Kind == "File" {
+			clauses = append(clauses, f.Name+" = "+attachmentIDStr)
+		}
+	}
+	if len(clauses) == 0 {
+		return 0
+	}
+
+	rf := types.RecordFilter{
+		ModuleID:    m.ID,
+		NamespaceID: m.NamespaceID,
+		Query:       strings.Join(clauses, " OR "),
+	}
+	rf.Limit = 1
+	set, _, err := dalutils.ComposeRecordsList(ctx, dal, m, rf)
+	if err != nil || len(set) == 0 {
+		return 0
+	}
+	return set[0].ID
 }
 
 var _ AttachmentService = &attachment{}

--- a/server/compose/service/attachment_hash.go
+++ b/server/compose/service/attachment_hash.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// hashFileContent hashes the full content of r using xxHash64 and returns
+// a 16-character lowercase hex string.
+//
+// The caller must seek r back to 0 before calling this function (if it is a
+// ReadSeeker), and must seek back to 0 again after this call before passing
+// r to any subsequent read operation.
+func hashFileContent(r io.Reader) (string, error) {
+	h := xxhash.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%016x", h.Sum64()), nil
+}
+
+// DuplicateAttachmentError is returned by CreateRecordAttachment when a file
+// with the same content hash already exists in the target module and
+// enforceUniqueness is enabled on the field.
+type DuplicateAttachmentError struct {
+	ExistingAttachmentID uint64
+	ExistingRecordID     uint64
+	ModuleID             uint64
+	NamespaceID          uint64
+	ConflictAction       string // "modal", "newTab", "sameTab", "alert"
+	RecordPageID         uint64 // resolved page ID for the target module
+	NamespaceSlug        string // resolved namespace slug
+}
+
+func (e *DuplicateAttachmentError) Error() string {
+	return "duplicate file: this file already exists in the target module"
+}

--- a/server/compose/types/attachment.go
+++ b/server/compose/types/attachment.go
@@ -20,6 +20,8 @@ type (
 		Meta       AttachmentMeta `json:"meta"`
 
 		NamespaceID uint64 `json:"namespaceID,string"`
+		ModuleID    uint64 `json:"moduleID,string,omitempty"`
+		Hash        string `json:"hash,omitempty"`
 
 		CreatedAt time.Time  `json:"createdAt,omitempty"`
 		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
@@ -34,6 +36,7 @@ type (
 		RecordID    uint64 `json:"recordID,string,omitempty"`
 		ModuleID    uint64 `json:"moduleID,string,omitempty"`
 		FieldName   string `json:"fieldName,omitempty"`
+		Hash        string `json:"hash,omitempty"`
 		Filter      string `json:"filter"`
 
 		Deleted filter.State `json:"deleted"`

--- a/server/store/adapters/rdbms/aux_types.gen.go
+++ b/server/store/adapters/rdbms/aux_types.gen.go
@@ -217,13 +217,15 @@ type (
 	// auxComposeAttachment is an auxiliary structure used for transporting to/from RDBMS store
 	auxComposeAttachment struct {
 		ID          uint64                     `db:"id"`
-		NamespaceID uint64                     `db:"namespace_id"`
-		OwnerID     uint64                     `db:"owner_id"`
+		NamespaceID uint64                     `db:"rel_namespace"`
+		OwnerID     uint64                     `db:"rel_owner"`
 		Kind        string                     `db:"kind"`
 		Url         string                     `db:"url"`
 		PreviewUrl  string                     `db:"preview_url"`
 		Name        string                     `db:"name"`
 		Meta        composeType.AttachmentMeta `db:"meta"`
+		Hash        *string                    `db:"hash"`
+		ModuleID    uint64                     `db:"rel_module"`
 		CreatedAt   time.Time                  `db:"created_at"`
 		UpdatedAt   *time.Time                 `db:"updated_at"`
 		DeletedAt   *time.Time                 `db:"deleted_at"`
@@ -1402,6 +1404,10 @@ func (aux *auxComposeAttachment) encode(res *composeType.Attachment) (_ error) {
 	aux.PreviewUrl = res.PreviewUrl
 	aux.Name = res.Name
 	aux.Meta = res.Meta
+	if res.Hash != "" {
+		aux.Hash = &res.Hash
+	}
+	aux.ModuleID = res.ModuleID
 	aux.CreatedAt = res.CreatedAt
 	aux.UpdatedAt = res.UpdatedAt
 	aux.DeletedAt = res.DeletedAt
@@ -1421,6 +1427,10 @@ func (aux auxComposeAttachment) decode() (res *composeType.Attachment, _ error) 
 	res.PreviewUrl = aux.PreviewUrl
 	res.Name = aux.Name
 	res.Meta = aux.Meta
+	if aux.Hash != nil {
+		res.Hash = *aux.Hash
+	}
+	res.ModuleID = aux.ModuleID
 	res.CreatedAt = aux.CreatedAt
 	res.UpdatedAt = aux.UpdatedAt
 	res.DeletedAt = aux.DeletedAt
@@ -1440,6 +1450,8 @@ func (aux *auxComposeAttachment) scan(row scanner) error {
 		&aux.PreviewUrl,
 		&aux.Name,
 		&aux.Meta,
+		&aux.Hash,
+		&aux.ModuleID,
 		&aux.CreatedAt,
 		&aux.UpdatedAt,
 		&aux.DeletedAt,

--- a/server/store/adapters/rdbms/filter.go
+++ b/server/store/adapters/rdbms/filter.go
@@ -77,8 +77,17 @@ func DefaultFilters() (f *extendedFilters) {
 	}
 
 	f.ComposeAttachment = func(s *Store, f composeType.AttachmentFilter) (ee []goqu.Expression, _ composeType.AttachmentFilter, err error) {
+		// The generated ComposeAttachmentFilter emits "namespace_id" for the NamespaceID
+		// condition, but the actual DB column is "rel_namespace". Zero it out before calling
+		// so the generated filter only handles "kind", then we emit the correct condition.
+		nsID := f.NamespaceID
+		f.NamespaceID = 0
 		if ee, f, err = ComposeAttachmentFilter(s.Dialect, f); err != nil {
 			return
+		}
+		f.NamespaceID = nsID
+		if nsID > 0 {
+			ee = append(ee, goqu.C("rel_namespace").Eq(nsID))
 		}
 
 		switch f.Kind {
@@ -91,28 +100,19 @@ func DefaultFilters() (f *extendedFilters) {
 
 		case composeType.IconAttachment:
 
-		case composeType.RecordAttachment:
-			panic("@todo pending implementation")
-			// query = query.
-			//	Join("compose_record_value AS v ON (v.ref = a.id)")
-			//
-			// if f.ModuleID > 0 {
-			//	query = query.
-			//		Join("compose_record AS r ON (r.id = v.record_id)").
-			//		Where(squirrel.Eq{"r.module_id": f.ModuleID})
-			// }
-			//
-			// if f.RecordID > 0 {
-			//	query = query.Where(squirrel.Eq{"v.record_id": f.RecordID})
-			// }
-			//
-			// if f.FieldName != "" {
-			//	query = query.Where(squirrel.Eq{"v.name": f.FieldName})
-			// }
+		case composeType.RecordAttachment, "":
 
 		default:
 			err = fmt.Errorf("unsupported kind value")
 			return
+		}
+
+		if f.ModuleID > 0 {
+			ee = append(ee, goqu.C("rel_module").Eq(f.ModuleID))
+		}
+
+		if f.Hash != "" {
+			ee = append(ee, goqu.C("hash").Eq(f.Hash))
 		}
 
 		if f.Filter != "" {

--- a/server/store/adapters/rdbms/filters.gen.go
+++ b/server/store/adapters/rdbms/filters.gen.go
@@ -511,7 +511,7 @@ func ComposeAttachmentFilter(d drivers.Dialect, f composeType.AttachmentFilter) 
 	}
 
 	if f.NamespaceID > 0 {
-		ee = append(ee, goqu.C("namespace_id").Eq(f.NamespaceID))
+		ee = append(ee, goqu.C("rel_namespace").Eq(f.NamespaceID))
 	}
 
 	return ee, f, err

--- a/server/store/adapters/rdbms/queries.gen.go
+++ b/server/store/adapters/rdbms/queries.gen.go
@@ -1429,6 +1429,8 @@ var (
 			"preview_url",
 			"name",
 			"meta",
+			"hash",
+			"rel_module",
 			"created_at",
 			"updated_at",
 			"deleted_at",
@@ -1439,6 +1441,10 @@ var (
 	//
 	// This function is auto-generated
 	composeAttachmentInsertQuery = func(d goqu.DialectWrapper, res *composeType.Attachment) *goqu.InsertDataset {
+		var hash interface{}
+		if res.Hash != "" {
+			hash = res.Hash
+		}
 		return d.Insert(composeAttachmentTable).
 			Rows(goqu.Record{
 				"id":            res.ID,
@@ -1449,6 +1455,8 @@ var (
 				"preview_url":   res.PreviewUrl,
 				"name":          res.Name,
 				"meta":          res.Meta,
+				"hash":          hash,
+				"rel_module":    res.ModuleID,
 				"created_at":    res.CreatedAt,
 				"updated_at":    res.UpdatedAt,
 				"deleted_at":    res.DeletedAt,
@@ -1460,6 +1468,10 @@ var (
 	// This function is auto-generated
 	composeAttachmentUpsertQuery = func(d goqu.DialectWrapper, res *composeType.Attachment) *goqu.InsertDataset {
 		var target = `,id`
+		var hash interface{}
+		if res.Hash != "" {
+			hash = res.Hash
+		}
 
 		return composeAttachmentInsertQuery(d, res).
 			OnConflict(
@@ -1472,6 +1484,8 @@ var (
 						"preview_url":   res.PreviewUrl,
 						"name":          res.Name,
 						"meta":          res.Meta,
+						"hash":          hash,
+						"rel_module":    res.ModuleID,
 						"created_at":    res.CreatedAt,
 						"updated_at":    res.UpdatedAt,
 						"deleted_at":    res.DeletedAt,
@@ -1484,6 +1498,10 @@ var (
 	//
 	// This function is auto-generated
 	composeAttachmentUpdateQuery = func(d goqu.DialectWrapper, res *composeType.Attachment) *goqu.UpdateDataset {
+		var hash interface{}
+		if res.Hash != "" {
+			hash = res.Hash
+		}
 		return d.Update(composeAttachmentTable).
 			Set(goqu.Record{
 				"rel_namespace": res.NamespaceID,
@@ -1493,6 +1511,8 @@ var (
 				"preview_url":   res.PreviewUrl,
 				"name":          res.Name,
 				"meta":          res.Meta,
+				"hash":          hash,
+				"rel_module":    res.ModuleID,
 				"created_at":    res.CreatedAt,
 				"updated_at":    res.UpdatedAt,
 				"deleted_at":    res.DeletedAt,

--- a/server/store/adapters/rdbms/upgrade_fixes.go
+++ b/server/store/adapters/rdbms/upgrade_fixes.go
@@ -1328,9 +1328,18 @@ func fix_2024_09_10_addHashAndModuleToComposeAttachment(ctx context.Context, s *
 	}
 	if err := addColumn(ctx, s, tableName, &dal.Attribute{
 		Ident: "ModuleID",
-		Type:  &dal.TypeID{},
+		Type:  &dal.TypeID{Nullable: true},
 		Store: &dal.CodecAlias{Ident: "rel_module"},
 	}); err != nil {
+		return err
+	}
+
+	// If table does not exist, skip index creation — table will be created
+	// with the correct schema in the next step of the upgrade process.
+	if _, err := s.DataDefiner.TableLookup(ctx, tableName); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/server/store/adapters/rdbms/upgrade_fixes.go
+++ b/server/store/adapters/rdbms/upgrade_fixes.go
@@ -55,6 +55,7 @@ var (
 		fix_2024_09_03_renameFederationNodeSyncComposeID,
 		fix_2024_09_03_addFederationNodeSyncNodeIDIndex,
 		fix_2024_9_7_migrateLabelsValueToJsonb,
+		fix_2024_09_10_addHashAndModuleToComposeAttachment,
 	}
 
 	fixesPost = []func(context.Context, *Store) error{
@@ -1312,6 +1313,52 @@ func fix_2024_9_7_migrateLabelsValueToJsonb(ctx context.Context, s *Store) (err 
 	return nil
 
 }
+func fix_2024_09_10_addHashAndModuleToComposeAttachment(ctx context.Context, s *Store) error {
+	const (
+		tableName = "compose_attachment"
+		indexName = "compose_attachment_idxHashModule"
+	)
+
+	if err := addColumn(ctx, s, tableName, &dal.Attribute{
+		Ident: "Hash",
+		Type:  &dal.TypeText{Nullable: true},
+		Store: &dal.CodecAlias{Ident: "hash"},
+	}); err != nil {
+		return err
+	}
+	if err := addColumn(ctx, s, tableName, &dal.Attribute{
+		Ident: "ModuleID",
+		Type:  &dal.TypeID{},
+		Store: &dal.CodecAlias{Ident: "rel_module"},
+	}); err != nil {
+		return err
+	}
+
+	// Create composite index on (hash, rel_module) for fast duplicate lookups.
+	// MySQL and SQL Server require an explicit existence check before CREATE INDEX.
+	driverName := s.DB.DriverName()
+	if strings.HasPrefix(driverName, "mysql") || strings.HasPrefix(driverName, "sqlserver") {
+		existing, err := s.DataDefiner.IndexLookup(ctx, indexName, tableName)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			return nil
+		}
+	}
+
+	hashModuleIdx := ddl.Index{
+		TableIdent: tableName,
+		Ident:      indexName,
+		Type:       "BTREE",
+		Fields: []*ddl.IndexField{
+			{Column: "hash"},
+			{Column: "rel_module"},
+		},
+	}
+	return s.DataDefiner.IndexCreate(ctx, tableName, &hashModuleIdx)
+}
+
 func count(ctx context.Context, s *Store, table string, ee ...goqu.Expression) (count int) {
 	db := s.DB.(goqu.SQLDatabase)
 


### PR DESCRIPTION
# The following changes are implemented
when uploading a file it would be good to check the file is unique within its own module or within a specific target module

if there is a duplicate detection then allow a choice of options ie alert with link to existing record, or open in modal or new tab or same tab


i used xxhash for its speed and the fact that it was already in the project 




https://github.com/cortezaproject/corteza/issues/2314







# Changes in the user interface:



in the field options you can choose to enforce uniqueness, and choose what you want to happen on conflict 

<img width="786" height="304" alt="image" src="https://github.com/user-attachments/assets/32f81842-e097-4716-b9b6-b0eb7d1ad473" />

the others are self explanatory the alert appears like this 

<img width="369" height="137" alt="image" src="https://github.com/user-attachments/assets/6c3f3564-32e0-4c13-9abf-cc873b78297d" />


the other option is you can select a different module to validate uniqueness against

<img width="777" height="305" alt="image" src="https://github.com/user-attachments/assets/6ca32156-0a90-4c9f-ba46-d613ab7ac170" />


# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
