### PR TITLE
Mitigate against motley (CVE-2026-6093)

### DIFF
--- a/server/store/adapters/rdbms/drivers/mssql/json.go
+++ b/server/store/adapters/rdbms/drivers/mssql/json.go
@@ -27,7 +27,7 @@ func jsonPath(pp ...any) (string, error) {
 		switch path := p.(type) {
 		case string:
 			sql.WriteString(".")
-			sql.WriteString(strings.ReplaceAll(path, "'", `\'`))
+			sql.WriteString(strings.ReplaceAll(path, "'", `''`))
 		case int:
 			sql.WriteString("[")
 			sql.WriteString(strconv.Itoa(path))


### PR DESCRIPTION
# The following changes are implemented
Properly escape quotations in TSQL to avoid SQL injections in the mssql backend. Only impacts one of the vulnerabilities, doesn't touch the meta json key-value stuff in `server/pkg/payload/util.go:122-129`

NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-6093
Advisory: https://fluidattacks.com/es/advisories/motley
Closes: #2342 

# Changes in the user interface:
Quotation marks are now properly handled with the TSQL backend. No other changes exist.

# Checklist when submitting a final (!draft) PR
 - [x] Commits are tidied up, squashed if needed and follow guidelines in CONTRIBUTING.md
 - [x] Code builds
 - [x] All existing tests pass
 - [ ] All new critical code is covered by tests
 - [x] PR is linked to the relevant issue(s)
 - [x] Rebased with the target branch
