### PR TITLE
2024.9.x fix composite dedup constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .run
 node_modules
 ignore
+.kilo*
+.claude*

--- a/server/compose/types/record_detect_duplicates.go
+++ b/server/compose/types/record_detect_duplicates.go
@@ -188,7 +188,7 @@ func (rule DeDupRule) checkDuplication(ctx context.Context, ls localeService, re
                 return nil
             })
 
-            _ = vv.Walk(func(v *RecordValue) error {
+            _ = existingVv.Walk(func(v *RecordValue) error {
                 if v.RecordID == rec.ID {
                     return nil
                 }

--- a/server/compose/types/record_detect_duplicates.go
+++ b/server/compose/types/record_detect_duplicates.go
@@ -148,23 +148,38 @@ func (rule DeDupRule) checkDuplication(ctx context.Context, ls localeService, re
 
     out = &RecordValueErrorSet{}
 
+    // For composite rules (multiple constraints), ALL constraints must match
+    // for the rule to trigger. Collect per-constraint results first.
+    type constraintResult struct {
+        matched bool
+        errors  []RecordValueError
+    }
+
+    results := make([]constraintResult, 0, len(rule.ConstraintSet))
+
     for _, c := range rule.ConstraintSet {
         rvv := recVal.FilterByName(c.Attribute)
         if rvv.Len() == 0 {
+            // New record has no value for this constraint field,
+            // so this constraint cannot match — composite rule cannot trigger.
+            results = append(results, constraintResult{matched: false})
             continue
         }
 
-        var (
-            valErr = &RecordValueErrorSet{}
-        )
+        cr := constraintResult{}
 
         existingVv := vv.FilterByName(c.Attribute)
         moduleField := rec.module.Fields.FindByName(c.Attribute)
 
         if moduleField.Multi && c.IsAllEqual() {
             multiValErr := rule.multiValueAllEqual(ctx, ls, c, rvv, existingVv)
-            out.Push(multiValErr)
+            if multiValErr.Kind != "" {
+                cr.matched = true
+                cr.errors = append(cr.errors, multiValErr)
+            }
         } else {
+            valErr := &RecordValueErrorSet{}
+
             rvvValueMap := make(map[string]*RecordValue)
             _ = rvv.Walk(func(rv *RecordValue) error {
                 if len(rv.Value) > 0 {
@@ -196,11 +211,30 @@ func (rule DeDupRule) checkDuplication(ctx context.Context, ls localeService, re
                 // 2. multiValue is oneOf, then one or more value needs to be a match then return error/warning
                 // 3. multiValue is equal, then all value needs to be a match then return error/warning
                 if (!valErr.IsValid() && (!c.HasMultiValue() || c.IsAllEqual()) && valErr.Len() == rvv.Len()) || (c.IsOneOf() && valErr.Len() > 0) {
-                    out.Push(valErr.Set...)
+                    cr.matched = true
+                    cr.errors = valErr.Set
                 }
 
                 return nil
             })
+        }
+
+        results = append(results, cr)
+    }
+
+    // Only emit errors if ALL constraints in the rule matched (composite AND logic).
+    // For single-constraint rules this is trivially equivalent to the old behavior.
+    allMatched := len(results) > 0
+    for _, r := range results {
+        if !r.matched {
+            allMatched = false
+            break
+        }
+    }
+
+    if allMatched {
+        for _, r := range results {
+            out.Push(r.errors...)
         }
     }
 

--- a/server/compose/types/record_detect_duplicates_test.go
+++ b/server/compose/types/record_detect_duplicates_test.go
@@ -482,6 +482,16 @@ func TestDeDupRule_checkCompositeConstraintDuplication(t *testing.T) {
 				expectErr: false,
 			},
 			{
+				name: "composite cross-field value swap - new(2,1) vs existing(1,2)",
+				rule: compositeRule,
+				rec:  makeRecord(1, "2", "1"),
+				vv: RecordValueSet{
+					&RecordValue{RecordID: 2, Name: "name", Value: "1"},
+					&RecordValue{RecordID: 2, Name: "email", Value: "2"},
+				},
+				expectErr: false,
+			},
+			{
 				name: "composite with missing field - new record has no email",
 				rule: compositeRule,
 				rec: Record{

--- a/server/compose/types/record_detect_duplicates_test.go
+++ b/server/compose/types/record_detect_duplicates_test.go
@@ -380,6 +380,145 @@ func TestDedupRule_checkMultiValueEqualDuplication(t *testing.T) {
 	}
 }
 
+func TestDeDupRule_checkCompositeConstraintDuplication(t *testing.T) {
+	var (
+		req = require.New(t)
+		ctx = context.Background()
+		ls  = locale.Global()
+
+		compositeRule = DeDupRule{
+			Name:   "composite rule",
+			Strict: true,
+			ConstraintSet: []*DeDupRuleConstraint{
+				{
+					Attribute: "name",
+					Modifier:  ignoreCase,
+				},
+				{
+					Attribute: "email",
+					Modifier:  caseSensitive,
+				},
+			},
+		}
+
+		makeRecord = func(id uint64, name, email string) Record {
+			return Record{
+				ID: id,
+				module: &Module{
+					ID: 1,
+					Fields: ModuleFieldSet{
+						&ModuleField{
+							Name:  "name",
+							Kind:  "String",
+							Multi: false,
+						},
+						&ModuleField{
+							Name:  "email",
+							Kind:  "Email",
+							Multi: false,
+						},
+					},
+				},
+				Values: RecordValueSet{
+					&RecordValue{
+						RecordID: id,
+						Name:     "name",
+						Value:    name,
+					},
+					&RecordValue{
+						RecordID: id,
+						Name:     "email",
+						Value:    email,
+					},
+				},
+			}
+		}
+
+		tests = []struct {
+			name      string
+			rule      DeDupRule
+			rec       Record
+			vv        RecordValueSet
+			expectErr bool
+		}{
+			{
+				name: "composite match - both fields match same record",
+				rule: compositeRule,
+				rec:  makeRecord(1, "John Doe", "john@test.com"),
+				vv: RecordValueSet{
+					&RecordValue{RecordID: 2, Name: "name", Value: "John Doe"},
+					&RecordValue{RecordID: 2, Name: "email", Value: "john@test.com"},
+				},
+				expectErr: true,
+			},
+			{
+				name: "composite partial match - only name matches (bug fix)",
+				rule: compositeRule,
+				rec:  makeRecord(1, "John Doe", "john@test.com"),
+				vv: RecordValueSet{
+					&RecordValue{RecordID: 2, Name: "name", Value: "John Doe"},
+					&RecordValue{RecordID: 2, Name: "email", Value: "other@test.com"},
+				},
+				expectErr: false,
+			},
+			{
+				name: "composite partial match - only email matches (bug fix)",
+				rule: compositeRule,
+				rec:  makeRecord(1, "John Doe", "john@test.com"),
+				vv: RecordValueSet{
+					&RecordValue{RecordID: 2, Name: "name", Value: "Jane Smith"},
+					&RecordValue{RecordID: 2, Name: "email", Value: "john@test.com"},
+				},
+				expectErr: false,
+			},
+			{
+				name: "composite no match - neither field matches",
+				rule: compositeRule,
+				rec:  makeRecord(1, "John Doe", "john@test.com"),
+				vv: RecordValueSet{
+					&RecordValue{RecordID: 2, Name: "name", Value: "Jane Smith"},
+					&RecordValue{RecordID: 2, Name: "email", Value: "jane@test.com"},
+				},
+				expectErr: false,
+			},
+			{
+				name: "composite with missing field - new record has no email",
+				rule: compositeRule,
+				rec: Record{
+					ID: 1,
+					module: &Module{
+						ID: 1,
+						Fields: ModuleFieldSet{
+							&ModuleField{Name: "name", Kind: "String", Multi: false},
+							&ModuleField{Name: "email", Kind: "Email", Multi: false},
+						},
+					},
+					Values: RecordValueSet{
+						&RecordValue{RecordID: 1, Name: "name", Value: "John Doe"},
+					},
+				},
+				vv: RecordValueSet{
+					&RecordValue{RecordID: 2, Name: "name", Value: "John Doe"},
+					&RecordValue{RecordID: 2, Name: "email", Value: "john@test.com"},
+				},
+				expectErr: false,
+			},
+		}
+	)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOut := tt.rule.checkDuplication(ctx, ls, tt.rec, tt.vv)
+			if tt.expectErr {
+				req.False(gotOut.IsValid(), "expected duplication errors but got none")
+				req.Greater(gotOut.Len(), 0, "expected at least one error")
+			} else {
+				req.True(gotOut.IsValid(), "expected no duplication errors but got: %v", gotOut)
+			}
+		})
+	}
+}
+
 func Test_matchValue(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# The following changes are implemented

this addresses the dedupe logic issues and when constraints are grouped they are treated as a joint constraint not individually 

https://github.com/cortezaproject/corteza/issues/2317

# Changes in the user interface:

there are no changes to the UI 

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [ ] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
